### PR TITLE
[FL-123] Cli socket: Fix sync rx call

### DIFF
--- a/applications/services/cli_socket/cli_socket.c
+++ b/applications/services/cli_socket/cli_socket.c
@@ -127,16 +127,19 @@ size_t cli_socket_rx(uint8_t* buffer, size_t size, uint32_t timeout) {
     }
 
     size_t received = 0;
-    while(received < size) {
-        int32_t ret = recv(cli_socket.client_socket, buffer + received, size - received, 0);
+    if(poll_ret > 0) {
+        while(received < size) {
+            // TODO exit if timeout
+            int32_t ret = recv(cli_socket.client_socket, buffer + received, size - received, 0);
 
-        if(ret < 0) {
-            CLI_SOCKET_DEBUG("disconnected while reading, errno: %d", errno);
-            furi_event_flag_set(cli_socket.evt_flags, FLAG_DISCONNECT);
-            return received;
+            if(ret < 0) {
+                CLI_SOCKET_DEBUG("disconnected while reading, errno: %d", errno);
+                furi_event_flag_set(cli_socket.evt_flags, FLAG_DISCONNECT);
+                return received;
+            }
+
+            received += ret;
         }
-
-        received += ret;
     }
 
     return received;


### PR DESCRIPTION
## What's new

Read socket only if there is data to read

## How to test

1. Cli `log` command works as expected
2. Cli `input dump` command works as expected