### PR TITLE
[FW-126] Fix display CLI command

### DIFF
--- a/applications/services/cli/cli_command_display.c
+++ b/applications/services/cli/cli_command_display.c
@@ -53,6 +53,7 @@ static void cli_command_show(Cli* cli, FuriString* args, GuiDisplayId id) {
     gui_lvgl_release(gui);
 
     while(!cli_cmd_interrupt_received(cli)) {
+        furi_delay_ms(50);
     };
 
     gui_lvgl_acquire(gui);


### PR DESCRIPTION
# What's new

- Use a delay to prevent the CLI from hogging the CPU

# How to test

1. Upload an image to the MMC
2. Show it on any of the displays: `display front show /ext/image.png`

The image should be shown.