### PR TITLE
Fix CLI 917

### DIFF
--- a/applications/services/cli_f64/cli.c
+++ b/applications/services/cli_f64/cli.c
@@ -463,7 +463,7 @@ void cli_session_close(Cli* cli) {
         cli->session->deinit();
     }
     cli->session = NULL;
-    furi_thread_set_stdout_callback(NULL), NULL;
+    furi_thread_set_stdout_callback(NULL, NULL);
     furi_check(furi_mutex_release(cli->mutex) == FuriStatusOk);
 }
 

--- a/applications/services/cli_f64/cli_i.h
+++ b/applications/services/cli_f64/cli_i.h
@@ -28,8 +28,9 @@ struct CliSession {
     void (*init)(void);
     void (*deinit)(void);
     size_t (*rx)(uint8_t* buffer, size_t size, uint32_t timeout);
+    size_t (*rx_stdin)(uint8_t* buffer, size_t size, uint32_t timeout, void* context);
     void (*tx)(const uint8_t* buffer, size_t size);
-    void (*tx_stdout)(const char* data, size_t size);
+    void (*tx_stdout)(const char* data, size_t size, void* context);
     bool (*is_connected)(void);
 };
 

--- a/applications/services/cli_f64/cli_uart.c
+++ b/applications/services/cli_f64/cli_uart.c
@@ -186,6 +186,11 @@ static size_t cli_uart_rx(uint8_t* buffer, size_t size, uint32_t timeout) {
     return rx_cnt;
 }
 
+static size_t cli_uart_rx_stdin(uint8_t* data, size_t size, uint32_t timeout, void* context) {
+    UNUSED(context);
+    return cli_uart_rx(data, size, timeout);
+}
+
 static void cli_uart_tx(const uint8_t* buffer, size_t size) {
     furi_assert(cli_uart_handle);
     furi_assert(buffer);
@@ -211,7 +216,8 @@ static void cli_uart_tx(const uint8_t* buffer, size_t size) {
     CLI_UART_DEBUG("tx %u end", size);
 }
 
-static void cli_uart_tx_stdout(const char* data, size_t size) {
+static void cli_uart_tx_stdout(const char* data, size_t size, void* context) {
+    UNUSED(context);
     cli_uart_tx((const uint8_t*)data, size);
 }
 
@@ -224,6 +230,7 @@ CliSession cli_uart = {
     cli_uart_init,
     cli_uart_deinit,
     cli_uart_rx,
+    cli_uart_rx_stdin,
     cli_uart_tx,
     cli_uart_tx_stdout,
     cli_uart_is_connected,


### PR DESCRIPTION
# What's new

- Fix work CLI 917

# How to test
1. uncomment 
CLI in .\bsb-firmware\applications\services\application.fam
2. assemble and flash 917
3. send U5 to DFU
4. connect the TTL fan to the debug port U5 (Tx-Tx, Rx-Rx) and check the operation of CLI 917

