### PR TITLE
[FL-134] Show apps menu on startup, more activity on back display

### DIFF
--- a/applications/main/dummy/dummy.c
+++ b/applications/main/dummy/dummy.c
@@ -14,7 +14,7 @@ typedef struct {
     FuriEventLoop* event_loop;
     Audio* audio;
     Gui* gui;
-    Label* label;
+    Label* labels[GuiDisplayIdMax];
     bool exit_on_back;
 } Dummy;
 
@@ -65,12 +65,17 @@ static Dummy* dummy_alloc(const char* message) {
         GuiLayer* main_layer = gui_get_layer(instance->gui, GuiLayerIdMain);
         gui_layer_add_input_callback(main_layer, dummy_input_callback, instance);
 
-        Widget* root = gui_layer_get_root_widget(main_layer, GuiDisplayIdFront);
-        instance->label = label_alloc(root);
+        Widget* root;
 
-        label_set_text(instance->label, message ? message : "Hello There");
+        for(GuiDisplayId id = 0; id < GuiDisplayIdMax; ++id) {
+            root = gui_layer_get_root_widget(main_layer, id);
 
-        widget_set_align(label_get_base(instance->label), AlignCenter);
+            Label* label = label_alloc(root);
+            label_set_text(label, message ? message : "Hello There");
+            widget_set_align(label_get_base(label), AlignCenter);
+
+            instance->labels[id] = label;
+        }
 
         if(message == NULL) {
             instance->exit_on_back = true;
@@ -84,7 +89,9 @@ static void dummy_free(Dummy* instance) {
     with_gui(instance->gui, {
         GuiLayer* main_layer = gui_get_layer(instance->gui, GuiLayerIdMain);
         gui_layer_remove_input_callback(main_layer, dummy_input_callback);
-        label_free(instance->label);
+        for(GuiDisplayId id = 0; id < GuiDisplayIdMax; ++id) {
+            label_free(instance->labels[id]);
+        }
     });
 
     furi_record_close(RECORD_GUI);

--- a/applications/services/desktop/desktop.c
+++ b/applications/services/desktop/desktop.c
@@ -315,7 +315,7 @@ static Desktop* desktop_alloc(void) {
     instance->overlay = desktop_overlay_alloc(gui);
 
     instance->current_request = desktop_start_request_alloc();
-    desktop_start_request_set_name(instance->current_request, "apps_menu");
+    instance->switch_pos = InputSwitchPositionApps;
 
     furi_event_loop_subscribe_message_queue(
         instance->event_loop,
@@ -343,6 +343,11 @@ static Desktop* desktop_alloc(void) {
 
     FuriPubSub* input_events = furi_record_open(RECORD_INPUT_EVENTS);
     furi_pubsub_subscribe(input_events, desktop_input_pubsub_callback, instance);
+
+    desktop_prepare_default_app(instance);
+    if(!loader_is_locked(instance->loader)) {
+        desktop_start_current_app(instance);
+    }
 
     furi_record_create(RECORD_DESKTOP, instance);
     return instance;

--- a/applications/services/input/input_f64.c
+++ b/applications/services/input/input_f64.c
@@ -9,8 +9,8 @@
 
 #define TAG "Input"
 
-#define INPUT_DEBOUNCE_TIMEOUT 1
-#define INPUT_DEBOUNCE_TICKS   4
+#define INPUT_DEBOUNCE_TIMEOUT 2
+#define INPUT_DEBOUNCE_TICKS   10
 #define INPUT_QUEUE_SIZE       15
 
 #ifdef INPUT_DEBUG

--- a/applications/system/apps_menu/apps_menu.c
+++ b/applications/system/apps_menu/apps_menu.c
@@ -17,7 +17,7 @@ typedef struct {
     FuriMessageQueue* queue;
     Desktop* desktop;
     Gui* gui;
-    Submenu* submenu;
+    Submenu* submenus[GuiDisplayIdMax];
 } AppsMenu;
 
 static void apps_menu_submenu_item_callback(uint32_t index, void* context) {
@@ -66,27 +66,50 @@ static AppsMenu* apps_menu_alloc(void) {
 
     with_gui(instance->gui, {
         GuiLayer* main_layer = gui_get_layer(instance->gui, GuiLayerIdMain);
-        Widget* root = gui_layer_get_root_widget(main_layer, GuiDisplayIdFront);
 
-        instance->submenu = submenu_alloc(root);
+        for(GuiDisplayId id = 0; id < GuiDisplayIdMax; ++id) {
+            Widget* root = gui_layer_get_root_widget(main_layer, id);
 
-        for(uint32_t i = 0; i < FLIPPER_APPS_COUNT; ++i) {
-            const FlipperInternalApplication* app = &FLIPPER_APPS[i];
-            submenu_add_item(
-                instance->submenu, app->name, i, apps_menu_submenu_item_callback, instance);
-        }
+            instance->submenus[id] = submenu_alloc(root);
+
+            for(uint32_t i = 0; i < FLIPPER_APPS_COUNT; ++i) {
+                const FlipperInternalApplication* app = &FLIPPER_APPS[i];
+                if(id == GuiDisplayIdFront) {
+                    submenu_add_item(
+                        instance->submenus[id],
+                        app->name,
+                        i,
+                        apps_menu_submenu_item_callback,
+                        instance);
+                } else {
+                    submenu_add_item(instance->submenus[id], app->name, i, NULL, NULL);
+                }
+            }
 
 #if APPS_MENU_ERROR_TEST
-        submenu_add_item(
-            instance->submenu, "Error Test", UINT32_MAX, apps_menu_submenu_item_callback, instance);
+            if(id == GuiDisplayIdFront) {
+                submenu_add_item(
+                    instance->submenu,
+                    "Error Test",
+                    UINT32_MAX,
+                    apps_menu_submenu_item_callback,
+                    instance);
+            } else {
+                submenu_add_item(instance->submenu, "Error Test", UINT32_MAX, NULL, NULL);
+            }
 #endif
+        }
     });
 
     return instance;
 }
 
 static void apps_menu_free(AppsMenu* instance) {
-    with_gui(instance->gui, { submenu_free(instance->submenu); });
+    with_gui(instance->gui, {
+        for(GuiDisplayId id = 0; id < GuiDisplayIdMax; ++id) {
+            submenu_free(instance->submenus[id]);
+        }
+    });
 
     furi_record_close(RECORD_GUI);
     furi_record_close(RECORD_DESKTOP);


### PR DESCRIPTION
# What's new

- On startup, if `LOADER_AUTOSTART` was not set, show the application menu
- Show more activity on the back display: apps menu or the placeholder string
- Improve input debounce stability

# How to test

1. Flash BOTH Main and Wireless firmware
2. The application menu should be showing upon startup on both displays
3. Setting an autostart app via `LOADER_AUTOSTART` should work as before
4. Encoder navigation should feel more stable with no occasional skips