### PR TITLE
EMI improvements: smooth front display GPIO signals

### DIFF
--- a/applications/services/front_display/front_display_driver.c
+++ b/applications/services/front_display/front_display_driver.c
@@ -241,19 +241,19 @@ static void octospi_init(void) {
         &gpio_front_display_sdi_ospi_d0,
         GpioModeAltFunctionPushPull,
         GpioPullNo,
-        GpioSpeedMedium,
+        GpioSpeedLow,
         GpioAltFn10OCTOSPI1);
     furi_hal_gpio_init_ex(
         &gpio_front_display_le_ospi_d1,
         GpioModeAltFunctionPushPull,
         GpioPullNo,
-        GpioSpeedMedium,
+        GpioSpeedLow,
         GpioAltFn10OCTOSPI1);
     furi_hal_gpio_init_ex(
         &gpio_front_display_dclk_ospi_clk,
         GpioModeAltFunctionPushPull,
         GpioPullNo,
-        GpioSpeedMedium,
+        GpioSpeedLow,
         GpioAltFn10OCTOSPI1);
 }
 

--- a/applications/services/front_display/front_display_scan.c
+++ b/applications/services/front_display/front_display_scan.c
@@ -75,7 +75,7 @@ static void gclk_tim_init(void) {
         &gpio_front_display_gclk,
         GpioModeAltFunctionPushPull,
         GpioPullNo,
-        GpioSpeedMedium,
+        GpioSpeedLow,
         GpioAltFn3TIM8);
 }
 
@@ -122,7 +122,7 @@ static void scan_tim_init(void) {
         &gpio_front_display_scan_latch,
         GpioModeAltFunctionPushPull,
         GpioPullNo,
-        GpioSpeedMedium,
+        GpioSpeedLow,
         GpioAltFn2TIM5);
 }
 
@@ -237,13 +237,13 @@ static void spi_595_init(void) {
         &gpio_front_display_scan_clk,
         GpioModeAltFunctionPushPull,
         GpioPullNo,
-        GpioSpeedMedium,
+        GpioSpeedLow,
         GpioAltFn5SPI2);
     furi_hal_gpio_init_ex(
         &gpio_front_display_scan_sdi,
         GpioModeAltFunctionPushPull,
         GpioPullNo,
-        GpioSpeedMedium,
+        GpioSpeedLow,
         GpioAltFn3SPI2);
 
     LL_SPI_TransmitData8(SPI2, SCAN_DISABLED);


### PR DESCRIPTION
# What's new

- Change front display gpio speed to GpioSpeedLow

# Verification 

- No EMI on low frequencies
- Front display still works
- Changed gpio still have proper fronts

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
