### PR TITLE
BUSY App fixes

### DIFF
--- a/applications/main/busy/busy.c
+++ b/applications/main/busy/busy.c
@@ -39,17 +39,6 @@ static const BusyAppScene* busy_scenes[BusyAppSceneIdMax] = {
     [BusyAppSceneIdSetup] = &busy_scene_setup,
 };
 
-static void busy_send_custom_event_direct(BusyApp* instance, uint32_t value) {
-    if(instance->current_scene_id < BusyAppSceneIdMax) {
-        const BusyEvent event = {
-            .type = BusyEventTypeCustom,
-            .custom_value = value,
-        };
-
-        busy_scenes[instance->current_scene_id]->on_event(&event, instance);
-    }
-}
-
 void busy_switch_to_scene(BusyApp* instance, BusyAppSceneId scene_id) {
     if(instance->current_scene_id < BusyAppSceneIdMax) {
         busy_scenes[instance->current_scene_id]->on_exit(instance);
@@ -105,7 +94,7 @@ void busy_timer_resume(BusyApp* instance) {
     const uint32_t timeout_ms = instance->enable_speed ? S_TO_MS(1) / SPEED_MULTIPLIER :
                                                          S_TO_MS(1);
     furi_event_loop_timer_start(instance->busy_timer, timeout_ms);
-    busy_send_custom_event_direct(instance, instance->state);
+    busy_send_custom_event(instance, instance->state);
 }
 
 void busy_timer_toggle(BusyApp* instance) {
@@ -212,7 +201,7 @@ void busy_timer_next_state(BusyApp* instance, bool skip_event) {
                                                          S_TO_MS(1);
 
     furi_event_loop_timer_start(instance->busy_timer, timeout_ms);
-    busy_send_custom_event_direct(instance, event);
+    busy_send_custom_event(instance, event);
 }
 
 static void busy_input_callback(const void* message, void* context) {
@@ -261,7 +250,7 @@ static void busy_scene_busy_timer_callback(void* context) {
     BusyApp* instance = context;
 
     if(--instance->interval_time_left_s > 0) {
-        busy_send_custom_event_direct(instance, BusyCustomEventUpdate);
+        busy_send_custom_event(instance, BusyCustomEventUpdate);
     } else {
         busy_timer_next_state(instance, false);
     }

--- a/applications/main/busy/busy.c
+++ b/applications/main/busy/busy.c
@@ -85,12 +85,10 @@ void busy_timer_stop(BusyApp* instance) {
 }
 
 void busy_timer_pause(BusyApp* instance) {
-    furi_assert(busy_timer_is_running(instance));
     furi_event_loop_timer_stop(instance->busy_timer);
 }
 
 void busy_timer_resume(BusyApp* instance) {
-    furi_assert(!busy_timer_is_running(instance));
     const uint32_t timeout_ms = instance->enable_speed ? S_TO_MS(1) / SPEED_MULTIPLIER :
                                                          S_TO_MS(1);
     furi_event_loop_timer_start(instance->busy_timer, timeout_ms);

--- a/applications/main/busy/busy.c
+++ b/applications/main/busy/busy.c
@@ -75,17 +75,27 @@ void* busy_get_current_scene_data(BusyApp* instance) {
 }
 
 void busy_timer_start(BusyApp* instance) {
+    FURI_LOG_I(TAG, "Timer starting");
+
     instance->state = BusyTimerStateIdle;
     busy_timer_next_state(instance, true);
+
+    FURI_LOG_I(TAG, "Timer started");
 }
 
 void busy_timer_stop(BusyApp* instance) {
+    FURI_LOG_I(TAG, "Timer stopping");
+
     furi_event_loop_timer_stop(instance->busy_timer);
     instance->state = BusyTimerStateIdle;
+
+    FURI_LOG_I(TAG, "Timer stopped");
 }
 
 void busy_timer_pause(BusyApp* instance) {
     furi_event_loop_timer_stop(instance->busy_timer);
+
+    FURI_LOG_I(TAG, "Timer paused");
 }
 
 void busy_timer_resume(BusyApp* instance) {
@@ -93,9 +103,13 @@ void busy_timer_resume(BusyApp* instance) {
                                                          S_TO_MS(1);
     furi_event_loop_timer_start(instance->busy_timer, timeout_ms);
     busy_send_custom_event(instance, instance->state);
+
+    FURI_LOG_I(TAG, "Timer resumed");
 }
 
 void busy_timer_toggle(BusyApp* instance) {
+    FURI_LOG_I(TAG, "Timer toggle");
+
     if(busy_timer_is_running(instance)) {
         busy_timer_pause(instance);
     } else {
@@ -107,13 +121,26 @@ bool busy_timer_is_running(BusyApp* instance) {
     return furi_event_loop_timer_is_running(instance->busy_timer);
 }
 
+static const char* busy_timer_get_state_name(BusyTimerState state) {
+    furi_assert(state < BusyTimerStateMax);
+
+    static const char* state_names[BusyTimerStateMax] = {
+        [BusyTimerStateIdle] = "Idle",
+        [BusyTimerStateWork] = "Work",
+        [BusyTimerStateRest] = "Rest",
+        [BusyTimerStateLongRest] = "LongRest",
+    };
+
+    return state_names[state];
+}
+
 static BusyTimerState busy_timer_calc_state(BusyApp* instance) {
     BusyTimerState state;
 
     if(instance->state == BusyTimerStateIdle) {
-        state = BusyTimerStateBusy;
+        state = BusyTimerStateWork;
 
-    } else if(instance->state == BusyTimerStateBusy) {
+    } else if(instance->state == BusyTimerStateWork) {
         if(instance->enable_intervals) {
             if(instance->intervals_done == instance->intervals_total - 1) {
                 state = BusyTimerStateLongRest;
@@ -122,7 +149,7 @@ static BusyTimerState busy_timer_calc_state(BusyApp* instance) {
             }
 
         } else {
-            state = BusyTimerStateBusy;
+            state = BusyTimerStateWork;
         }
 
     } else if(instance->state == BusyTimerStateRest || instance->state == BusyTimerStateLongRest) {
@@ -130,10 +157,10 @@ static BusyTimerState busy_timer_calc_state(BusyApp* instance) {
             instance->intervals_done = 0;
         }
 
-        state = BusyTimerStateBusy;
+        state = BusyTimerStateWork;
 
     } else {
-        furi_crash("Impossibru!");
+        furi_crash("calc_state(): invalid state");
     }
 
     return state;
@@ -142,10 +169,12 @@ static BusyTimerState busy_timer_calc_state(BusyApp* instance) {
 static uint32_t busy_timer_calc_interval(BusyApp* instance) {
     uint32_t interval;
 
-    if(instance->state == BusyTimerStateBusy) {
+    if(instance->state == BusyTimerStateWork) {
         if(instance->enable_intervals) {
+            FURI_LOG_D(TAG, "Calculating work time based on intervals");
             interval = MIN(M_TO_S(instance->work_time_mn), instance->total_time_left_s);
         } else {
+            FURI_LOG_D(TAG, "Calculating work time based on total time");
             interval = MIN(M_TO_S(instance->total_time_mn), instance->total_time_left_s);
         }
     } else if(instance->state == BusyTimerStateRest) {
@@ -153,7 +182,7 @@ static uint32_t busy_timer_calc_interval(BusyApp* instance) {
     } else if(instance->state == BusyTimerStateLongRest) {
         interval = MIN(M_TO_S(instance->long_rest_time_mn), instance->total_time_left_s);
     } else {
-        furi_crash("Impossibru!");
+        furi_crash("calc_interval(): invalid state");
     }
 
     return interval;
@@ -163,37 +192,56 @@ static BusyCustomEvent busy_timer_calc_event(BusyApp* instance, bool skip_event)
     BusyCustomEvent event = BusyCustomEventUpdate;
 
     if(!skip_event) {
-        if(instance->total_time_left_s == 0) {
+        if(instance->state == BusyTimerStateIdle) {
             if(!instance->enable_autorestart_session) {
                 event = BusyCustomEventSessionEnd;
+            } else {
+                FURI_LOG_D(TAG, "Autorestart session OFF, skipping event");
             }
         } else if(instance->state == BusyTimerStateRest || instance->state == BusyTimerStateLongRest) {
             if(!instance->enable_autostart_work) {
                 event = BusyCustomEventIntervalEnd;
+            } else {
+                FURI_LOG_D(TAG, "Autorestart work OFF, skipping event");
             }
-        } else if(instance->state == BusyTimerStateBusy) {
+        } else if(instance->state == BusyTimerStateWork) {
             if(!instance->enable_autostart_rest) {
                 event = BusyCustomEventIntervalEnd;
+            } else {
+                FURI_LOG_D(TAG, "Autorestart rest OFF, skipping event");
             }
         }
+    } else {
+        FURI_LOG_D(TAG, "Skipping state change event");
     }
 
     return event;
 }
 
 void busy_timer_next_state(BusyApp* instance, bool skip_event) {
-    const BusyCustomEvent event = busy_timer_calc_event(instance, skip_event);
+    FURI_LOG_I(TAG, "Current timer state: %s", busy_timer_get_state_name(instance->state));
 
-    if(instance->total_time_left_s == 0) {
+    if(instance->total_time_left_s == 0 && instance->state != BusyTimerStateIdle) {
         instance->state = BusyTimerStateIdle;
+        FURI_LOG_I(TAG, "Time is up, restarting the timer");
+    }
+
+    if(instance->state == BusyTimerStateIdle) {
         instance->total_time_left_s = M_TO_S(instance->total_time_mn);
         instance->intervals_done = 0;
+        FURI_LOG_I(TAG, "New session start with total time of %lu min", instance->total_time_mn);
     }
+
+    const BusyCustomEvent event = busy_timer_calc_event(instance, skip_event);
 
     instance->state = busy_timer_calc_state(instance);
     instance->interval_time_s = busy_timer_calc_interval(instance);
     instance->interval_time_left_s = instance->interval_time_s;
     instance->total_time_left_s -= instance->interval_time_s;
+
+    FURI_LOG_I(TAG, "New timer state: %s", busy_timer_get_state_name(instance->state));
+    FURI_LOG_I(TAG, "New interval time: %lu min", S_TO_M(instance->interval_time_s));
+    FURI_LOG_I(TAG, "Remaining time: %lu min", S_TO_M(instance->total_time_left_s));
 
     const uint32_t timeout_ms = instance->enable_speed ? S_TO_MS(1) / SPEED_MULTIPLIER :
                                                          S_TO_MS(1);

--- a/applications/main/busy/busy_i.h
+++ b/applications/main/busy/busy_i.h
@@ -31,7 +31,7 @@ typedef enum {
 
 typedef enum {
     BusyTimerStateIdle,
-    BusyTimerStateBusy,
+    BusyTimerStateWork,
     BusyTimerStateRest,
     BusyTimerStateLongRest,
     BusyTimerStateMax,

--- a/applications/main/busy/busy_i.h
+++ b/applications/main/busy/busy_i.h
@@ -46,10 +46,12 @@ typedef enum {
 
 typedef enum {
     BusyCustomEventUpdate = 100,
-    BusyCustomEventNext,
-    BusyCustomEventBack,
     BusyCustomEventIntervalEnd,
     BusyCustomEventSessionEnd,
+    BusyCustomEventNext,
+    BusyCustomEventBack,
+    BusyCustomEventStartSingle,
+    BusyCustomEventStartDouble,
 } BusyCustomEvent;
 
 typedef struct {

--- a/applications/main/busy/scenes/busy_scene_next.c
+++ b/applications/main/busy/scenes/busy_scene_next.c
@@ -13,9 +13,7 @@ static void busy_scene_next_button_event_callback(lv_event_t* event) {
 static void busy_scene_next_on_enter(void* context) {
     BusyApp* instance = context;
 
-    if(busy_timer_is_running(instance)) {
-        busy_timer_pause(instance);
-    }
+    busy_timer_pause(instance);
 
     BusySceneNext* data = busy_get_current_scene_data(instance);
 

--- a/applications/main/busy/scenes/busy_scene_quit.c
+++ b/applications/main/busy/scenes/busy_scene_quit.c
@@ -67,15 +67,19 @@ static void busy_scene_quit_on_exit(void* context) {
 static void busy_scene_quit_on_event(const BusyEvent* event, void* context) {
     BusyApp* instance = context;
 
-    if(event->type == BusyEventTypeCustom) {
-        BusySceneQuit* data = busy_get_current_scene_data(instance);
-        const lv_obj_t* button = (const lv_obj_t*)event->custom_value;
+    if(event->type == BusyEventTypeBack) {
+        busy_timer_stop(instance);
+        busy_switch_to_scene(instance, BusyAppSceneIdStart);
 
-        if(button == data->quit_button) {
+    } else if(event->type == BusyEventTypeCustom) {
+        BusySceneQuit* data = busy_get_current_scene_data(instance);
+        const uint32_t button_id = event->custom_value;
+
+        if(button_id == (uint32_t)data->quit_button) {
             busy_timer_stop(instance);
             busy_switch_to_scene(instance, BusyAppSceneIdStart);
 
-        } else if(button == data->cancel_button) {
+        } else if(button_id == (uint32_t)data->cancel_button) {
             if(instance->total_time_mn >= TOTAL_TIME_LOW_THR_MN) {
                 busy_timer_resume(instance);
                 busy_switch_to_scene(instance, BusyAppSceneIdTimer);

--- a/applications/main/busy/scenes/busy_scene_quit.c
+++ b/applications/main/busy/scenes/busy_scene_quit.c
@@ -12,6 +12,15 @@ static void busy_button_event_callback(lv_event_t* event) {
     busy_send_custom_event(instance, (uint32_t)lv_event_get_target_obj(event));
 }
 
+static void busy_scene_handle_cancel(BusyApp* instance) {
+    if(instance->total_time_mn >= TOTAL_TIME_LOW_THR_MN) {
+        busy_timer_resume(instance);
+        busy_switch_to_scene(instance, BusyAppSceneIdTimer);
+    } else {
+        busy_switch_to_scene(instance, BusyAppSceneIdStatic);
+    }
+}
+
 static void busy_scene_quit_on_enter(void* context) {
     BusyApp* instance = context;
     BusySceneQuit* data = busy_get_current_scene_data(instance);
@@ -68,8 +77,7 @@ static void busy_scene_quit_on_event(const BusyEvent* event, void* context) {
     BusyApp* instance = context;
 
     if(event->type == BusyEventTypeBack) {
-        busy_timer_stop(instance);
-        busy_switch_to_scene(instance, BusyAppSceneIdStart);
+        busy_scene_handle_cancel(instance);
 
     } else if(event->type == BusyEventTypeCustom) {
         BusySceneQuit* data = busy_get_current_scene_data(instance);
@@ -80,12 +88,7 @@ static void busy_scene_quit_on_event(const BusyEvent* event, void* context) {
             busy_switch_to_scene(instance, BusyAppSceneIdStart);
 
         } else if(button_id == (uint32_t)data->cancel_button) {
-            if(instance->total_time_mn >= TOTAL_TIME_LOW_THR_MN) {
-                busy_timer_resume(instance);
-                busy_switch_to_scene(instance, BusyAppSceneIdTimer);
-            } else {
-                busy_switch_to_scene(instance, BusyAppSceneIdStatic);
-            }
+            busy_scene_handle_cancel(instance);
         }
     }
 }

--- a/applications/main/busy/scenes/busy_scene_quit.c
+++ b/applications/main/busy/scenes/busy_scene_quit.c
@@ -72,13 +72,13 @@ static void busy_scene_quit_on_event(const BusyEvent* event, void* context) {
         const lv_obj_t* button = (const lv_obj_t*)event->custom_value;
 
         if(button == data->quit_button) {
-            busy_switch_to_scene(instance, BusyAppSceneIdStart);
             busy_timer_stop(instance);
+            busy_switch_to_scene(instance, BusyAppSceneIdStart);
 
         } else if(button == data->cancel_button) {
             if(instance->total_time_mn >= TOTAL_TIME_LOW_THR_MN) {
-                busy_switch_to_scene(instance, BusyAppSceneIdTimer);
                 busy_timer_resume(instance);
+                busy_switch_to_scene(instance, BusyAppSceneIdTimer);
             } else {
                 busy_switch_to_scene(instance, BusyAppSceneIdStatic);
             }

--- a/applications/main/busy/scenes/busy_scene_start.c
+++ b/applications/main/busy/scenes/busy_scene_start.c
@@ -64,9 +64,9 @@ static void busy_scene_start_on_event(const BusyEvent* event, void* context) {
 
     if(event->type == BusyEventTypeCustom) {
         BusySceneStart* data = busy_get_current_scene_data(instance);
-        const lv_obj_t* button = (const lv_obj_t*)event->custom_value;
+        const uint32_t button_id = event->custom_value;
 
-        if(button == data->start_button) {
+        if(button_id == (uint32_t)data->start_button) {
             if(instance->total_time_mn >= TOTAL_TIME_LOW_THR_MN) {
                 busy_timer_start(instance);
                 busy_switch_to_scene(instance, BusyAppSceneIdTimer);
@@ -74,7 +74,7 @@ static void busy_scene_start_on_event(const BusyEvent* event, void* context) {
                 busy_switch_to_scene(instance, BusyAppSceneIdStatic);
             }
 
-        } else if(button == data->setup_button) {
+        } else if(button_id == (uint32_t)data->setup_button) {
             busy_switch_to_scene(instance, BusyAppSceneIdSetup);
         }
     }

--- a/applications/main/busy/scenes/busy_scene_static.c
+++ b/applications/main/busy/scenes/busy_scene_static.c
@@ -74,9 +74,7 @@ static void busy_scene_static_on_event(const BusyEvent* event, void* context) {
 
     if(event->type == BusyEventTypeStart) {
         busy_scene_static_toggle_pause_overlay(instance);
-
     } else if(event->type == BusyEventTypeBack) {
-        // TODO: Ignore if pause overlay on
         busy_switch_to_scene(instance, BusyAppSceneIdQuit);
     }
 }

--- a/applications/main/busy/scenes/busy_scene_timer.c
+++ b/applications/main/busy/scenes/busy_scene_timer.c
@@ -74,12 +74,16 @@ static void busy_scene_timer_update(BusyApp* instance) {
     gui_lvgl_release(instance->gui);
 }
 
-static void busy_scene_timer_toggle_pause_overlay(BusyApp* instance) {
+static void busy_scene_timer_show_pause_overlay(BusyApp* instance, bool show) {
     BusySceneTimer* data = busy_get_current_scene_data(instance);
+
+    if(show == !!data->overlay) {
+        return;
+    }
 
     gui_lvgl_acquire(instance->gui);
 
-    if(data->overlay == NULL) {
+    if(show) {
         lv_obj_t* top = gui_lvgl_get_layer(instance->gui, GuiDisplayIdFront, GuiLayerIdTop);
 
         data->overlay = lv_obj_create(top);
@@ -99,6 +103,11 @@ static void busy_scene_timer_toggle_pause_overlay(BusyApp* instance) {
     }
 
     gui_lvgl_release(instance->gui);
+}
+
+static void busy_scene_timer_toggle_pause_overlay(BusyApp* instance) {
+    BusySceneTimer* data = busy_get_current_scene_data(instance);
+    busy_scene_timer_show_pause_overlay(instance, data->overlay == NULL);
 }
 
 static void busy_scene_timer_start_pressed_callback(lv_event_t* event) {
@@ -192,6 +201,7 @@ static void busy_scene_timer_on_event(const BusyEvent* event, void* context) {
 
     } else if(event->type == BusyEventTypeOk) {
         busy_timer_next_state(instance, true);
+        busy_scene_timer_show_pause_overlay(instance, false);
 
     } else if(event->type == BusyEventTypeCustom) {
         if(event->custom_value == BusyCustomEventUpdate) {
@@ -204,8 +214,8 @@ static void busy_scene_timer_on_event(const BusyEvent* event, void* context) {
             busy_timer_toggle(instance);
             busy_scene_timer_toggle_pause_overlay(instance);
         } else if(event->custom_value == BusyCustomEventStartDouble) {
-            busy_timer_next_state(instance, false);
-            busy_scene_timer_toggle_pause_overlay(instance);
+            busy_timer_next_state(instance, true);
+            busy_scene_timer_show_pause_overlay(instance, false);
         }
     }
 }

--- a/applications/main/busy/scenes/busy_scene_timer.c
+++ b/applications/main/busy/scenes/busy_scene_timer.c
@@ -103,12 +103,16 @@ static void busy_scene_timer_toggle_pause_overlay(BusyApp* instance) {
 
 static void busy_scene_timer_start_pressed_callback(lv_event_t* event) {
     BusyApp* instance = lv_event_get_user_data(event);
-    const lv_event_code_t code = lv_event_get_code(event);
 
-    if(code == LV_EVENT_SINGLE_CLICKED) {
-        busy_send_custom_event(instance, BusyCustomEventStartSingle);
-    } else if(code == LV_EVENT_DOUBLE_CLICKED) {
-        busy_send_custom_event(instance, BusyCustomEventStartDouble);
+    const lv_event_code_t code = lv_event_get_code(event);
+    const lv_indev_t* indev = lv_event_get_param(event);
+
+    if(lv_indev_get_type(indev) == LV_INDEV_TYPE_KEYPAD) {
+        if(code == LV_EVENT_SINGLE_CLICKED) {
+            busy_send_custom_event(instance, BusyCustomEventStartSingle);
+        } else if(code == LV_EVENT_DOUBLE_CLICKED) {
+            busy_send_custom_event(instance, BusyCustomEventStartDouble);
+        }
     }
 }
 
@@ -162,6 +166,10 @@ static void busy_scene_timer_on_exit(void* context) {
     BusySceneTimer* data = busy_get_current_scene_data(instance);
 
     gui_lvgl_acquire(instance->gui);
+
+    // Stop sending input events to the label
+    // TODO: Why isn't it removed automatically?
+    lv_group_remove_obj(data->info_label);
 
     lv_obj_delete(data->main_image);
     lv_obj_delete(data->time_label);

--- a/applications/main/busy/scenes/busy_scene_timer.c
+++ b/applications/main/busy/scenes/busy_scene_timer.c
@@ -101,6 +101,17 @@ static void busy_scene_timer_toggle_pause_overlay(BusyApp* instance) {
     gui_lvgl_release(instance->gui);
 }
 
+static void busy_scene_timer_start_pressed_callback(lv_event_t* event) {
+    BusyApp* instance = lv_event_get_user_data(event);
+    const lv_event_code_t code = lv_event_get_code(event);
+
+    if(code == LV_EVENT_SINGLE_CLICKED) {
+        busy_send_custom_event(instance, BusyCustomEventStartSingle);
+    } else if(code == LV_EVENT_DOUBLE_CLICKED) {
+        busy_send_custom_event(instance, BusyCustomEventStartDouble);
+    }
+}
+
 static void busy_scene_timer_on_enter(void* context) {
     BusyApp* instance = context;
     BusySceneTimer* data = busy_get_current_scene_data(instance);
@@ -123,6 +134,19 @@ static void busy_scene_timer_on_enter(void* context) {
     // TODO: Implement in theme
     lv_obj_set_style_text_color(data->info_label, lv_color_white(), LV_PART_MAIN);
     lv_obj_set_pos(data->info_label, 41, 10);
+
+    lv_obj_add_event_cb(
+        data->info_label,
+        busy_scene_timer_start_pressed_callback,
+        LV_EVENT_SINGLE_CLICKED,
+        instance);
+    lv_obj_add_event_cb(
+        data->info_label,
+        busy_scene_timer_start_pressed_callback,
+        LV_EVENT_DOUBLE_CLICKED,
+        instance);
+    // Send input events to the label
+    lv_group_add_obj(lv_group_get_default(), data->info_label);
 
     data->time_bar = lv_bar_create(active);
     lv_obj_set_pos(data->time_bar, 1, 15);
@@ -155,19 +179,11 @@ static void busy_scene_timer_on_exit(void* context) {
 static void busy_scene_timer_on_event(const BusyEvent* event, void* context) {
     BusyApp* instance = context;
 
-    if(event->type == BusyEventTypeStart) {
-        busy_scene_timer_toggle_pause_overlay(instance);
-        busy_timer_toggle(instance);
-
-    } else if(event->type == BusyEventTypeBack) {
-        if(busy_timer_is_running(instance)) {
-            busy_switch_to_scene(instance, BusyAppSceneIdQuit);
-        }
+    if(event->type == BusyEventTypeBack) {
+        busy_switch_to_scene(instance, BusyAppSceneIdQuit);
 
     } else if(event->type == BusyEventTypeOk) {
-        if(busy_timer_is_running(instance)) {
-            busy_timer_next_state(instance, true);
-        }
+        busy_timer_next_state(instance, true);
 
     } else if(event->type == BusyEventTypeCustom) {
         if(event->custom_value == BusyCustomEventUpdate) {
@@ -176,6 +192,12 @@ static void busy_scene_timer_on_event(const BusyEvent* event, void* context) {
             busy_switch_to_scene(instance, BusyAppSceneIdNext);
         } else if(event->custom_value == BusyCustomEventSessionEnd) {
             busy_switch_to_scene(instance, BusyAppSceneIdRestart);
+        } else if(event->custom_value == BusyCustomEventStartSingle) {
+            busy_timer_toggle(instance);
+            busy_scene_timer_toggle_pause_overlay(instance);
+        } else if(event->custom_value == BusyCustomEventStartDouble) {
+            busy_timer_next_state(instance, false);
+            busy_scene_timer_toggle_pause_overlay(instance);
         }
     }
 }

--- a/applications/main/busy/scenes/busy_scene_timer.c
+++ b/applications/main/busy/scenes/busy_scene_timer.c
@@ -21,7 +21,7 @@ static void busy_scene_timer_state_update(BusySceneTimer* data) {
     uint32_t bar_color_indicator;
 
     // TODO: Use colours from theme
-    if(data->timer_state == BusyTimerStateBusy) {
+    if(data->timer_state == BusyTimerStateWork) {
         main_image_dsc = &I_busy_39x14;
         bar_color_main = 0x4A0000;
         bar_color_indicator = 0xFF0000;
@@ -63,7 +63,7 @@ static void busy_scene_timer_update(BusyApp* instance) {
     lv_label_set_text_fmt(data->time_label, "%02lu:%02lu", minutes, seconds);
     lv_bar_set_value(data->time_bar, percent, LV_ANIM_OFF);
 
-    if(data->timer_state == BusyTimerStateBusy) {
+    if(data->timer_state == BusyTimerStateWork) {
         lv_label_set_text_fmt(instance->back_label, "BUSY: %02lu:%02lu", minutes, seconds);
     } else if(data->timer_state == BusyTimerStateRest) {
         lv_label_set_text_fmt(instance->back_label, "REST: %02lu:%02lu", minutes, seconds);

--- a/applications/services/gui_lvgl/gui_lvgl.c
+++ b/applications/services/gui_lvgl/gui_lvgl.c
@@ -210,11 +210,11 @@ static void gui_lvgl_tick_callback(void* context) {
     furi_assert(context);
     GuiLvgl* instance = context;
 
-    if(furi_mutex_acquire(instance->access_mutex, 2) == FuriStatusOk) {
+    if(furi_mutex_acquire(instance->access_mutex, 0) == FuriStatusOk) {
         lv_timer_periodic_handler();
         furi_mutex_release(instance->access_mutex);
     } else {
-        FURI_LOG_W(TAG, "Gui lockup: tick skipped");
+        FURI_LOG_T(TAG, "Gui lockup: tick skipped");
     }
 }
 
@@ -224,18 +224,22 @@ static void gui_lvgl_input_queue_callback(FuriEventLoopObject* object, void* con
     GuiLvgl* instance = context;
     furi_assert(object == instance->input_queue);
 
-    furi_check(
-        furi_message_queue_get(instance->input_queue, &instance->input_event, 0) == FuriStatusOk);
+    if(furi_mutex_acquire(instance->access_mutex, 0) == FuriStatusOk) {
+        while(furi_message_queue_get(instance->input_queue, &instance->input_event, 0) ==
+              FuriStatusOk) {
+            const GuiInputId input_id = instance->input_event.id;
+            furi_assert(input_id < GuiInputIdMax);
 
-    const GuiInputId input_id = instance->input_event.id;
-    furi_assert(input_id < GuiInputIdMax);
+            for(uint32_t i = 0; i < GuiDisplayIdMax; ++i) {
+                lv_indev_t* indev = instance->display_data[i].lv_indevs[input_id];
 
-    for(uint32_t i = 0; i < GuiDisplayIdMax; ++i) {
-        lv_indev_t* indev = instance->display_data[i].lv_indevs[input_id];
-
-        if(indev != NULL) {
-            lv_indev_read(indev);
+                if(indev != NULL) {
+                    lv_indev_read(indev);
+                }
+            }
         }
+
+        furi_mutex_release(instance->access_mutex);
     }
 }
 


### PR DESCRIPTION
# What's new

- Improved input thread safety
- Added double tap on start button
- General behaviour improvements
- Added more logging output

# How to test

1. Flash the Main firmware.
2. Use the BUSY app normally. It should behave correctly and not crash.