### PR TITLE
[FL-61] CLI Audio command

### DIFF
--- a/applications/services/audio/audio.c
+++ b/applications/services/audio/audio.c
@@ -24,6 +24,7 @@ typedef enum {
 
 typedef enum {
     AudioMessageTypePlayFile,
+    AudioMessageTypeStop,
     AudioMessageTypeSetVolume,
 } AudioMessageType;
 
@@ -160,6 +161,8 @@ static void audio_message_queue_callback(FuriEventLoopObject* object, void* cont
 
     if(msg.type == AudioMessageTypePlayFile) {
         result = audio_handle_play_file(instance, &msg);
+    } else if(msg.type == AudioMessageTypeStop) {
+        instance->should_stop = true;
     } else if(msg.type == AudioMessageTypeSetVolume) {
         instance->volume = msg.volume;
     } else {
@@ -243,6 +246,16 @@ bool audio_play_file(Audio* instance, const char* file_name) {
     audio_send_message(instance, &msg);
 
     return result;
+}
+
+void audio_stop(Audio* instance) {
+    furi_check(instance);
+
+    const AudioMessage msg = {
+        .type = AudioMessageTypeStop,
+    };
+
+    audio_send_message(instance, &msg);
 }
 
 void audio_set_volume(Audio* instance, float volume) {

--- a/applications/services/audio/audio.h
+++ b/applications/services/audio/audio.h
@@ -38,6 +38,13 @@ typedef struct Audio Audio;
 bool audio_play_file(Audio* instance, const char* file_name);
 
 /**
+ * @brief Stop playing current audio from file.
+ *
+ * @param[in,out] instance pointer to the Audio instance
+ */
+void audio_stop(Audio* instance);
+
+/**
  * @brief Set the playback volume.
  *
  * The volume MUST be in range 0.0 (mute) to 1.0 (full volume).

--- a/applications/services/cli/application.fam
+++ b/applications/services/cli/application.fam
@@ -15,5 +15,6 @@ App(
         "cli_command_display.c",
         "cli_command_status_lights.c",
         "cli_command_light_sensor.c",
+        "cli_command_audio.c",
     ],
 )

--- a/applications/services/cli/cli_command_audio.c
+++ b/applications/services/cli/cli_command_audio.c
@@ -1,0 +1,67 @@
+#include "cli_command_audio.h"
+
+#include <furi/furi.h>
+
+#include <audio/audio.h>
+#include <storage/storage.h>
+#include <toolbox/args.h>
+
+typedef enum {
+    CliAudioCommandStart,
+    CliAudioCommandStop,
+} CliAudioCommand;
+
+static void audio_cli_command_print_usage(void) {
+    printf("Usage:\r\n");
+    printf("audio start <path>\r\n");
+    printf("audio stop\r\n");
+}
+
+void cli_command_audio(Cli* cli, FuriString* args, void* context) {
+    UNUSED(cli);
+    UNUSED(context);
+
+    FuriString* str_tmp = furi_string_alloc();
+    CliAudioCommand cmd = CliAudioCommandStart;
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+
+    bool parsed = false;
+    do {
+        if(!args_read_string_and_trim(args, str_tmp)) break;
+        if(furi_string_cmp_str(str_tmp, "start") == 0) {
+            cmd = CliAudioCommandStart;
+        } else if(furi_string_cmp_str(str_tmp, "stop") == 0) {
+            cmd = CliAudioCommandStop;
+        } else {
+            printf("Invalid command %s\r\n", furi_string_get_cstr(str_tmp));
+            audio_cli_command_print_usage();
+            break;
+        }
+
+        if(cmd == CliAudioCommandStart) {
+            if(!args_read_string_and_trim(args, str_tmp)) break;
+            if(!storage_file_exists(storage, furi_string_get_cstr(str_tmp))) {
+                printf("File %s does not exist\r\n", furi_string_get_cstr(str_tmp));
+                break;
+            }
+        }
+        parsed = true;
+    } while(false);
+
+    if(!parsed) {
+        return;
+    }
+
+    Audio* audio = furi_record_open(RECORD_AUDIO);
+    if(cmd == CliAudioCommandStart) {
+        if(!audio_play_file(audio, furi_string_get_cstr(str_tmp))) {
+            printf("Failed to play file %s\r\n", furi_string_get_cstr(str_tmp));
+        }
+    } else if(cmd == CliAudioCommandStop) {
+        audio_stop(audio);
+    }
+
+    furi_record_close(RECORD_AUDIO);
+    furi_record_close(RECORD_STORAGE);
+    furi_string_free(str_tmp);
+}

--- a/applications/services/cli/cli_command_audio.c
+++ b/applications/services/cli/cli_command_audio.c
@@ -49,6 +49,8 @@ void cli_command_audio(Cli* cli, FuriString* args, void* context) {
     } while(false);
 
     if(!parsed) {
+        furi_string_free(str_tmp);
+        furi_record_close(RECORD_STORAGE);
         return;
     }
 

--- a/applications/services/cli/cli_command_audio.h
+++ b/applications/services/cli/cli_command_audio.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "cli_i.h"
+
+void cli_command_audio(Cli* cli, FuriString* args, void* context);

--- a/applications/services/cli/cli_commands_u5.c
+++ b/applications/services/cli/cli_commands_u5.c
@@ -3,6 +3,7 @@
 #include "cli_command_display.h"
 #include "cli_command_status_lights.h"
 #include "cli_command_light_sensor.h"
+#include "cli_command_audio.h"
 
 #include <core/thread.h>
 #include <core/thread_list.h>
@@ -531,4 +532,5 @@ void cli_commands_init(Cli* cli) {
         cli, "status_lights", CliCommandFlagParallelSafe, cli_command_status_lights, NULL);
     cli_add_command(
         cli, "light_sensor", CliCommandFlagParallelSafe, cli_command_light_sensor, NULL);
+    cli_add_command(cli, "audio", CliCommandFlagParallelSafe, cli_command_audio, NULL);
 }

--- a/scripts/audio.py
+++ b/scripts/audio.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
 # How to use:
-# audio.py convert click_1.wav click_1.inc
+# audio.py convert input.mp3 output.wav
 
 from flipper.app import App
 import subprocess
-import array
 
 
 class Main(App):
     def init(self):
         self.subparsers = self.parser.add_subparsers(help="sub-command help")
         self.parser_convert = self.subparsers.add_parser(
-            "convert", help="Process icons and build icon registry"
+            "convert", help="Convert audio file using FFmpeg"
         )
         self.parser_convert.add_argument("source", help="Source file")
         self.parser_convert.add_argument("destination", help="Destination file")
@@ -32,15 +31,10 @@ class Main(App):
             "1",
             "-ar",
             "44100",
-            "-",  # stdout
+            self.args.destination,
         )
-        print(" ".join(ffmpeg))
-        with open(self.args.destination, "w") as file_output:
-            with subprocess.Popen(ffmpeg, stdout=subprocess.PIPE) as proc:
-                while data := proc.stdout.read(4096):
-                    data_input = array.array("h", data)
-                    data_block = ", ".join(str(i) for i in data_input)
-                    file_output.write(data_block + ",\n")
+        print("Running command:", " ".join(ffmpeg))
+        subprocess.run(ffmpeg, check=True)
         return 0
 
 


### PR DESCRIPTION
1. Add audio_stop API in audio service
2. Change scripts/audio.py converter to convert ready to use raw samples files
3. Add `audio start <path>` and `audio stop` CLI commands

To test:
1.  Convert .wav file using scripts/audio.py script: .`/scripts/audio.py convert <input.wav> <output>`
2. Send resulting file on storage: `./scripts/storage.py send <file> </ext/file_path>`
3. Connect to CLI via telnet and run audio commands