### PR TITLE
Storage.py: fix variable scope

### DIFF
--- a/scripts/flipper/storage_socket.py
+++ b/scripts/flipper/storage_socket.py
@@ -449,9 +449,9 @@ class FlipperStorageOperations:
         self.logger.debug(
             f"* send_file_to_storage:  {local_file_path}->{flipper_file_path}, {force=}"
         )
+        do_upload = True
         if self.storage.exist_file(flipper_file_path):
-            do_upload = force
-            if not do_upload:
+            if not force:
                 hash_local = self.storage.hash_local(local_file_path)
                 hash_flipper = self.storage.hash_flipper(flipper_file_path)
                 self.logger.debug(f"hash check: local {hash_local}, flipper {hash_flipper}")


### PR DESCRIPTION
# What's new

- Fix error if the file to upload does not exist yet

# How to test

1. Use `storage.py` to upload both existing and non-existent files