### PR TITLE
[FW-50] device_info cli command

### DIFF
--- a/applications/services/cli/cli_command_sl_cli.c
+++ b/applications/services/cli/cli_command_sl_cli.c
@@ -49,10 +49,10 @@ static void cli_command_sl_cli_send_command(Intercom* intercom, FuriString* cmd)
     furi_assert(tx_size == sz);
 }
 
-void cli_command_sl_cli_send_command_get_response(Cli* cli, const char* command) {
+void cli_command_sl_cli_send_command_get_response(Cli* cli, const char* sl_cmd) {
     CliCommandSlCli* instance = cli_command_sl_cli_alloc();
 
-    FuriString* buf = furi_string_alloc_printf("%s\r", command);
+    FuriString* buf = furi_string_alloc_printf("%s\r", sl_cmd);
     cli_command_sl_cli_send_command(instance->intercom, buf);
 
     while(true) {
@@ -101,5 +101,51 @@ void cli_command_sl_cli(Cli* cli, FuriString* args, void* context) {
         }
     }
 
+    cli_command_sl_cli_free(instance);
+}
+
+void cli_command_sl_echo(Cli* cli, FuriString* args, void* context) {
+    UNUSED(context);
+    UNUSED(args);
+
+    const uint32_t baud = 230400UL;
+
+    printf("Starting 917 echo server on %ld\r\n", baud);
+    FuriString* cmd = furi_string_alloc_printf("echo_server  %ld\r", baud);
+
+    CliCommandSlCli* instance = cli_command_sl_cli_alloc();
+    cli_command_sl_cli_send_command(instance->intercom, cmd);
+
+    FuriHalSerialHandle* serial = furi_hal_serial_control_acquire(FuriHalSerialIdUsart6);
+    furi_hal_serial_init(serial, baud);
+    furi_hal_serial_clear(serial, FuriHalSerialDirectionTxRx);
+
+    while(true) {
+        uint8_t ch = cli_getc(cli);
+
+        if(ch == CliSymbolAsciiETX) {
+            break;
+        } else if(ch == CliSymbolAsciiCR || ch == CliSymbolAsciiLF)
+            continue;
+
+        furi_hal_serial_tx(serial, &ch, 1);
+        if(!furi_hal_serial_tx_wait_complete(serial, 100)) {
+            break;
+        }
+
+        furi_delay_ms(10);
+
+        while(furi_hal_serial_rx_available(serial)) {
+            ch = furi_hal_serial_rx(serial);
+            cli_putc(cli, ch);
+        }
+    }
+
+    furi_hal_serial_control_release(serial);
+
+    furi_string_printf(cmd, "%c\r", CliSymbolAsciiETX);
+    cli_command_sl_cli_send_command(instance->intercom, cmd);
+
+    furi_string_free(cmd);
     cli_command_sl_cli_free(instance);
 }

--- a/applications/services/cli/cli_command_sl_cli.c
+++ b/applications/services/cli/cli_command_sl_cli.c
@@ -42,15 +42,18 @@ static void cli_command_sl_cli_free(CliCommandSlCli* instance) {
     free(instance);
 }
 
+static void cli_command_sl_cli_send_command(Intercom* intercom, FuriString* cmd) {
+    const size_t sz = furi_string_size(cmd);
+    const size_t tx_size =
+        intercom_tx(intercom, IntercomChannelCli, furi_string_get_cstr(cmd), sz, FuriWaitForever);
+    furi_assert(tx_size == sz);
+}
+
 void cli_command_sl_cli_send_command_get_response(Cli* cli, const char* command) {
     CliCommandSlCli* instance = cli_command_sl_cli_alloc();
 
     FuriString* buf = furi_string_alloc_printf("%s\r", command);
-    size_t sz = furi_string_size(buf);
-
-    const size_t tx_size = intercom_tx(
-        instance->intercom, IntercomChannelCli, furi_string_get_cstr(buf), sz, FuriWaitForever);
-    furi_assert(tx_size == sz);
+    cli_command_sl_cli_send_command(instance->intercom, buf);
 
     while(true) {
         const size_t rx_size = furi_stream_buffer_receive(
@@ -59,6 +62,9 @@ void cli_command_sl_cli_send_command_get_response(Cli* cli, const char* command)
         if(!rx_size) break;
         cli_write(cli, instance->rx_data, rx_size);
     }
+
+    furi_string_printf(buf, "%c\r", CliSymbolAsciiETX);
+    cli_command_sl_cli_send_command(instance->intercom, buf);
 
     cli_command_sl_cli_free(instance);
     furi_string_free(buf);

--- a/applications/services/cli/cli_command_sl_cli.c
+++ b/applications/services/cli/cli_command_sl_cli.c
@@ -42,6 +42,28 @@ static void cli_command_sl_cli_free(CliCommandSlCli* instance) {
     free(instance);
 }
 
+void cli_command_sl_cli_send_command_get_response(Cli* cli, const char* command) {
+    CliCommandSlCli* instance = cli_command_sl_cli_alloc();
+
+    FuriString* buf = furi_string_alloc_printf("%s\r", command);
+    size_t sz = furi_string_size(buf);
+
+    const size_t tx_size = intercom_tx(
+        instance->intercom, IntercomChannelCli, furi_string_get_cstr(buf), sz, FuriWaitForever);
+    furi_assert(tx_size == sz);
+
+    while(true) {
+        const size_t rx_size = furi_stream_buffer_receive(
+            instance->rx_buffer, instance->rx_data, sizeof(instance->rx_data), 100);
+
+        if(!rx_size) break;
+        cli_write(cli, instance->rx_data, rx_size);
+    }
+
+    cli_command_sl_cli_free(instance);
+    furi_string_free(buf);
+}
+
 void cli_command_sl_cli(Cli* cli, FuriString* args, void* context) {
     UNUSED(args);
     UNUSED(context);

--- a/applications/services/cli/cli_command_sl_cli.h
+++ b/applications/services/cli/cli_command_sl_cli.h
@@ -2,4 +2,5 @@
 
 #include "cli_i.h"
 
+void cli_command_sl_cli_send_command_get_response(Cli* cli, const char* command);
 void cli_command_sl_cli(Cli* cli, FuriString* args, void* context);

--- a/applications/services/cli/cli_command_sl_cli.h
+++ b/applications/services/cli/cli_command_sl_cli.h
@@ -2,5 +2,12 @@
 
 #include "cli_i.h"
 
-void cli_command_sl_cli_send_command_get_response(Cli* cli, const char* command);
+/** Call sl command by name, print response and terminate sl cli session.
+ *
+ * @param      cli       pointer to cli instance
+ * @param      sl_cmd    sl command name
+ */
+void cli_command_sl_cli_send_command_get_response(Cli* cli, const char* sl_cmd);
+
 void cli_command_sl_cli(Cli* cli, FuriString* args, void* context);
+void cli_command_sl_echo(Cli* cli, FuriString* args, void* context);

--- a/applications/services/cli/cli_commands.c
+++ b/applications/services/cli/cli_commands.c
@@ -219,56 +219,6 @@ void cli_command_free(Cli* cli, FuriString* args, void* context) {
     printf("Maximum pool block: %zu\r\n", memmgr_pool_get_max_block());
 }
 
-static void cli_send_sl_cli_cmd(FuriString* cmd) {
-    Intercom* intercom = furi_record_open(RECORD_INTERCOM);
-    size_t sz = furi_string_size(cmd);
-    size_t tx_size =
-        intercom_tx(intercom, IntercomChannelCli, furi_string_get_cstr(cmd), sz, FuriWaitForever);
-    furi_assert(tx_size == sz);
-    furi_record_close(RECORD_INTERCOM);
-}
-
-void cli_command_sl_echo(Cli* cli, FuriString* args, void* context) {
-    UNUSED(context);
-    UNUSED(args);
-
-    const uint32_t baud = 230400UL;
-
-    printf("Starting 917 echo server on %ld\r\n", baud);
-    FuriString* cmd = furi_string_alloc_printf("echo_server  %ld\r", baud);
-    cli_send_sl_cli_cmd(cmd);
-
-    FuriHalSerialHandle* serial = furi_hal_serial_control_acquire(FuriHalSerialIdUsart6);
-    furi_hal_serial_init(serial, baud);
-    furi_hal_serial_clear(serial, FuriHalSerialDirectionTxRx);
-
-    while(true) {
-        uint8_t ch = cli_getc(cli);
-
-        if(ch == CliSymbolAsciiETX) {
-            break;
-        } else if(ch == CliSymbolAsciiCR || ch == CliSymbolAsciiLF)
-            continue;
-
-        furi_hal_serial_tx(serial, &ch, 1);
-        if(!furi_hal_serial_tx_wait_complete(serial, 100)) {
-            break;
-        }
-
-        furi_delay_ms(10);
-
-        while(furi_hal_serial_rx_available(serial)) {
-            ch = furi_hal_serial_rx(serial);
-            cli_putc(cli, ch);
-        }
-    }
-
-    furi_hal_serial_control_release(serial);
-    furi_string_printf(cmd, "%c\r", CliSymbolAsciiETX);
-    cli_send_sl_cli_cmd(cmd);
-    furi_string_free(cmd);
-}
-
 static void cli_command_sysctl_debug(Cli* cli, FuriString* args, void* context) {
     UNUSED(context);
 

--- a/applications/services/cli/cli_commands.c
+++ b/applications/services/cli/cli_commands.c
@@ -6,6 +6,7 @@
 #include "cli_command_audio.h"
 #include "cli_command_sl_cli.h"
 
+#include <intercom/intercom.h>
 #include <core/thread.h>
 #include <core/thread_list.h>
 #include <furi_hal.h>
@@ -13,6 +14,7 @@
 #include <time.h>
 #include <loader/loader.h>
 #include <toolbox/args.h>
+#include <furi_hal_info.h>
 
 void cli_command_help(Cli* cli, FuriString* args, void* context) {
     UNUSED(args);
@@ -271,14 +273,27 @@ void cli_command_echo(Cli* cli, FuriString* args, void* context) {
     printf("%s\r\n", furi_string_get_cstr(args));
 }
 
-void cli_commands_init(Cli* cli) {
-    //cli_add_command(cli, "!", CliCommandFlagParallelSafe, cli_command_info, (void*)true);
-    //cli_add_command(cli, "info", CliCommandFlagParallelSafe, cli_command_info, NULL);
-    //cli_add_command(cli, "device_info", CliCommandFlagParallelSafe, cli_command_info, (void*)true);
+static void
+    cli_command_device_info_callback(const char* key, const char* value, bool last, void* context) {
+    UNUSED(last);
+    UNUSED(context);
+    printf("%-30s: %s\r\n", key, value);
+}
 
+void cli_command_device_info(Cli* cli, FuriString* args, void* context) {
+    UNUSED(cli);
+    UNUSED(args);
+    UNUSED(context);
+
+    furi_hal_info_get(cli_command_device_info_callback, '_', NULL);
+    cli_command_sl_cli_send_command_get_response(cli, "device_info");
+}
+
+void cli_commands_init(Cli* cli) {
     cli_add_command(cli, "?", CliCommandFlagParallelSafe, cli_command_help, NULL);
     cli_add_command(cli, "help", CliCommandFlagParallelSafe, cli_command_help, NULL);
 
+    cli_add_command(cli, "device_info", CliCommandFlagParallelSafe, cli_command_device_info, NULL);
     cli_add_command(cli, "uptime", CliCommandFlagParallelSafe, cli_command_uptime, NULL);
     cli_add_command(cli, "log", CliCommandFlagParallelSafe, cli_command_log, NULL);
     cli_add_command(cli, "top", CliCommandFlagParallelSafe, cli_command_top, NULL);

--- a/applications/services/cli_f64/cli_commands.c
+++ b/applications/services/cli_f64/cli_commands.c
@@ -3,6 +3,7 @@
 #include <core/thread.h>
 #include <core/thread_list.h>
 #include <furi_hal.h>
+#include <furi_hal_info.h>
 #include <task_control_block.h>
 #include <time.h>
 #include <args.h>
@@ -221,10 +222,25 @@ void cli_command_free_blocks(Cli* cli, FuriString* args, void* context) {
     memmgr_heap_printf_free_blocks();
 }
 
+static void
+    cli_command_device_info_callback(const char* key, const char* value, bool last, void* context) {
+    UNUSED(last);
+    UNUSED(context);
+    printf("%-30s: %s\r\n", key, value);
+}
+
+void cli_command_device_info(Cli* cli, FuriString* args, void* context) {
+    UNUSED(cli);
+    UNUSED(args);
+    UNUSED(context);
+    furi_hal_info_get(cli_command_device_info_callback, '_', NULL);
+}
+
 void cli_commands_init(Cli* cli) {
     cli_add_command(cli, "?", CliCommandFlagParallelSafe, cli_command_help, NULL);
     cli_add_command(cli, "help", CliCommandFlagParallelSafe, cli_command_help, NULL);
 
+    cli_add_command(cli, "device_info", CliCommandFlagParallelSafe, cli_command_device_info, NULL);
     cli_add_command(cli, "uptime", CliCommandFlagParallelSafe, cli_command_uptime, NULL);
     cli_add_command(cli, "log", CliCommandFlagParallelSafe, cli_command_log, NULL);
     cli_add_command(cli, "top", CliCommandFlagParallelSafe, cli_command_top, NULL);

--- a/lib/toolbox_f64/property.c
+++ b/lib/toolbox_f64/property.c
@@ -1,0 +1,33 @@
+#include "property.h"
+
+#include <core/check.h>
+
+void property_value_out(PropertyValueContext* ctx, const char* fmt, unsigned int nparts, ...) {
+    furi_check(ctx);
+    furi_string_reset(ctx->key);
+
+    va_list args;
+    va_start(args, nparts);
+
+    for(size_t i = 0; i < nparts; ++i) {
+        const char* keypart = va_arg(args, const char*);
+        furi_string_cat(ctx->key, keypart);
+        if(i < nparts - 1) {
+            furi_string_push_back(ctx->key, ctx->sep);
+        }
+    }
+
+    const char* value_str;
+
+    if(fmt) {
+        furi_string_vprintf(ctx->value, fmt, args);
+        value_str = furi_string_get_cstr(ctx->value);
+    } else {
+        // C string passthrough (no formatting)
+        value_str = va_arg(args, const char*);
+    }
+
+    va_end(args);
+
+    ctx->out(furi_string_get_cstr(ctx->key), value_str, ctx->last, ctx->context);
+}

--- a/lib/toolbox_f64/property.h
+++ b/lib/toolbox_f64/property.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <core/string.h>
+
+/** Callback type called every time another key-value pair of device information is ready
+ *
+ * @param      key[in]      device information type identifier
+ * @param      value[in]    device information value
+ * @param      last[in]     whether the passed key-value pair is the last one
+ * @param      context[in]  to pass to callback
+ */
+typedef void (*PropertyValueCallback)(const char* key, const char* value, bool last, void* context);
+
+typedef struct {
+    FuriString* key; /**< key string buffer, must be initialised before use */
+    FuriString* value; /**< value string buffer, must be initialised before use */
+    PropertyValueCallback out; /**< output callback function */
+    char sep; /**< separator character between key parts */
+    bool last; /**< flag to indicate last element */
+    void* context; /**< user-defined context, passed through to out callback */
+} PropertyValueContext;
+
+/** Builds key and value strings and outputs them via a callback function
+ *
+ * @param       ctx[in]     local property context
+ * @param       fmt[in]     value format, set to NULL to bypass formatting
+ * @param       nparts[in]  number of key parts (separated by character)
+ * @param       ...[in]     list of key parts followed by value
+ */
+void property_value_out(PropertyValueContext* ctx, const char* fmt, unsigned int nparts, ...);
+
+#ifdef __cplusplus
+}
+#endif

--- a/targets/f20/furi_hal/furi_hal_info.c
+++ b/targets/f20/furi_hal/furi_hal_info.c
@@ -1,0 +1,142 @@
+#include <furi_hal_info.h>
+
+#include <furi_hal_version.h>
+#include <furi.h>
+
+FURI_WEAK void furi_hal_info_get_api_version(uint16_t* major, uint16_t* minor) {
+    *major = 0;
+    *minor = 0;
+}
+
+void furi_hal_info_get(PropertyValueCallback out, char sep, void* context) {
+    UNUSED(out);
+    UNUSED(sep);
+    UNUSED(context);
+
+    FuriString* key = furi_string_alloc();
+    FuriString* value = furi_string_alloc();
+
+    PropertyValueContext property_context = {
+        .key = key, .value = value, .out = out, .sep = sep, .last = false, .context = context};
+
+    // Firmware version
+    const Version* firmware_version = furi_hal_version_get_firmware_version();
+    if(firmware_version) {
+        if(sep == '.') {
+            property_value_out(
+                &property_context,
+                NULL,
+                4,
+                "U5"
+                "firmware",
+                "commit",
+                "hash",
+                version_get_githash(firmware_version));
+        } else {
+            property_value_out(
+                &property_context,
+                NULL,
+                3,
+                "U5",
+                "firmware",
+                "commit",
+                version_get_githash(firmware_version));
+        }
+
+        property_value_out(
+            &property_context,
+            NULL,
+            4,
+            "U5",
+            "firmware",
+            "commit",
+            "dirty",
+            version_get_dirty_flag(firmware_version) ? "true" : "false");
+
+        if(sep == '.') {
+            property_value_out(
+                &property_context,
+                NULL,
+                5,
+                "U5",
+                "firmware",
+                "branch",
+                "name",
+                version_get_gitbranch(firmware_version));
+        } else {
+            property_value_out(
+                &property_context,
+                NULL,
+                3,
+                "U5",
+                "firmware",
+                "branch",
+                version_get_gitbranch(firmware_version));
+        }
+
+        property_value_out(
+            &property_context,
+            NULL,
+            4,
+            "U5",
+            "firmware",
+            "branch",
+            "num",
+            version_get_gitbranchnum(firmware_version));
+        property_value_out(
+            &property_context,
+            NULL,
+            3,
+            "U5",
+            "firmware",
+            "version",
+            version_get_version(firmware_version));
+        property_value_out(
+            &property_context,
+            NULL,
+            4,
+            "U5",
+            "firmware",
+            "build",
+            "date",
+            version_get_builddate(firmware_version));
+        property_value_out(
+            &property_context,
+            "%d",
+            3,
+            "U5",
+            "firmware",
+            "target",
+            version_get_target(firmware_version));
+
+        uint16_t api_version_major, api_version_minor;
+        furi_hal_info_get_api_version(&api_version_major, &api_version_minor);
+        property_value_out(
+            &property_context, "%d", 4, "U5", "firmware", "api", "major", api_version_major);
+        property_value_out(
+            &property_context, "%d", 4, "U5", "firmware", "api", "minor", api_version_minor);
+
+        property_value_out(
+            &property_context,
+            NULL,
+            4,
+            "U5",
+            "firmware",
+            "origin",
+            "fork",
+            version_get_firmware_origin(firmware_version));
+
+        property_value_out(
+            &property_context,
+            NULL,
+            4,
+            "U5",
+            "firmware",
+            "origin",
+            "git",
+            version_get_git_origin(firmware_version));
+    }
+
+    furi_string_free(key);
+    furi_string_free(value);
+}

--- a/targets/f20/furi_hal/furi_hal_info.h
+++ b/targets/f20/furi_hal/furi_hal_info.h
@@ -1,0 +1,29 @@
+/**
+ * @file furi_hal_info.h
+ * Device info HAL API
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <core/string.h>
+#include <toolbox/property.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void furi_hal_info_get_api_version(uint16_t* major, uint16_t* minor);
+
+/** Get device information
+  *
+  * @param[in]  callback     callback to provide with new data
+  * @param[in]  sep          category separator character
+  * @param[in]  context      context to pass to callback
+  */
+void furi_hal_info_get(PropertyValueCallback callback, char sep, void* context);
+
+#ifdef __cplusplus
+}
+#endif

--- a/targets/f64/furi_hal/furi_hal_info.c
+++ b/targets/f64/furi_hal/furi_hal_info.c
@@ -1,0 +1,142 @@
+#include <furi_hal_info.h>
+
+#include <furi_hal_version.h>
+#include <furi.h>
+
+FURI_WEAK void furi_hal_info_get_api_version(uint16_t* major, uint16_t* minor) {
+    *major = 0;
+    *minor = 0;
+}
+
+void furi_hal_info_get(PropertyValueCallback out, char sep, void* context) {
+    UNUSED(out);
+    UNUSED(sep);
+    UNUSED(context);
+
+    FuriString* key = furi_string_alloc();
+    FuriString* value = furi_string_alloc();
+
+    PropertyValueContext property_context = {
+        .key = key, .value = value, .out = out, .sep = sep, .last = false, .context = context};
+
+    // Firmware version
+    const Version* firmware_version = furi_hal_version_get_firmware_version();
+    if(firmware_version) {
+        if(sep == '.') {
+            property_value_out(
+                &property_context,
+                NULL,
+                4,
+                "917"
+                "firmware",
+                "commit",
+                "hash",
+                version_get_githash(firmware_version));
+        } else {
+            property_value_out(
+                &property_context,
+                NULL,
+                3,
+                "917",
+                "firmware",
+                "commit",
+                version_get_githash(firmware_version));
+        }
+
+        property_value_out(
+            &property_context,
+            NULL,
+            4,
+            "917",
+            "firmware",
+            "commit",
+            "dirty",
+            version_get_dirty_flag(firmware_version) ? "true" : "false");
+
+        if(sep == '.') {
+            property_value_out(
+                &property_context,
+                NULL,
+                5,
+                "917",
+                "firmware",
+                "branch",
+                "name",
+                version_get_gitbranch(firmware_version));
+        } else {
+            property_value_out(
+                &property_context,
+                NULL,
+                3,
+                "917",
+                "firmware",
+                "branch",
+                version_get_gitbranch(firmware_version));
+        }
+
+        property_value_out(
+            &property_context,
+            NULL,
+            4,
+            "917",
+            "firmware",
+            "branch",
+            "num",
+            version_get_gitbranchnum(firmware_version));
+        property_value_out(
+            &property_context,
+            NULL,
+            3,
+            "917",
+            "firmware",
+            "version",
+            version_get_version(firmware_version));
+        property_value_out(
+            &property_context,
+            NULL,
+            4,
+            "917",
+            "firmware",
+            "build",
+            "date",
+            version_get_builddate(firmware_version));
+        property_value_out(
+            &property_context,
+            "%d",
+            3,
+            "917",
+            "firmware",
+            "target",
+            version_get_target(firmware_version));
+
+        uint16_t api_version_major, api_version_minor;
+        furi_hal_info_get_api_version(&api_version_major, &api_version_minor);
+        property_value_out(
+            &property_context, "%d", 4, "917", "firmware", "api", "major", api_version_major);
+        property_value_out(
+            &property_context, "%d", 4, "917", "firmware", "api", "minor", api_version_minor);
+
+        property_value_out(
+            &property_context,
+            NULL,
+            4,
+            "917",
+            "firmware",
+            "origin",
+            "fork",
+            version_get_firmware_origin(firmware_version));
+
+        property_value_out(
+            &property_context,
+            NULL,
+            4,
+            "917",
+            "firmware",
+            "origin",
+            "git",
+            version_get_git_origin(firmware_version));
+    }
+
+    furi_string_free(key);
+    furi_string_free(value);
+}

--- a/targets/f64/furi_hal/furi_hal_info.h
+++ b/targets/f64/furi_hal/furi_hal_info.h
@@ -1,0 +1,29 @@
+/**
+ * @file furi_hal_info.h
+ * Device info HAL API
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <core/string.h>
+#include <toolbox/property.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void furi_hal_info_get_api_version(uint16_t* major, uint16_t* minor);
+
+/** Get device information
+  *
+  * @param[in]  callback     callback to provide with new data
+  * @param[in]  sep          category separator character
+  * @param[in]  context      context to pass to callback
+  */
+void furi_hal_info_get(PropertyValueCallback callback, char sep, void* context);
+
+#ifdef __cplusplus
+}
+#endif

--- a/targets/f64/furi_hal/furi_hal_version.c
+++ b/targets/f64/furi_hal/furi_hal_version.c
@@ -1,0 +1,10 @@
+#include <furi_hal_version.h>
+#include <furi_hal_rtc.h>
+
+#include <furi.h>
+
+#define TAG "FuriHalVersion"
+
+const struct Version* furi_hal_version_get_firmware_version(void) {
+    return version_get();
+}

--- a/targets/f64/target.json
+++ b/targets/f64/target.json
@@ -81,6 +81,7 @@
         "print",
         "targets",
         "furi",
+        "version",
         "toolbox_f64",
         "firmware_applications_f64"
     ],


### PR DESCRIPTION
# What's new

- furi_hal_version and info added
- device_info command added to both CPUs
- sl_echo moved to another place

# Verification 

- run `device_info` it will show information from both CPUs

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
