### PR TITLE
[FW-117] USB network settings. Change default IP adress to 10.0.4.20

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,6 @@
 [submodule "lib/matter_ext"]
 	path = lib/matter_ext
 	url = https://github.com/flipperdevices/silabs_matter_extension.git
+[submodule "lib/cjson"]
+	path = lib/cjson
+	url = https://github.com/DaveGamble/cJSON.git

--- a/applications/services/usb_network/usb_descriptors.c
+++ b/applications/services/usb_network/usb_descriptors.c
@@ -252,17 +252,19 @@ bool tud_vendor_control_xfer_cb(
         case UsbVendorReqWebUsb:
 
             // Get landing page url
-            const char* webusb_url_str = usb_network_settings_get_webusb_url();
+            const char* hostname = usb_network_settings_get_hostname();
+            const char* zone = ".local";
 
             size_t webusb_url_desc_size =
-                sizeof(tusb_desc_webusb_url_t) + strlen(webusb_url_str) + 1;
+                sizeof(tusb_desc_webusb_url_t) + strlen(hostname) + strlen(zone) + 1;
             tusb_desc_webusb_url_t* webusb_url = alloca(webusb_url_desc_size);
             memset(webusb_url, 0, webusb_url_desc_size);
 
-            webusb_url->bLength = 3 + strlen(webusb_url_str);
+            webusb_url->bLength = 3 + strlen(hostname) + strlen(zone);
             webusb_url->bDescriptorType = 3; // WEBUSB URL type
             webusb_url->bScheme = 0; // 0: http, 1: https
-            strcpy(webusb_url->url, webusb_url_str);
+            strcpy(webusb_url->url, hostname);
+            strcat(webusb_url->url, zone);
 
             return tud_control_xfer(
                 rhport, request, (void*)(uintptr_t)webusb_url, webusb_url->bLength);

--- a/applications/services/usb_network/usb_descriptors.c
+++ b/applications/services/usb_network/usb_descriptors.c
@@ -2,7 +2,7 @@
 #include <tusb.h>
 #include <class/net/net_device.h>
 #include <class/net/ncm.h>
-#include "usb_i.h"
+#include "usb_network_settings.h"
 
 #define VERSION_BCD(maj, min, rev) (((maj & 0xFF) << 8) | ((min & 0x0F) << 4) | (rev & 0x0F))
 
@@ -139,7 +139,7 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
         break;
 
     case UsbStrNcmMac:
-        const uint8_t* ncm_mac = usb_network_get_mac_address();
+        const uint8_t* ncm_mac = usb_network_settings_get_mac_address();
         for(uint8_t i = 0; i < 6; i++) {
             desc_string_temp[i * 2 + 1] = "0123456789ABCDEF"[(ncm_mac[i] >> 4) & 0xf];
             desc_string_temp[i * 2 + 2] = "0123456789ABCDEF"[(ncm_mac[i] >> 0) & 0xf];
@@ -237,13 +237,6 @@ static uint8_t const desc_ms_os_20[] = {
     /* clang-format on */
 };
 
-static const tusb_desc_webusb_url_t desc_webusb_url = {
-    .bLength = 3 + sizeof(WEBUSB_URL) - 1,
-    .bDescriptorType = 3, // WEBUSB URL type
-    .bScheme = 0, // 0: http, 1: https
-    .url = WEBUSB_URL,
-};
-
 bool tud_vendor_control_xfer_cb(
     uint8_t rhport,
     uint8_t stage,
@@ -257,9 +250,22 @@ bool tud_vendor_control_xfer_cb(
     case TUSB_REQ_TYPE_VENDOR:
         switch(request->bRequest) {
         case UsbVendorReqWebUsb:
+
             // Get landing page url
+            const char* webusb_url_str = usb_network_settings_get_webusb_url();
+
+            size_t webusb_url_desc_size =
+                sizeof(tusb_desc_webusb_url_t) + strlen(webusb_url_str) + 1;
+            tusb_desc_webusb_url_t* webusb_url = alloca(webusb_url_desc_size);
+            memset(webusb_url, 0, webusb_url_desc_size);
+
+            webusb_url->bLength = 3 + strlen(webusb_url_str);
+            webusb_url->bDescriptorType = 3; // WEBUSB URL type
+            webusb_url->bScheme = 0; // 0: http, 1: https
+            strcpy(webusb_url->url, webusb_url_str);
+
             return tud_control_xfer(
-                rhport, request, (void*)(uintptr_t)&desc_webusb_url, desc_webusb_url.bLength);
+                rhport, request, (void*)(uintptr_t)webusb_url, webusb_url->bLength);
 
         case UsbVendorReqMsos20:
             if(request->wIndex == 7) {

--- a/applications/services/usb_network/usb_i.h
+++ b/applications/services/usb_network/usb_i.h
@@ -1,11 +1,12 @@
 #pragma once
+#include <stdint.h>
 
-// TODO: furi_hal_version
-#define USB_NETWORK_MAC      {0x0C, 0xFA, 0x22, 0x01, 0x23, 0x45}
-#define USB_NETWORK_IP       LWIP_MAKEU32(10, 12, 34, 1)
-#define USB_NETWORK_HOSTNAME "busybar"
-#define WEBUSB_URL           USB_NETWORK_HOSTNAME ".local"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 void usb_network_init(void);
 
-const uint8_t* usb_network_get_mac_address(void);
+#ifdef __cplusplus
+}
+#endif

--- a/applications/services/usb_network/usb_network.c
+++ b/applications/services/usb_network/usb_network.c
@@ -9,14 +9,13 @@
 #include <tusb.h>
 #include "usb_i.h"
 #include "usb_network.h"
+#include "usb_network_settings.h"
 
 #define TAG "USB NET"
 
 #define USB_NET_IPERF
 #define DHCP_ENTRIES_MAX   3
 #define DHCP_LEASE_DEFAULT (24 * 60 * 60)
-
-#define INIT_IP4(a, b, c, d) {PP_HTONL(LWIP_MAKEU32(a, b, c, d))}
 
 struct UsbNetwork {
     struct netif netif_data;
@@ -27,14 +26,6 @@ struct UsbNetwork {
 };
 
 static UsbNetwork* usb_network = NULL;
-
-static const ip4_addr_t ipaddr = {PP_HTONL(USB_NETWORK_IP)};
-static const ip4_addr_t netmask = INIT_IP4(255, 0, 0, 0);
-static const ip4_addr_t gateway = INIT_IP4(0, 0, 0, 0);
-
-const uint8_t* usb_network_get_mac_address(void) {
-    return (const uint8_t[6])USB_NETWORK_MAC;
-}
 
 static err_t linkoutput_fn(struct netif* netif, struct pbuf* p) {
     (void)netif;
@@ -151,11 +142,20 @@ static void usb_network_init_netif(void* arg) {
     usb_network->netif = &(usb_network->netif_data);
 
     usb_network->netif_data.hwaddr_len = 6;
-    memcpy(usb_network->netif_data.hwaddr, usb_network_get_mac_address(), 6);
+    memcpy(usb_network->netif_data.hwaddr, usb_network_settings_get_mac_address(), 6);
     usb_network->netif_data.hwaddr[5] ^= 0x01;
 
+    UsbNetworkAddress address = usb_network_settings_get_address();
+
+    const ip4_addr_t ip = {
+        PP_HTONL(LWIP_MAKEU32(address.ip.a, address.ip.b, address.ip.c, address.ip.d))};
+    const ip4_addr_t gateway = {PP_HTONL(
+        LWIP_MAKEU32(address.gateway.a, address.gateway.b, address.gateway.c, address.gateway.d))};
+    const ip4_addr_t netmask = {PP_HTONL(
+        LWIP_MAKEU32(address.netmask.a, address.netmask.b, address.netmask.c, address.netmask.d))};
+
     usb_network->netif = netif_add(
-        &(usb_network->netif_data), &ipaddr, &netmask, &gateway, NULL, netif_init_cb, tcpip_input);
+        &(usb_network->netif_data), &ip, &netmask, &gateway, NULL, netif_init_cb, tcpip_input);
 #if LWIP_IPV6
     netif_create_ip6_linklocal_address(usb_network->netif, 1);
 #endif
@@ -165,13 +165,22 @@ static void usb_network_init_netif(void* arg) {
         ;
 
     // Prepare DHCP configuration
+    uint8_t counter = 0;
     for(uint8_t i = 0; i < DHCP_ENTRIES_MAX; i++) {
-        usb_network->dhcp_entries[i].addr.addr = PP_HTONL(USB_NETWORK_IP + i + 1);
+        // check for collision with our own address
+        if(counter == address.ip.d) {
+            counter++;
+        }
+
+        usb_network->dhcp_entries[i].addr.addr =
+            PP_HTONL(LWIP_MAKEU32(address.ip.a, address.ip.b, address.ip.c, counter));
         usb_network->dhcp_entries[i].lease = DHCP_LEASE_DEFAULT;
+        counter++;
     }
+
     usb_network->dhcp_config.router.addr = PP_HTONL(LWIP_MAKEU32(0, 0, 0, 0));
     usb_network->dhcp_config.port = 67;
-    usb_network->dhcp_config.dns.addr = 0; //PP_HTONL(USB_NETWORK_IP);
+    usb_network->dhcp_config.dns.addr = 0;
     usb_network->dhcp_config.domain = "usb";
     usb_network->dhcp_config.num_entry = DHCP_ENTRIES_MAX;
     usb_network->dhcp_config.entries = usb_network->dhcp_entries;
@@ -180,7 +189,7 @@ static void usb_network_init_netif(void* arg) {
         ;
 
     mdns_resp_init();
-    mdns_resp_add_netif(netif_default, USB_NETWORK_HOSTNAME);
+    mdns_resp_add_netif(netif_default, usb_network_settings_get_hostname());
     mdns_resp_add_service(
         netif_default, "httpd", "_http", DNSSD_PROTO_TCP, 80, mdns_srv_txt, NULL);
     mdns_resp_announce(netif_default);
@@ -201,6 +210,8 @@ void usb_network_thread_cleanup(UsbNetwork* usb_network) {
 }
 
 void usb_network_init(void) {
+    usb_network_settings_init();
+
     FuriSemaphore* lwip_start_sem = furi_semaphore_alloc(1, 0);
     tcpip_init(usb_network_lwip_start_callback, lwip_start_sem);
     furi_check(furi_semaphore_acquire(lwip_start_sem, FuriWaitForever) == FuriStatusOk);

--- a/applications/services/usb_network/usb_network.c
+++ b/applications/services/usb_network/usb_network.c
@@ -165,10 +165,10 @@ static void usb_network_init_netif(void* arg) {
         ;
 
     // Prepare DHCP configuration
-    uint8_t counter = 0;
+    uint8_t counter = address.ip.d;
     for(uint8_t i = 0; i < DHCP_ENTRIES_MAX; i++) {
         // check for collision with our own address
-        if(counter == address.ip.d) {
+        if(counter == address.ip.d || counter == 0) {
             counter++;
         }
 

--- a/applications/services/usb_network/usb_network_settings.c
+++ b/applications/services/usb_network/usb_network_settings.c
@@ -1,11 +1,17 @@
 #include <stdint.h>
 #include <furi.h>
 #include "usb_network_settings.h"
+#include <storage/storage.h>
+#include <cjson/cJSON.h>
 
 // TODO: furi_hal_version
 #define DEFAULT_MAC         {0x0C, 0xFA, 0x22, 0x01, 0x23, 0x45}
 #define DEFAULT_HOSTNAME    "busybar"
 #define DEFAULT_WEBUSB_ZONE ".local"
+
+#define SETTINGS_FILE "/ext/data/settings/usb_network_settings.json"
+
+#define TAG "USB NET"
 
 static FuriString* hostname = NULL;
 static FuriString* webusb_url = NULL;
@@ -13,7 +19,7 @@ static FuriString* webusb_url = NULL;
 static UsbNetworkAddress address = {
     .ip = {10, 12, 34, 1},
     .netmask = {255, 255, 255, 0},
-    .gateway = {10, 12, 34, 1},
+    .gateway = {0, 0, 0, 0},
 };
 
 static uint8_t mac_address[6] = DEFAULT_MAC;
@@ -36,7 +42,92 @@ const char* usb_network_settings_get_webusb_url(void) {
     return furi_string_get_cstr(webusb_url);
 }
 
+static bool furi_string_from_cjson(FuriString* str, cJSON* root, const char* key) {
+    cJSON* item = cJSON_GetObjectItem(root, key);
+
+    if(item) {
+        furi_string_set(str, item->valuestring);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+static bool usb_network_ip_from_cjson(UsbNetworkIp* ip, cJSON* root, const char* key) {
+    cJSON* item = cJSON_GetObjectItem(root, key);
+
+    if(item) {
+        unsigned int ip_arr[4];
+        size_t items = sscanf(
+            item->valuestring, "%u.%u.%u.%u", &ip_arr[0], &ip_arr[1], &ip_arr[2], &ip_arr[3]);
+        if(items == 4 && ip_arr[0] < 256 && ip_arr[1] < 256 && ip_arr[2] < 256 &&
+           ip_arr[3] < 256) {
+            *ip = (UsbNetworkIp){ip_arr[0], ip_arr[1], ip_arr[2], ip_arr[3]};
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool usb_settings_load(Storage* storage) {
+    bool result = false;
+    File* file = storage_file_alloc(storage);
+
+    do {
+        if(!storage_file_open(file, SETTINGS_FILE, FSAM_READ, FSOM_OPEN_EXISTING)) {
+            break;
+        }
+
+        size_t file_size = storage_file_size(file);
+        if(file_size == 0) {
+            break;
+        }
+
+        char* buffer = malloc(file_size + 1);
+        if(!buffer) {
+            break;
+        }
+
+        if(storage_file_read(file, buffer, file_size) != file_size) {
+            break;
+        }
+
+        buffer[file_size] = '\0';
+
+        result = true;
+
+        cJSON* root = cJSON_Parse(buffer);
+        if(root) {
+            furi_string_from_cjson(hostname, root, "hostname");
+            furi_string_from_cjson(webusb_url, root, "webusb_url");
+            usb_network_ip_from_cjson(&address.ip, root, "ip");
+            usb_network_ip_from_cjson(&address.netmask, root, "netmask");
+        }
+        cJSON_Delete(root);
+
+    } while(false);
+
+    storage_file_free(file);
+    return result;
+}
+
 void usb_network_settings_init(void) {
     hostname = furi_string_alloc_set(DEFAULT_HOSTNAME);
     webusb_url = furi_string_alloc_set(DEFAULT_HOSTNAME DEFAULT_WEBUSB_ZONE);
+
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    usb_settings_load(storage);
+    furi_record_close(RECORD_STORAGE);
+
+    FURI_LOG_D(TAG, "Hostname: %s", furi_string_get_cstr(hostname));
+    FURI_LOG_D(TAG, "WebUSB URL: %s", furi_string_get_cstr(webusb_url));
+    FURI_LOG_D(TAG, "IP: %d.%d.%d.%d", address.ip.a, address.ip.b, address.ip.c, address.ip.d);
+    FURI_LOG_D(
+        TAG,
+        "Netmask: %d.%d.%d.%d",
+        address.netmask.a,
+        address.netmask.b,
+        address.netmask.c,
+        address.netmask.d);
 }

--- a/applications/services/usb_network/usb_network_settings.c
+++ b/applications/services/usb_network/usb_network_settings.c
@@ -1,0 +1,42 @@
+#include <stdint.h>
+#include <furi.h>
+#include "usb_network_settings.h"
+
+// TODO: furi_hal_version
+#define DEFAULT_MAC         {0x0C, 0xFA, 0x22, 0x01, 0x23, 0x45}
+#define DEFAULT_HOSTNAME    "busybar"
+#define DEFAULT_WEBUSB_ZONE ".local"
+
+static FuriString* hostname = NULL;
+static FuriString* webusb_url = NULL;
+
+static UsbNetworkAddress address = {
+    .ip = {10, 12, 34, 1},
+    .netmask = {255, 255, 255, 0},
+    .gateway = {10, 12, 34, 1},
+};
+
+static uint8_t mac_address[6] = DEFAULT_MAC;
+
+UsbNetworkAddress usb_network_settings_get_address(void) {
+    return address;
+}
+
+const uint8_t* usb_network_settings_get_mac_address(void) {
+    return mac_address;
+}
+
+const char* usb_network_settings_get_hostname(void) {
+    furi_check(hostname);
+    return furi_string_get_cstr(hostname);
+}
+
+const char* usb_network_settings_get_webusb_url(void) {
+    furi_check(webusb_url);
+    return furi_string_get_cstr(webusb_url);
+}
+
+void usb_network_settings_init(void) {
+    hostname = furi_string_alloc_set(DEFAULT_HOSTNAME);
+    webusb_url = furi_string_alloc_set(DEFAULT_HOSTNAME DEFAULT_WEBUSB_ZONE);
+}

--- a/applications/services/usb_network/usb_network_settings.c
+++ b/applications/services/usb_network/usb_network_settings.c
@@ -17,7 +17,7 @@ static FuriString* hostname = NULL;
 static FuriString* webusb_url = NULL;
 
 static UsbNetworkAddress address = {
-    .ip = {10, 12, 34, 1},
+    .ip = {10, 0, 4, 20},
     .netmask = {255, 255, 255, 0},
     .gateway = {0, 0, 0, 0},
 };

--- a/applications/services/usb_network/usb_network_settings.c
+++ b/applications/services/usb_network/usb_network_settings.c
@@ -14,7 +14,6 @@
 #define TAG "USB NET"
 
 static FuriString* hostname = NULL;
-static FuriString* webusb_url = NULL;
 
 static UsbNetworkAddress address = {
     .ip = {10, 0, 4, 20},
@@ -35,11 +34,6 @@ const uint8_t* usb_network_settings_get_mac_address(void) {
 const char* usb_network_settings_get_hostname(void) {
     furi_check(hostname);
     return furi_string_get_cstr(hostname);
-}
-
-const char* usb_network_settings_get_webusb_url(void) {
-    furi_check(webusb_url);
-    return furi_string_get_cstr(webusb_url);
 }
 
 static bool furi_string_from_cjson(FuriString* str, cJSON* root, const char* key) {
@@ -100,7 +94,6 @@ static bool usb_settings_load(Storage* storage) {
         cJSON* root = cJSON_Parse(buffer);
         if(root) {
             furi_string_from_cjson(hostname, root, "hostname");
-            furi_string_from_cjson(webusb_url, root, "webusb_url");
             usb_network_ip_from_cjson(&address.ip, root, "ip");
             usb_network_ip_from_cjson(&address.netmask, root, "netmask");
         }
@@ -114,14 +107,12 @@ static bool usb_settings_load(Storage* storage) {
 
 void usb_network_settings_init(void) {
     hostname = furi_string_alloc_set(DEFAULT_HOSTNAME);
-    webusb_url = furi_string_alloc_set(DEFAULT_HOSTNAME DEFAULT_WEBUSB_ZONE);
 
     Storage* storage = furi_record_open(RECORD_STORAGE);
     usb_settings_load(storage);
     furi_record_close(RECORD_STORAGE);
 
     FURI_LOG_D(TAG, "Hostname: %s", furi_string_get_cstr(hostname));
-    FURI_LOG_D(TAG, "WebUSB URL: %s", furi_string_get_cstr(webusb_url));
     FURI_LOG_D(TAG, "IP: %d.%d.%d.%d", address.ip.a, address.ip.b, address.ip.c, address.ip.d);
     FURI_LOG_D(
         TAG,

--- a/applications/services/usb_network/usb_network_settings.h
+++ b/applications/services/usb_network/usb_network_settings.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint8_t a;
+    uint8_t b;
+    uint8_t c;
+    uint8_t d;
+} UsbNetworkIp;
+
+typedef struct {
+    UsbNetworkIp ip;
+    UsbNetworkIp netmask;
+    UsbNetworkIp gateway;
+} UsbNetworkAddress;
+
+void usb_network_settings_init(void);
+
+UsbNetworkAddress usb_network_settings_get_address(void);
+
+const uint8_t* usb_network_settings_get_mac_address(void);
+
+const char* usb_network_settings_get_hostname(void);
+
+const char* usb_network_settings_get_webusb_url(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications/services/usb_network/usb_network_settings.h
+++ b/applications/services/usb_network/usb_network_settings.h
@@ -27,8 +27,6 @@ const uint8_t* usb_network_settings_get_mac_address(void);
 
 const char* usb_network_settings_get_hostname(void);
 
-const char* usb_network_settings_get_webusb_url(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/lib/cjson.scons
+++ b/lib/cjson.scons
@@ -1,0 +1,16 @@
+Import("env")
+
+env.Append(
+    CPPPATH=[
+        "#/lib/lwip/cjson",
+    ],
+)
+
+libenv = env.Clone(FW_LIB_NAME="cjson")
+libenv.ApplyLibFlags()
+
+sources = libenv.Glob("cjson/cJSON.c", source=True)
+
+lib = libenv.StaticLibrary("${FW_LIB_NAME}", sources)
+libenv.Install("${LIB_DIST_DIR}", lib)
+Return("lib")

--- a/lib/register_bsb_common_libs.scons
+++ b/lib/register_bsb_common_libs.scons
@@ -7,6 +7,7 @@ for libname in [
     "nema_gfx",
     "canvas_oled",
     "lwip",
+    "cjson",
     "lvgl",
     "lvgl_addons",
     "network",

--- a/scripts/storage.py
+++ b/scripts/storage.py
@@ -83,7 +83,7 @@ class Main(App):
         self.parser_stress.set_defaults(func=self.stress)
 
     def _get_port(self):
-        return ("10.12.34.1", 23)
+        return ("10.0.4.20", 23)
 
     @WrapStorageOp
     def mkdir(self):

--- a/scripts/storage.py
+++ b/scripts/storage.py
@@ -83,6 +83,8 @@ class Main(App):
         self.parser_stress.set_defaults(func=self.stress)
 
     def _get_port(self):
+        if self.args.port != "auto":
+            return (self.args.port, 23)
         return ("10.0.4.20", 23)
 
     @WrapStorageOp

--- a/targets/f20/target.json
+++ b/targets/f20/target.json
@@ -102,6 +102,7 @@
         "print",
         "fatfs",
         "lwip",
+        "cjson",
         "lvgl",
         "lvgl_addons",
         "network",


### PR DESCRIPTION
# !!Warning!!
**Default IP has been changed to 10.0.4.20**

## Simple usb network settings.

How to test:

[usb_network_settings.json](https://github.com/user-attachments/files/19323583/usb_network_settings.json)

(Any of the fields in the JSON file can be omitted. The default value will be used.)

```
. ./scripts/toolchain/fbtenv.sh                                                       
./scripts/storage.py send usb_network_settings.json /ext/data/settings/usb_network_settings.json
```

Reboot device. Check the logs to see if the settings have been updated.

```
161 [D][USB NET] Hostname: busybar2
165 [D][USB NET] IP: 10.0.13.37
167 [D][USB NET] Netmask: 255.255.254.0
```

