### PR TITLE
[FW-47] 917 debug uart testing

### DIFF
--- a/applications/services/cli/cli_commands.c
+++ b/applications/services/cli/cli_commands.c
@@ -282,24 +282,20 @@ static void cli_send_sl_cli_cmd(FuriString* cmd) {
 }
 
 void cli_command_sl_echo(Cli* cli, FuriString* args, void* context) {
-    UNUSED(args);
     UNUSED(context);
+    UNUSED(args);
 
-    printf("Starting echo server on 917...\r\n");
+    const uint32_t baud = 230400UL;
 
-    FuriString* cmd = furi_string_alloc_printf("echo_server\r");
+    printf("Starting 917 echo server on %ld\r\n", baud);
+    FuriString* cmd = furi_string_alloc_printf("echo_server  %ld\r", baud);
     cli_send_sl_cli_cmd(cmd);
 
     FuriHalSerialHandle* serial = furi_hal_serial_control_acquire(FuriHalSerialIdUsart6);
-    furi_hal_serial_init(serial, 230400UL);
+    furi_hal_serial_init(serial, baud);
     furi_hal_serial_clear(serial, FuriHalSerialDirectionTxRx);
 
     while(true) {
-        while(furi_hal_serial_rx_available(serial)) {
-            uint8_t data = furi_hal_serial_rx(serial);
-            cli_putc(cli, data);
-        }
-
         uint8_t ch = cli_getc(cli);
 
         if(ch == CliSymbolAsciiETX) {
@@ -313,10 +309,14 @@ void cli_command_sl_echo(Cli* cli, FuriString* args, void* context) {
         }
 
         furi_delay_ms(10);
+
+        while(furi_hal_serial_rx_available(serial)) {
+            ch = furi_hal_serial_rx(serial);
+            cli_putc(cli, ch);
+        }
     }
 
     furi_hal_serial_control_release(serial);
-
     furi_string_printf(cmd, "%c\r", CliSymbolAsciiETX);
     cli_send_sl_cli_cmd(cmd);
     furi_string_free(cmd);

--- a/applications/services/cli/cli_commands.c
+++ b/applications/services/cli/cli_commands.c
@@ -13,6 +13,7 @@
 #include <time.h>
 #include <loader/loader.h>
 #include <toolbox/args.h>
+#include <intercom/intercom.h>
 
 void cli_command_help(Cli* cli, FuriString* args, void* context) {
     UNUSED(args);
@@ -269,6 +270,56 @@ void cli_command_echo(Cli* cli, FuriString* args, void* context) {
     UNUSED(cli);
     UNUSED(context);
     printf("%s\r\n", furi_string_get_cstr(args));
+}
+
+static void cli_send_sl_cli_cmd(FuriString* cmd) {
+    Intercom* intercom = furi_record_open(RECORD_INTERCOM);
+    size_t sz = furi_string_size(cmd);
+    size_t tx_size =
+        intercom_tx(intercom, IntercomChannelCli, furi_string_get_cstr(cmd), sz, FuriWaitForever);
+    furi_assert(tx_size == sz);
+    furi_record_close(RECORD_INTERCOM);
+}
+
+void cli_command_sl_echo(Cli* cli, FuriString* args, void* context) {
+    UNUSED(args);
+    UNUSED(context);
+
+    printf("Starting echo server on 917...\r\n");
+
+    FuriString* cmd = furi_string_alloc_printf("echo_server\r");
+    cli_send_sl_cli_cmd(cmd);
+
+    FuriHalSerialHandle* serial = furi_hal_serial_control_acquire(FuriHalSerialIdUsart6);
+    furi_hal_serial_init(serial, 230400UL);
+    furi_hal_serial_clear(serial, FuriHalSerialDirectionTxRx);
+
+    while(true) {
+        while(furi_hal_serial_rx_available(serial)) {
+            uint8_t data = furi_hal_serial_rx(serial);
+            cli_putc(cli, data);
+        }
+
+        uint8_t ch = cli_getc(cli);
+
+        if(ch == CliSymbolAsciiETX) {
+            break;
+        } else if(ch == CliSymbolAsciiCR || ch == CliSymbolAsciiLF)
+            continue;
+
+        furi_hal_serial_tx(serial, &ch, 1);
+        if(!furi_hal_serial_tx_wait_complete(serial, 100)) {
+            break;
+        }
+
+        furi_delay_ms(10);
+    }
+
+    furi_hal_serial_control_release(serial);
+
+    furi_string_printf(cmd, "%c\r", CliSymbolAsciiETX);
+    cli_send_sl_cli_cmd(cmd);
+    furi_string_free(cmd);
 }
 
 void cli_commands_init(Cli* cli) {

--- a/applications/services/cli/cli_commands.c
+++ b/applications/services/cli/cli_commands.c
@@ -217,61 +217,6 @@ void cli_command_free(Cli* cli, FuriString* args, void* context) {
     printf("Maximum pool block: %zu\r\n", memmgr_pool_get_max_block());
 }
 
-static void cli_command_sysctl_debug(Cli* cli, FuriString* args, void* context) {
-    UNUSED(context);
-
-    if(furi_string_equal_str(args, "0")) {
-        cli_delete_command(cli, "gpio");
-        printf("Debug disabled.");
-    } else if(furi_string_equal_str(args, "1")) {
-        cli_add_command(cli, "gpio", CliCommandFlagParallelSafe, cli_command_gpio, NULL);
-        printf("Debug enabled.");
-    } else {
-        cli_print_usage("sysctl debug", "<1|0>", furi_string_get_cstr(args));
-    }
-}
-
-static void cli_command_sysctl_print_usage() {
-    printf("Usage:\r\n");
-    printf("sysctl <cmd>\r\n");
-    printf("Cmd list:\r\n");
-    printf("\tdebug - enables or disables some debug commands\r\n");
-}
-
-void cli_command_sysctl(Cli* cli, FuriString* args, void* context) {
-    FuriString* cmd;
-    cmd = furi_string_alloc();
-
-    do {
-        if(!args_read_string_and_trim(args, cmd)) {
-            cli_command_sysctl_print_usage();
-            break;
-        }
-
-        if(furi_string_cmp_str(cmd, "debug") == 0) {
-            cli_command_sysctl_debug(cli, args, context);
-            break;
-        }
-        cli_command_sysctl_print_usage();
-    } while(false);
-
-    furi_string_free(cmd);
-}
-
-void cli_command_free_blocks(Cli* cli, FuriString* args, void* context) {
-    UNUSED(cli);
-    UNUSED(args);
-    UNUSED(context);
-
-    memmgr_heap_printf_free_blocks();
-}
-
-void cli_command_echo(Cli* cli, FuriString* args, void* context) {
-    UNUSED(cli);
-    UNUSED(context);
-    printf("%s\r\n", furi_string_get_cstr(args));
-}
-
 static void cli_send_sl_cli_cmd(FuriString* cmd) {
     Intercom* intercom = furi_record_open(RECORD_INTERCOM);
     size_t sz = furi_string_size(cmd);
@@ -320,6 +265,63 @@ void cli_command_sl_echo(Cli* cli, FuriString* args, void* context) {
     furi_string_printf(cmd, "%c\r", CliSymbolAsciiETX);
     cli_send_sl_cli_cmd(cmd);
     furi_string_free(cmd);
+}
+
+static void cli_command_sysctl_debug(Cli* cli, FuriString* args, void* context) {
+    UNUSED(context);
+
+    if(furi_string_equal_str(args, "0")) {
+        cli_delete_command(cli, "gpio");
+        cli_delete_command(cli, "sl_echo");
+        printf("Debug disabled.");
+    } else if(furi_string_equal_str(args, "1")) {
+        cli_add_command(cli, "gpio", CliCommandFlagParallelSafe, cli_command_gpio, NULL);
+        cli_add_command(cli, "sl_echo", CliCommandFlagParallelSafe, cli_command_sl_echo, NULL);
+        printf("Debug enabled.");
+    } else {
+        cli_print_usage("sysctl debug", "<1|0>", furi_string_get_cstr(args));
+    }
+}
+
+static void cli_command_sysctl_print_usage() {
+    printf("Usage:\r\n");
+    printf("sysctl <cmd>\r\n");
+    printf("Cmd list:\r\n");
+    printf("\tdebug - enables or disables some debug commands\r\n");
+}
+
+void cli_command_sysctl(Cli* cli, FuriString* args, void* context) {
+    FuriString* cmd;
+    cmd = furi_string_alloc();
+
+    do {
+        if(!args_read_string_and_trim(args, cmd)) {
+            cli_command_sysctl_print_usage();
+            break;
+        }
+
+        if(furi_string_cmp_str(cmd, "debug") == 0) {
+            cli_command_sysctl_debug(cli, args, context);
+            break;
+        }
+        cli_command_sysctl_print_usage();
+    } while(false);
+
+    furi_string_free(cmd);
+}
+
+void cli_command_free_blocks(Cli* cli, FuriString* args, void* context) {
+    UNUSED(cli);
+    UNUSED(args);
+    UNUSED(context);
+
+    memmgr_heap_printf_free_blocks();
+}
+
+void cli_command_echo(Cli* cli, FuriString* args, void* context) {
+    UNUSED(cli);
+    UNUSED(context);
+    printf("%s\r\n", furi_string_get_cstr(args));
 }
 
 void cli_commands_init(Cli* cli) {

--- a/applications/services/cli_f64/cli_commands.c
+++ b/applications/services/cli_f64/cli_commands.c
@@ -221,6 +221,56 @@ void cli_command_free_blocks(Cli* cli, FuriString* args, void* context) {
     memmgr_heap_printf_free_blocks();
 }
 
+static void cli_command_echo_server_rx_callback(
+    FuriHalSerialHandle* handle,
+    FuriHalSerialRxEvent event,
+    void* context) {
+    FuriStreamBuffer* stream = context;
+    if(event & (FuriHalSerialRxEventData | FuriHalSerialRxEventIdle)) {
+        while(furi_hal_serial_rx_available(handle)) {
+            uint8_t c = furi_hal_serial_rx(handle);
+            furi_check(furi_stream_buffer_send(stream, &c, sizeof(c), 0) == sizeof(c));
+        }
+    }
+}
+
+void cli_command_echo_server(Cli* cli, FuriString* args, void* context) {
+    UNUSED(args);
+    UNUSED(context);
+
+    FuriStreamBuffer* stream = furi_stream_buffer_alloc(5U, 1);
+
+    FuriHalSerialHandle* serial = furi_hal_serial_control_acquire(FuriHalSerialIdUart1);
+    furi_hal_serial_init(serial, 230400UL);
+
+    furi_hal_serial_set_callback(serial, NULL, cli_command_echo_server_rx_callback, stream);
+    furi_hal_serial_clear(serial, FuriHalSerialDirectionTxRx);
+    furi_hal_serial_async_rx_start(serial, false);
+
+    FURI_LOG_D("Echo", "Echo server started");
+    while(!cli_cmd_interrupt_received(cli)) {
+        if(!furi_stream_buffer_bytes_available(stream)) continue;
+
+        uint8_t ch;
+        if(!furi_stream_buffer_receive(stream, &ch, sizeof(ch), 100)) {
+            FURI_LOG_W("Echo", "Failed to read data from stream");
+            break;
+        }
+        FURI_LOG_D("Echo", "Rx: %c", ch);
+        furi_hal_serial_tx(serial, &ch, sizeof(ch));
+        if(!furi_hal_serial_tx_wait_complete(serial, 100)) {
+            FURI_LOG_W("Echo", "Failed to send data back");
+            break;
+        }
+    }
+
+    furi_hal_serial_async_rx_stop(serial);
+    furi_hal_serial_set_callback(serial, NULL, NULL, NULL);
+    furi_hal_serial_control_release(serial);
+    furi_stream_buffer_free(stream);
+    FURI_LOG_D("Echo", "Echo server stopped");
+}
+
 void cli_commands_init(Cli* cli) {
     cli_add_command(cli, "?", CliCommandFlagParallelSafe, cli_command_help, NULL);
     cli_add_command(cli, "help", CliCommandFlagParallelSafe, cli_command_help, NULL);
@@ -230,4 +280,5 @@ void cli_commands_init(Cli* cli) {
     cli_add_command(cli, "top", CliCommandFlagParallelSafe, cli_command_top, NULL);
     cli_add_command(cli, "free", CliCommandFlagParallelSafe, cli_command_free, NULL);
     cli_add_command(cli, "free_blocks", CliCommandFlagParallelSafe, cli_command_free_blocks, NULL);
+    cli_add_command(cli, "echo_server", CliCommandFlagParallelSafe, cli_command_echo_server, NULL);
 }

--- a/applications/services/cli_f64/cli_commands.c
+++ b/applications/services/cli_f64/cli_commands.c
@@ -5,7 +5,7 @@
 #include <furi_hal.h>
 #include <task_control_block.h>
 #include <time.h>
-#include <args.h>
+#include <toolbox/args.h>
 
 // Close to ISO, `date +'%Y-%m-%d %H:%M:%S %u'`
 #define CLI_DATE_FORMAT "%.4d-%.2d-%.2d %.2d:%.2d:%.2d %d"
@@ -235,31 +235,36 @@ static void cli_command_echo_server_rx_callback(
 }
 
 void cli_command_echo_server(Cli* cli, FuriString* args, void* context) {
-    UNUSED(args);
     UNUSED(context);
+
+    uint32_t baud = 0;
+    if(!args_read_int_and_trim(args, (int*)&baud)) {
+        FURI_LOG_W("EchoSrv", "Unable to parse baud");
+        return;
+    }
 
     FuriStreamBuffer* stream = furi_stream_buffer_alloc(5U, 1);
 
     FuriHalSerialHandle* serial = furi_hal_serial_control_acquire(FuriHalSerialIdUart1);
-    furi_hal_serial_init(serial, 230400UL);
+    furi_hal_serial_init(serial, baud);
 
     furi_hal_serial_set_callback(serial, NULL, cli_command_echo_server_rx_callback, stream);
     furi_hal_serial_clear(serial, FuriHalSerialDirectionTxRx);
     furi_hal_serial_async_rx_start(serial, false);
 
-    FURI_LOG_D("Echo", "Echo server started");
+    FURI_LOG_D("EchoSrv", "Echo server started on baud %ld", baud);
     while(!cli_cmd_interrupt_received(cli)) {
         if(!furi_stream_buffer_bytes_available(stream)) continue;
 
         uint8_t ch;
         if(!furi_stream_buffer_receive(stream, &ch, sizeof(ch), 100)) {
-            FURI_LOG_W("Echo", "Failed to read data from stream");
+            FURI_LOG_W("EchoSrv", "Failed to read data from stream");
             break;
         }
-        FURI_LOG_D("Echo", "Rx: %c", ch);
+        FURI_LOG_D("EchoSrv", "Rx: %c", ch);
         furi_hal_serial_tx(serial, &ch, sizeof(ch));
         if(!furi_hal_serial_tx_wait_complete(serial, 100)) {
-            FURI_LOG_W("Echo", "Failed to send data back");
+            FURI_LOG_W("EchoSrv", "Failed to send data back");
             break;
         }
     }
@@ -268,7 +273,7 @@ void cli_command_echo_server(Cli* cli, FuriString* args, void* context) {
     furi_hal_serial_set_callback(serial, NULL, NULL, NULL);
     furi_hal_serial_control_release(serial);
     furi_stream_buffer_free(stream);
-    FURI_LOG_D("Echo", "Echo server stopped");
+    FURI_LOG_D("EchoSrv", "Echo server stopped");
 }
 
 void cli_commands_init(Cli* cli) {

--- a/targets/f64/furi_hal/furi_hal_serial.c
+++ b/targets/f64/furi_hal/furi_hal_serial.c
@@ -106,6 +106,11 @@ static void furi_hal_serial_enable_fifo(FuriHalSerialHandle* handle) {
     periph->FCR = FCR_RT_ONE_CHAR | FCR_DMAM_SET | FCR_FIFOE_SET;
 }
 
+static void furi_hal_serial_disable_fifo(FuriHalSerialHandle* handle) {
+    USART0_Type* periph = furi_hal_serial_resources[handle->id].periph;
+    periph->FCR_b.FIFOE = 0;
+}
+
 void furi_hal_serial_init(FuriHalSerialHandle* handle, uint32_t baud) {
     furi_check(handle);
 
@@ -205,7 +210,7 @@ void furi_hal_serial_init(FuriHalSerialHandle* handle, uint32_t baud) {
         furi_hal_gpio_enable_ulp_on_hp(&gpio_ulp_i_3, GpioAltFn3ULP_UART_TX);
 
     } else {
-        furi_crash();
+        furi_crash("Invalid serial id");
     }
 
     furi_hal_serial_set_baud_rate(handle, baud);
@@ -216,7 +221,24 @@ void furi_hal_serial_init(FuriHalSerialHandle* handle, uint32_t baud) {
 
 void furi_hal_serial_deinit(FuriHalSerialHandle* handle) {
     furi_check(handle);
-    // TODO: Other deinitialisation
+    furi_hal_serial_disable_fifo(handle);
+
+    if(handle->id == FuriHalSerialIdUsart0) {
+        furi_hal_bus_disable(FuriHalBusUSART1_PCLK);
+        furi_hal_bus_disable(FuriHalBusUSART1_SCLK);
+
+    } else if(handle->id == FuriHalSerialIdUart1) {
+        furi_hal_bus_disable(FuriHalBusUSART2_PCLK);
+        furi_hal_bus_disable(FuriHalBusUSART2_SCLK);
+
+    } else if(handle->id == FuriHalSerialIdUlpuart) {
+        furi_hal_bus_disable(FuriHalBusULPSS_CLK);
+        furi_hal_bus_disable(FuriHalBusUlpSCLK_UART);
+        furi_hal_bus_disable(FuriHalBusUlpPCLK_UART);
+
+    } else {
+        furi_crash("Invalid serial id");
+    }
     furi_hal_serial[handle->id].handle = NULL;
 }
 


### PR DESCRIPTION
U5 side:
- `sl_echo` command added and become available after `sysctl debug 1`

917 side:
- 'echo_server' command added. This is called implicitly from u5 via `IntercomChannelCli` when `sl_echo` is called. Termination is also done implicitly.
- some uart deinit logic added

How to test:

1. Open bsb cli and run `sysctl debug 1`
2. Run `sl_echo`
3. Type anything to cli and press enter. Data will be transmitted from U5 via DBG_UART to 917 and then transmitted back from it and appear in cli