### PR TITLE
[FW-106] Intercom synchronisation on request

### DIFF
--- a/applications/services/intercom/intercom.c
+++ b/applications/services/intercom/intercom.c
@@ -14,10 +14,22 @@
 #define INTERCOM_BAUD_RATE (11250000UL)
 #endif
 
-#ifdef STM32U595xx
-#define INTERCOM_SERIAL FuriHalSerialIdUsart1
+#if defined(STM32U595xx)
+#define TARGET_F20
+#elif defined(SI917)
+#define TARGET_F64
 #else
+#error "Unsupported MCU"
+#endif
+
+#if defined(TARGET_F20)
+#define INTERCOM_SERIAL FuriHalSerialIdUsart1
+#define INTERCOM_GPIO   gpio_917_irq
+#elif defined(TARGET_F64)
 #define INTERCOM_SERIAL FuriHalSerialIdUsart0
+#define INTERCOM_GPIO   gpio_u5_irq
+#else
+#error "Unsupported target"
 #endif
 
 typedef struct {
@@ -38,10 +50,20 @@ struct Intercom {
 };
 
 typedef enum {
-    IntercomEventFrameSent = 1UL << 0,
-    IntercomEventFrameReceived = 1UL << 1,
-    IntercomEventDataAvailable = 1UL << 2,
+    IntercomEventSyncRequested = 1UL << 0,
+    IntercomEventFrameSent = 1UL << 1,
+    IntercomEventFrameReceived = 1UL << 2,
+    IntercomEventDataAvailable = 1UL << 3,
 } IntercomEvent;
+
+// Called in ISR context
+static void intercom_gpio_irq_callback(void* context) {
+    furi_assert(context);
+    Intercom* instance = context;
+
+    furi_hal_gpio_remove_int_callback(&INTERCOM_GPIO);
+    furi_event_loop_set_custom_event(instance->event_loop, IntercomEventSyncRequested);
+}
 
 // Called in ISR context
 static void intercom_serial_tx_callback(
@@ -114,6 +136,26 @@ static void intercom_default_error_callback(IntercomError error, void* context) 
     }
 }
 
+static FURI_ALWAYS_INLINE void intercom_process_sync_requested_event(Intercom* instance) {
+    INTERCOM_LOG_D("Sync requested");
+
+    furi_hal_serial_dma_rx_stop(instance->serial);
+
+    if(intercom_sync_serial(instance->serial)) {
+// TODO: Unify function signatures
+#if defined (TARGET_F20)
+        furi_hal_gpio_init_simple(&INTERCOM_GPIO, GpioModeInterruptFall);
+        furi_hal_gpio_add_int_callback(&INTERCOM_GPIO, intercom_gpio_irq_callback, instance);
+#elif defined (TARGET_F64)
+        furi_hal_gpio_add_int_callback(&INTERCOM_GPIO, GpioConditionFall, intercom_gpio_irq_callback, instance);
+#else
+#error "Unsupported target"
+#endif
+    } else {
+        instance->error_callback(IntercomErrorSync, instance->error_callback_context);
+    }
+}
+
 static FURI_ALWAYS_INLINE void intercom_send_tx_frame(Intercom* instance) {
     IntercomFrame* tx_frame = &instance->tx_frame;
 
@@ -154,6 +196,10 @@ static FURI_ALWAYS_INLINE void intercom_process_tx_frame_event(Intercom* instanc
 
 static void intercom_custom_event_callback(uint32_t events, void* context) {
     Intercom* instance = context;
+    if(events & IntercomEventSyncRequested) {
+        INTERCOM_LOG_D("IntercomEventSyncRequested");
+        intercom_process_sync_requested_event(instance);
+    }
     if(events & IntercomEventFrameSent) {
         INTERCOM_LOG_D("IntercomEventFrameSent");
         intercom_process_tx_frame_event(instance);
@@ -191,10 +237,10 @@ static Intercom* intercom_alloc(void) {
 
     furi_hal_serial_init(instance->serial, INTERCOM_BAUD_RATE);
     furi_hal_serial_set_hw_flow_control(instance->serial, FuriHalSerialHwFlowControlRtsCts);
-
-    if(!intercom_sync_serial(instance->serial)) {
-        instance->error_callback(IntercomErrorSync, instance->error_callback_context);
-    }
+    // Pulse gpio_xxx_irq pin to request synchronisation procedure
+    intercom_sync_request(&INTERCOM_GPIO);
+    // Perform initial synchronisation procedure
+    intercom_process_sync_requested_event(instance);
 
     furi_hal_serial_set_callback(
         instance->serial, intercom_serial_tx_callback, intercom_serial_rx_callback, instance);

--- a/applications/services/intercom/intercom.c
+++ b/applications/services/intercom/intercom.c
@@ -190,13 +190,11 @@ static Intercom* intercom_alloc(void) {
         instance->event_loop, intercom_custom_event_callback, instance);
 
     furi_hal_serial_init(instance->serial, INTERCOM_BAUD_RATE);
+    furi_hal_serial_set_hw_flow_control(instance->serial, FuriHalSerialHwFlowControlRtsCts);
 
     if(!intercom_sync_serial(instance->serial)) {
         instance->error_callback(IntercomErrorSync, instance->error_callback_context);
     }
-
-    furi_hal_serial_set_hw_flow_control(instance->serial, FuriHalSerialHwFlowControlRtsCts);
-    furi_hal_serial_clear(instance->serial, FuriHalSerialDirectionTxRx);
 
     furi_hal_serial_set_callback(
         instance->serial, intercom_serial_tx_callback, intercom_serial_rx_callback, instance);

--- a/applications/services/intercom/intercom.c
+++ b/applications/services/intercom/intercom.c
@@ -143,11 +143,12 @@ static FURI_ALWAYS_INLINE void intercom_process_sync_requested_event(Intercom* i
 
     if(intercom_sync_serial(instance->serial)) {
 // TODO: Unify function signatures
-#if defined (TARGET_F20)
+#if defined(TARGET_F20)
         furi_hal_gpio_init_simple(&INTERCOM_GPIO, GpioModeInterruptFall);
         furi_hal_gpio_add_int_callback(&INTERCOM_GPIO, intercom_gpio_irq_callback, instance);
-#elif defined (TARGET_F64)
-        furi_hal_gpio_add_int_callback(&INTERCOM_GPIO, GpioConditionFall, intercom_gpio_irq_callback, instance);
+#elif defined(TARGET_F64)
+        furi_hal_gpio_add_int_callback(
+            &INTERCOM_GPIO, GpioConditionFall, intercom_gpio_irq_callback, instance);
 #else
 #error "Unsupported target"
 #endif

--- a/applications/services/intercom/intercom.c
+++ b/applications/services/intercom/intercom.c
@@ -151,6 +151,8 @@ static FURI_ALWAYS_INLINE void intercom_process_sync_requested_event(Intercom* i
 #else
 #error "Unsupported target"
 #endif
+        furi_hal_serial_dma_rx_start(
+            instance->serial, (void*)&instance->rx_frame, sizeof(IntercomFrame));
     } else {
         instance->error_callback(IntercomErrorSync, instance->error_callback_context);
     }
@@ -237,15 +239,12 @@ static Intercom* intercom_alloc(void) {
 
     furi_hal_serial_init(instance->serial, INTERCOM_BAUD_RATE);
     furi_hal_serial_set_hw_flow_control(instance->serial, FuriHalSerialHwFlowControlRtsCts);
+    furi_hal_serial_set_callback(
+        instance->serial, intercom_serial_tx_callback, intercom_serial_rx_callback, instance);
     // Pulse gpio_xxx_irq pin to request synchronisation procedure
     intercom_sync_request(&INTERCOM_GPIO);
     // Perform initial synchronisation procedure
     intercom_process_sync_requested_event(instance);
-
-    furi_hal_serial_set_callback(
-        instance->serial, intercom_serial_tx_callback, intercom_serial_rx_callback, instance);
-    furi_hal_serial_dma_rx_start(
-        instance->serial, (void*)&instance->rx_frame, sizeof(IntercomFrame));
 
     furi_record_create(RECORD_INTERCOM, instance);
     return instance;

--- a/applications/services/intercom/intercom.c
+++ b/applications/services/intercom/intercom.c
@@ -1,17 +1,6 @@
-#include "intercom.h"
-
-#include <furi.h>
-
-#include <furi_hal_serial.h>
-#include <furi_hal_serial_control.h>
-
-#include "intercom_frame.h"
+#include "intercom_i.h"
 
 #define TAG "IntercomSrv"
-
-#define INTERCOM_SYNC_TIMEOUT_MS    (10000UL)
-#define INTERCOM_SYNC_INTERVAL_1_MS (5UL)
-#define INTERCOM_SYNC_INTERVAL_2_MS (1UL)
 
 #define INTERCOM_TX_TIMEOUT_MS (1000UL)
 
@@ -186,60 +175,6 @@ static void intercom_tx_timer_callback(void* context) {
     instance->error_callback(IntercomErrorTransmit, instance->error_callback_context);
 }
 
-static bool intercom_sync_serial(FuriHalSerialHandle* serial) {
-    bool success = true;
-
-    const uint8_t leader_1 = 0x55;
-    const uint8_t leader_2 = 0xAA;
-
-    do {
-        const uint32_t start_time = furi_get_tick();
-
-        // Stage 1 - ensure that the target is responding
-        while(true) {
-            furi_hal_serial_tx(serial, &leader_1, 1);
-            furi_hal_serial_tx_wait_complete(serial);
-
-            if(furi_hal_serial_rx_available(serial)) {
-                if(furi_hal_serial_rx(serial) == leader_1) {
-                    break;
-                }
-
-            } else if(furi_get_tick() - start_time < INTERCOM_SYNC_TIMEOUT_MS) {
-                furi_delay_ms(INTERCOM_SYNC_INTERVAL_1_MS);
-
-            } else {
-                success = false;
-                break;
-            }
-        }
-
-        if(!success) break;
-
-        // Stage 2 - ensure that data streams are in sync
-        furi_hal_serial_tx(serial, &leader_2, 1);
-        furi_hal_serial_tx_wait_complete(serial);
-
-        while(true) {
-            if(furi_hal_serial_rx_available(serial)) {
-                if(furi_hal_serial_rx(serial) == leader_2) {
-                    break;
-                }
-
-            } else if(furi_get_tick() - start_time < INTERCOM_SYNC_TIMEOUT_MS) {
-                furi_delay_ms(INTERCOM_SYNC_INTERVAL_2_MS);
-
-            } else {
-                success = false;
-                break;
-            }
-        }
-
-    } while(false);
-
-    return success;
-}
-
 static Intercom* intercom_alloc(void) {
     Intercom* instance = malloc(sizeof(Intercom));
 
@@ -251,18 +186,20 @@ static Intercom* intercom_alloc(void) {
     instance->error_callback = intercom_default_error_callback;
     instance->error_callback_context = instance;
 
-    furi_hal_serial_init(instance->serial, INTERCOM_BAUD_RATE);
-    furi_hal_serial_set_hw_flow_control(instance->serial, FuriHalSerialHwFlowControlRtsCts);
-    furi_hal_serial_set_callback(
-        instance->serial, intercom_serial_tx_callback, intercom_serial_rx_callback, instance);
     furi_event_loop_set_custom_event_callback(
         instance->event_loop, intercom_custom_event_callback, instance);
+
+    furi_hal_serial_init(instance->serial, INTERCOM_BAUD_RATE);
 
     if(!intercom_sync_serial(instance->serial)) {
         instance->error_callback(IntercomErrorSync, instance->error_callback_context);
     }
 
+    furi_hal_serial_set_hw_flow_control(instance->serial, FuriHalSerialHwFlowControlRtsCts);
     furi_hal_serial_clear(instance->serial, FuriHalSerialDirectionTxRx);
+
+    furi_hal_serial_set_callback(
+        instance->serial, intercom_serial_tx_callback, intercom_serial_rx_callback, instance);
     furi_hal_serial_dma_rx_start(
         instance->serial, (void*)&instance->rx_frame, sizeof(IntercomFrame));
 

--- a/applications/services/intercom/intercom_frame.h
+++ b/applications/services/intercom/intercom_frame.h
@@ -4,8 +4,7 @@
  */
 #pragma once
 
-#include <stdint.h>
-#include <stddef.h>
+#include <furi.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,21 +15,17 @@ extern "C" {
 /** Maximum data (payload) size */
 #define INTERCOM_FRAME_DATA_SIZE (INTERCOM_FRAME_SIZE - 5U)
 
-#pragma pack(push, 1)
-
 /**
  * @brief Intercom frame structure.
  *
  * All Intercom frames have a fixed size of 1024 bytes.
  */
-typedef struct {
+typedef struct FURI_PACKED {
     uint8_t channel; /**< Channel identifier */
     uint16_t data_size; /**< Size of the data (payload) contained in this frame */
     uint8_t data[INTERCOM_FRAME_DATA_SIZE]; /**< Data (payload) to transmit with the frame */
     uint16_t check; /**< 16-bit checksum for transmission error detection */
 } IntercomFrame;
-
-#pragma pack(pop)
 
 static_assert(sizeof(IntercomFrame) == INTERCOM_FRAME_SIZE);
 

--- a/applications/services/intercom/intercom_i.h
+++ b/applications/services/intercom/intercom_i.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "intercom.h"
+#include "intercom_frame.h"
+
+#include <furi.h>
+
+#include <furi_hal_serial.h>
+#include <furi_hal_serial_control.h>
+
+bool intercom_sync_serial(FuriHalSerialHandle* serial);

--- a/applications/services/intercom/intercom_i.h
+++ b/applications/services/intercom/intercom_i.h
@@ -7,5 +7,7 @@
 
 #include <furi_hal_serial.h>
 #include <furi_hal_serial_control.h>
+#include <furi_hal_resources.h>
 
+void intercom_sync_request(const GpioPin* gpio);
 bool intercom_sync_serial(FuriHalSerialHandle* serial);

--- a/applications/services/intercom/intercom_sync.c
+++ b/applications/services/intercom/intercom_sync.c
@@ -45,7 +45,7 @@ static bool
 
     const uint32_t start_time = furi_get_tick();
 
-    while(true) {
+    while(furi_get_tick() - start_time < INTERCOM_SYNC_TIMEOUT_MS) {
         if(send_leader) {
             furi_hal_serial_tx(serial, &sequence->leader, 1);
             if(!furi_hal_serial_tx_wait_complete(serial, INTERCOM_SYNC_TIMEOUT_MS)) {
@@ -62,12 +62,9 @@ static bool
                 success = true;
                 break;
             }
-
-        } else if(furi_get_tick() - start_time < INTERCOM_SYNC_TIMEOUT_MS) {
-            furi_delay_ms(sequence->interval);
-        } else {
-            break;
         }
+
+        furi_delay_ms(sequence->interval);
     }
 
     return success;

--- a/applications/services/intercom/intercom_sync.c
+++ b/applications/services/intercom/intercom_sync.c
@@ -45,7 +45,7 @@ static bool
 
     const uint32_t start_time = furi_get_tick();
 
-    while(furi_get_tick() - start_time < INTERCOM_SYNC_TIMEOUT_MS) {
+    while(furi_get_tick() - start_time < furi_ms_to_ticks(INTERCOM_SYNC_TIMEOUT_MS)) {
         if(send_leader) {
             furi_hal_serial_tx(serial, &sequence->leader, 1);
             if(!furi_hal_serial_tx_wait_complete(serial, INTERCOM_SYNC_TIMEOUT_MS)) {

--- a/applications/services/intercom/intercom_sync.c
+++ b/applications/services/intercom/intercom_sync.c
@@ -109,3 +109,11 @@ bool intercom_sync_serial(FuriHalSerialHandle* serial) {
 
     return success;
 }
+
+void intercom_sync_request(const GpioPin* gpio) {
+    furi_hal_gpio_init(gpio, GpioModeOutputOpenDrain, GpioPullNo, GpioSpeedLow);
+    furi_hal_gpio_write_open_drain(gpio, false);
+    furi_delay_us(10);
+    furi_hal_gpio_write_open_drain(gpio, true);
+    furi_hal_gpio_init(gpio, GpioModeInput, GpioPullNo, GpioSpeedLow);
+}

--- a/applications/services/intercom/intercom_sync.c
+++ b/applications/services/intercom/intercom_sync.c
@@ -1,0 +1,112 @@
+#include "intercom_i.h"
+
+#define INTERCOM_SYNC_LEADER_1 (0x55)
+#define INTERCOM_SYNC_LEADER_2 (0xAA)
+
+#define INTERCOM_SYNC_INTERVAL_1_MS (5UL)
+#define INTERCOM_SYNC_INTERVAL_2_MS (1UL)
+
+#define INTERCOM_SYNC_TIMEOUT_MS (10000UL)
+
+typedef struct {
+    uint8_t leader;
+    uint32_t interval;
+    bool repeat_leader;
+} IntercomSyncSequence;
+
+static const IntercomSyncSequence intercom_sync_sequences[] = {
+    // Sequence 1 - ensure that the target is responding
+    {
+        .leader = INTERCOM_SYNC_LEADER_1,
+        .interval = INTERCOM_SYNC_INTERVAL_1_MS,
+        .repeat_leader = true,
+    },
+    // Sequence 2 - ensure that data streams are in sync
+    {
+        .leader = INTERCOM_SYNC_LEADER_2,
+        .interval = INTERCOM_SYNC_INTERVAL_2_MS,
+        .repeat_leader = false,
+    },
+};
+
+/**
+ * Basic principle of operation:
+ *
+ * 1. Send a leader character,
+ * 2. Wait for received data,
+ * 3. If the received character is a leader character, report success.
+ * 4. If no characters have been received, retry until a leader character is detected or the timeout expires.
+ * 5. Depending on the repeat_leader flag, send the leader repeatedly when retrying, or do it only in the beginning.
+ */
+static bool
+    intercom_sync_sequence(FuriHalSerialHandle* serial, const IntercomSyncSequence* sequence) {
+    bool success = false;
+    bool send_leader = true;
+
+    const uint32_t start_time = furi_get_tick();
+
+    while(true) {
+        if(send_leader) {
+            furi_hal_serial_tx(serial, &sequence->leader, 1);
+            furi_hal_serial_tx_wait_complete(serial);
+            // If repeat_leader is false, then the leader is sent only once
+            if(!sequence->repeat_leader) {
+                send_leader = false;
+            }
+        }
+
+        if(furi_hal_serial_rx_available(serial)) {
+            if(furi_hal_serial_rx(serial) == sequence->leader) {
+                success = true;
+                break;
+            }
+
+        } else if(furi_get_tick() - start_time < INTERCOM_SYNC_TIMEOUT_MS) {
+            furi_delay_ms(sequence->interval);
+        } else {
+            break;
+        }
+    }
+
+    return success;
+}
+
+/**
+ * The synchronisation procedure lets 2 devices agree on where the beginning of the data stream is.
+ *
+ * This method has the following benefits:
+ * - Rejection of any erroneous data that might have been accidentally sent during configuration.
+ * - Independence of the startup timing. Both sides only must be brought up within the timeout period.
+ *
+ * Basic operating principle:
+ *
+ * 1. Send the 1st sequence leader character REPEATEDLY until the other side responds with it.
+ * 2. Send the 2nd sequence leader character ONCE until the other side responds with it.
+ * 3. Once the 2nd sequence leader character has been received, the data streams are synchronised.
+ * 4. If any of the above procedures could not be completed within a timeout, report an error.
+ *
+ * Example time diagram:
+ *
+ * 1st sequence leader char = 'A'
+ * 2nd sequence leader char = 'B'
+ *
+ * SIDE A | TX | (startup) AAAAAAAAAAAAAAAB
+ *        | RX | (garbage or silence)    AB(sync!)
+ * -------+----+----------------------------------
+ * SIDE B | TX | (startup)               AB
+ *        | RX | (garbage or silence)    AB(sync!)
+ * -------+----+----------------------------------
+ *               TIME ->
+ */
+bool intercom_sync_serial(FuriHalSerialHandle* serial) {
+    bool success = true;
+
+    for(uint32_t i = 0; i < COUNT_OF(intercom_sync_sequences); ++i) {
+        if(!intercom_sync_sequence(serial, &intercom_sync_sequences[i])) {
+            success = false;
+            break;
+        }
+    }
+
+    return success;
+}

--- a/applications/services/intercom/intercom_sync.c
+++ b/applications/services/intercom/intercom_sync.c
@@ -48,7 +48,9 @@ static bool
     while(true) {
         if(send_leader) {
             furi_hal_serial_tx(serial, &sequence->leader, 1);
-            furi_hal_serial_tx_wait_complete(serial);
+            if(!furi_hal_serial_tx_wait_complete(serial, INTERCOM_SYNC_TIMEOUT_MS)) {
+                break;
+            }
             // If repeat_leader is false, then the leader is sent only once
             if(!sequence->repeat_leader) {
                 send_leader = false;

--- a/targets/f20/furi_hal/furi_hal_gpio.h
+++ b/targets/f20/furi_hal/furi_hal_gpio.h
@@ -290,8 +290,7 @@ static inline void furi_hal_gpio_write(const GpioPin* gpio, const bool state) {
  * Compatibility macro for systems that require a different
  * open drain GPIO procedure
  */
-#define furi_hal_gpio_write_open_drain(gpio, state) \
-    furi_hal_gpio_write(gpio, state)
+#define furi_hal_gpio_write_open_drain(gpio, state) furi_hal_gpio_write(gpio, state)
 
 /**
  * GPIO read pin

--- a/targets/f20/furi_hal/furi_hal_gpio.h
+++ b/targets/f20/furi_hal/furi_hal_gpio.h
@@ -287,6 +287,13 @@ static inline void furi_hal_gpio_write(const GpioPin* gpio, const bool state) {
 }
 
 /**
+ * Compatibility macro for systems that require a different
+ * open drain GPIO procedure
+ */
+#define furi_hal_gpio_write_open_drain(gpio, state) \
+    furi_hal_gpio_write(gpio, state)
+
+/**
  * GPIO read pin
  * @param port GPIO port
  * @param pin pin mask

--- a/targets/f20/furi_hal/furi_hal_serial.c
+++ b/targets/f20/furi_hal/furi_hal_serial.c
@@ -719,7 +719,16 @@ void furi_hal_serial_dma_rx_start(FuriHalSerialHandle* handle, uint8_t* buffer, 
 
 void furi_hal_serial_dma_rx_stop(FuriHalSerialHandle* handle) {
     furi_check(handle);
-    // TODO: Implement
+    FuriHalSerial* serial = furi_hal_serial[handle->id];
+    furi_check(serial);
+
+    USART_TypeDef* periph = serial->periph_ptr;
+    const uint32_t dma_channel = serial->dma_rx_channel;
+
+    FURI_CRITICAL_ENTER();
+    LL_USART_DisableDMAReq_RX(periph);
+    LL_DMA_DisableChannel(GPDMA1, dma_channel);
+    FURI_CRITICAL_EXIT();
 }
 
 void furi_hal_serial_clear(FuriHalSerialHandle* handle, FuriHalSerialDirection dir) {

--- a/targets/f20/furi_hal/furi_hal_serial.c
+++ b/targets/f20/furi_hal/furi_hal_serial.c
@@ -3,6 +3,7 @@
 
 #include <furi_hal_resources.h>
 #include <furi_hal_interrupt.h>
+#include <furi_hal_cortex.h>
 #include <furi_hal_bus.h>
 #include <furi_hal_dma.h>
 
@@ -619,10 +620,21 @@ void furi_hal_serial_tx(FuriHalSerialHandle* handle, const uint8_t* buffer, size
     }
 }
 
-void furi_hal_serial_tx_wait_complete(FuriHalSerialHandle* handle) {
+bool furi_hal_serial_tx_wait_complete(FuriHalSerialHandle* handle, uint32_t timeout) {
     furi_check(handle);
-    while(!LL_USART_IsActiveFlag_TXFE(furi_hal_serial_resources[handle->id].periph))
-        ;
+
+    bool success = false;
+
+    FuriHalCortexTimer timer = furi_hal_cortex_timer_get(timeout * 1000);
+
+    while(!furi_hal_cortex_timer_is_expired(timer)) {
+        if(LL_USART_IsActiveFlag_TXFE(furi_hal_serial_resources[handle->id].periph)) {
+            success = true;
+            break;
+        }
+    }
+
+    return success;
 }
 
 bool furi_hal_serial_rx_available(FuriHalSerialHandle* handle) {

--- a/targets/f20/furi_hal/furi_hal_serial.h
+++ b/targets/f20/furi_hal/furi_hal_serial.h
@@ -149,8 +149,10 @@ void furi_hal_serial_tx(FuriHalSerialHandle* handle, const uint8_t* buffer, size
  * Wait for the transmission to complete.
  *
  * @param handle Pointer to the serial handle.
+ * @param timeout Timeout in milliseconds.
+ * @returns true if the transmission was complete within the timeout, false otherwise
  */
-void furi_hal_serial_tx_wait_complete(FuriHalSerialHandle* handle);
+bool furi_hal_serial_tx_wait_complete(FuriHalSerialHandle* handle, uint32_t timeout);
 
 /**
  * Determine whether there is received data ready for reading.

--- a/targets/f20/furi_hal/furi_hal_serial_control.c
+++ b/targets/f20/furi_hal/furi_hal_serial_control.c
@@ -200,7 +200,7 @@ void furi_hal_serial_control_suspend(void) {
     furi_check(furi_hal_serial_control);
 
     for(size_t i = 0; i < FuriHalSerialIdMax; i++) {
-        furi_hal_serial_tx_wait_complete(&furi_hal_serial_control->handles[i]);
+        furi_hal_serial_tx_wait_complete(&furi_hal_serial_control->handles[i], 100);
         furi_hal_serial_suspend(&furi_hal_serial_control->handles[i]);
     }
 }

--- a/targets/f20/furi_hal/furi_hal_serial_control.c
+++ b/targets/f20/furi_hal/furi_hal_serial_control.c
@@ -7,6 +7,8 @@
 
 #define TAG "FuriHalSerialControl"
 
+#define TX_TIMEOUT_MS (1000)
+
 typedef enum {
     FuriHalSerialControlMessageTypeStop,
     FuriHalSerialControlMessageTypeAcquire,
@@ -200,7 +202,7 @@ void furi_hal_serial_control_suspend(void) {
     furi_check(furi_hal_serial_control);
 
     for(size_t i = 0; i < FuriHalSerialIdMax; i++) {
-        furi_hal_serial_tx_wait_complete(&furi_hal_serial_control->handles[i], 100);
+        furi_hal_serial_tx_wait_complete(&furi_hal_serial_control->handles[i], TX_TIMEOUT_MS);
         furi_hal_serial_suspend(&furi_hal_serial_control->handles[i]);
     }
 }

--- a/targets/f64/furi_hal/furi_hal_resources.c
+++ b/targets/f64/furi_hal/furi_hal_resources.c
@@ -49,7 +49,7 @@ const GpioPin gpio_i_encoder_b = {.type = GpioTypeHp, .pin = 74};
 const GpioPin gpio_i_uart1_tx = {.type = GpioTypeHp, .pin = 75};
 
 const GpioPin gpio_ulp_0 = {.type = GpioTypeUlp, .pin = 0};
-const GpioPin gpio_irq = {.type = GpioTypeUlp, .pin = 1};
+const GpioPin gpio_u5_irq = {.type = GpioTypeUlp, .pin = 1};
 const GpioPin gpio_ulp_2 = {.type = GpioTypeUlp, .pin = 2};
 const GpioPin gpio_ulp_i_3 = {.type = GpioTypeUlp, .pin = 3};
 const GpioPin gpio_ulp_4 = {.type = GpioTypeUlp, .pin = 4};

--- a/targets/f64/furi_hal/furi_hal_resources.h
+++ b/targets/f64/furi_hal/furi_hal_resources.h
@@ -70,7 +70,7 @@ extern const GpioPin gpio_i_uart1_tx; /**< Not available on the package, interna
 
 /* ULP GPIO pins */
 extern const GpioPin gpio_ulp_0;
-extern const GpioPin gpio_irq;
+extern const GpioPin gpio_u5_irq;
 extern const GpioPin gpio_ulp_2;
 extern const GpioPin gpio_ulp_i_3; /**< Not available on the package, internal use only */
 extern const GpioPin gpio_ulp_4;

--- a/targets/f64/furi_hal/furi_hal_serial.c
+++ b/targets/f64/furi_hal/furi_hal_serial.c
@@ -2,6 +2,7 @@
 #include <furi_hal_serial_types_i.h>
 
 #include <furi_hal_resources.h>
+#include <furi_hal_cortex.h>
 #include <furi_hal_bus.h>
 #include <furi_hal_dma.h>
 
@@ -342,10 +343,21 @@ void furi_hal_serial_tx(FuriHalSerialHandle* handle, const uint8_t* buffer, size
     }
 }
 
-void furi_hal_serial_tx_wait_complete(FuriHalSerialHandle* handle) {
+bool furi_hal_serial_tx_wait_complete(FuriHalSerialHandle* handle, uint32_t timeout) {
     furi_check(handle);
-    while(!furi_hal_serial_resources[handle->id].periph->USR_b.TFE)
-        ;
+
+    bool success = false;
+
+    FuriHalCortexTimer timer = furi_hal_cortex_timer_get(timeout * 1000);
+
+    while(!furi_hal_cortex_timer_is_expired(timer)) {
+        if(furi_hal_serial_resources[handle->id].periph->USR_b.TFE) {
+            success = true;
+            break;
+        }
+    }
+
+    return success;
 }
 
 bool furi_hal_serial_rx_available(FuriHalSerialHandle* handle) {

--- a/targets/f64/furi_hal/furi_hal_serial.h
+++ b/targets/f64/furi_hal/furi_hal_serial.h
@@ -143,8 +143,10 @@ void furi_hal_serial_tx(FuriHalSerialHandle* handle, const uint8_t* buffer, size
  * Wait for the transmission to complete.
  *
  * @param handle Pointer to the serial handle.
+ * @param timeout Timeout in milliseconds.
+ * @returns true if the transmission was complete within the timeout, false otherwise
  */
-void furi_hal_serial_tx_wait_complete(FuriHalSerialHandle* handle);
+bool furi_hal_serial_tx_wait_complete(FuriHalSerialHandle* handle, uint32_t timeout);
 
 /**
  * Determine whether there is received data ready for reading.

--- a/targets/f64/furi_hal/furi_hal_serial_control.c
+++ b/targets/f64/furi_hal/furi_hal_serial_control.c
@@ -200,7 +200,7 @@ void furi_hal_serial_control_suspend(void) {
     furi_check(furi_hal_serial_control);
 
     for(size_t i = 0; i < FuriHalSerialIdMax; i++) {
-        furi_hal_serial_tx_wait_complete(&furi_hal_serial_control->handles[i]);
+        furi_hal_serial_tx_wait_complete(&furi_hal_serial_control->handles[i], 100);
         furi_hal_serial_suspend(&furi_hal_serial_control->handles[i]);
     }
 }

--- a/targets/f64/furi_hal/furi_hal_serial_control.c
+++ b/targets/f64/furi_hal/furi_hal_serial_control.c
@@ -7,6 +7,8 @@
 
 #define TAG "FuriHalSerialControl"
 
+#define TX_TIMEOUT_MS (1000)
+
 typedef enum {
     FuriHalSerialControlMessageTypeStop,
     FuriHalSerialControlMessageTypeAcquire,
@@ -200,7 +202,7 @@ void furi_hal_serial_control_suspend(void) {
     furi_check(furi_hal_serial_control);
 
     for(size_t i = 0; i < FuriHalSerialIdMax; i++) {
-        furi_hal_serial_tx_wait_complete(&furi_hal_serial_control->handles[i], 100);
+        furi_hal_serial_tx_wait_complete(&furi_hal_serial_control->handles[i], TX_TIMEOUT_MS);
         furi_hal_serial_suspend(&furi_hal_serial_control->handles[i]);
     }
 }


### PR DESCRIPTION
# What's new

- Add the ability to re-synchronise the `Intercom` serial streams at any point in time
- Fix a bug that prevented Intercom from crashing upon timeout expiration
- Separate synchronisation code, document it better
- Improve `furi_hal_serial` and `furi_hal_gpio`

# How to test

1. Flash BOTH Main and Wireless firmware.
2. With the BSB on, reset any of the microcontrollers. Intercom should continue working normally.

# Caveats

- If an Intercom transaction is ongoing, might still fail and cause a crash (further testing an d improvements may be necessary).
- EMMC card still won't mount if Intercom is taking a long time to synchronise (for example, when the Wireless microcontroller is off or non-functional) - planned for FW-107.
