### PR TITLE
Usb-eth MAC addr based on chip uid

### DIFF
--- a/applications/services/usb_network/usb_network_settings.c
+++ b/applications/services/usb_network/usb_network_settings.c
@@ -3,15 +3,15 @@
 #include "usb_network_settings.h"
 #include <storage/storage.h>
 #include <cjson/cJSON.h>
+#include <furi_hal_version.h>
 
 // TODO: furi_hal_version
-#define DEFAULT_MAC         {0x0C, 0xFA, 0x22, 0x01, 0x23, 0x45}
 #define DEFAULT_HOSTNAME    "busybar"
 #define DEFAULT_WEBUSB_ZONE ".local"
 
-#define SETTINGS_FILE "/ext/data/settings/usb_network_settings.json"
+#define SETTINGS_FILE EXT_PATH("data/settings/usb_network_settings.json")
 
-#define TAG "USB NET"
+#define TAG "USBNet"
 
 static FuriString* hostname = NULL;
 
@@ -21,14 +21,12 @@ static UsbNetworkAddress address = {
     .gateway = {0, 0, 0, 0},
 };
 
-static uint8_t mac_address[6] = DEFAULT_MAC;
-
 UsbNetworkAddress usb_network_settings_get_address(void) {
     return address;
 }
 
 const uint8_t* usb_network_settings_get_mac_address(void) {
-    return mac_address;
+    return furi_hal_version_get_ble_mac();
 }
 
 const char* usb_network_settings_get_hostname(void) {

--- a/targets/f20/furi_hal/furi_hal_version.c
+++ b/targets/f20/furi_hal/furi_hal_version.c
@@ -1,10 +1,32 @@
 #include <furi_hal_version.h>
 #include <furi_hal_rtc.h>
 
+#include <stm32u5xx_ll_utils.h>
+
 #include <furi.h>
 
 #define TAG "FuriHalVersion"
 
+#define FLIPPER_MAC_0 0x0C
+#define FLIPPER_MAC_1 0xFA
+#define FLIPPER_MAC_2 0x22
+
+static uint8_t ble_mac[6] = {FLIPPER_MAC_0, FLIPPER_MAC_1, FLIPPER_MAC_2, 0, 0, 0};
+
 const struct Version* furi_hal_version_get_firmware_version(void) {
     return version_get();
+}
+
+const uint8_t* furi_hal_version_get_ble_mac(void) {
+    uint32_t uid[3] = {0};
+    uid[0] = LL_GetUID_Word0(); // X and Y coordinates on the wafer expressed in BCD format
+    uid[1] = LL_GetUID_Word1(); // Wafer number and lot number
+    uid[2] = LL_GetUID_Word2(); // Lot number (ASCII encoded)
+
+    // Generate a unique MAC address based on the UID
+    ble_mac[3] = (uid[0] >> 16) & 0xFF;
+    ble_mac[4] = uid[0] & 0xFF;
+    ble_mac[5] = (uid[1] >> 16) & 0xFF;
+
+    return ble_mac;
 }


### PR DESCRIPTION
# What's new

- Now BSB eth interface over USB should use different MAC addresses between devices

# Verification 

- Flash and check the MAC address

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
