### PR TITLE
[FW-109] Fix intercom crash

### DIFF
--- a/applications/main/wifi_setup/application.fam
+++ b/applications/main/wifi_setup/application.fam
@@ -3,7 +3,7 @@ App(
     name="WiFi Setup",
     apptype=FlipperAppType.APP,
     entry_point="wifi_setup_app",
-    requires=["gui"],
+    requires=["gui_lvgl"],
     stack_size=2 * 1024,
     fap_category="Debug",
     targets=["f20"],

--- a/applications/services/intercom/intercom.c
+++ b/applications/services/intercom/intercom.c
@@ -152,6 +152,7 @@ static FURI_ALWAYS_INLINE void intercom_process_sync_requested_event(Intercom* i
 #else
 #error "Unsupported target"
 #endif
+        furi_hal_serial_clear(instance->serial, FuriHalSerialDirectionTxRx);
         furi_hal_serial_dma_rx_start(
             instance->serial, (void*)&instance->rx_frame, sizeof(IntercomFrame));
     } else {


### PR DESCRIPTION
# What's new

- No more crashy-crashy

# How to test
1. Enable the `wifi_setup` app (change the credentials for your network) 
2. Flash both Main and Wireless firmware
3. From the Apps menu, launch Wifi Setup, no crashes should occur. 
