### PR TITLE
Back display test: add inverted pattern for oled display jigs

### DIFF
--- a/applications/main/back_display_test/back_display_test.h
+++ b/applications/main/back_display_test/back_display_test.h
@@ -11,6 +11,7 @@ extern "C" {
 
 typedef enum {
     BackDisplayTestPatternFill,
+    BackDisplayTestPatternFillInverted,
     BackDisplayTestPatternCheckerboard,
     BackDisplayTestPatternGradientHorizontal,
     BackDisplayTestPatternGradientVertical,

--- a/applications/main/back_display_test/back_display_test_canvas.c
+++ b/applications/main/back_display_test/back_display_test_canvas.c
@@ -31,6 +31,13 @@ static void back_display_test_canvas_update_fill(Canvas* canvas, BackDisplayTest
 }
 
 static void
+    back_display_test_canvas_update_fill_inverted(Canvas* canvas, BackDisplayTestColor color) {
+    BackDisplayTestColor inverted_color = BackDisplayTestColor0 - color;
+    canvas_set_fill_color(canvas, back_display_test_colors[inverted_color].color);
+    canvas_fill(canvas);
+}
+
+static void
     back_display_test_canvas_update_checkerboard(Canvas* canvas, BackDisplayTestColor color) {
     canvas_set_line_width(canvas, 0);
     canvas_set_fill_color(canvas, back_display_test_colors[color].color);
@@ -216,6 +223,8 @@ typedef struct {
 
 static const BackDisplayTestPatternInfo back_display_test_patterns[BackDisplayTestPatternMax] = {
     [BackDisplayTestPatternFill] = {back_display_test_canvas_update_fill, "Fill"},
+    [BackDisplayTestPatternFillInverted] =
+        {back_display_test_canvas_update_fill_inverted, "Fill inverted"},
     [BackDisplayTestPatternCheckerboard] =
         {back_display_test_canvas_update_checkerboard, "Checker"},
     [BackDisplayTestPatternGradientHorizontal] =


### PR DESCRIPTION
# What's new

Add Fill inverted pattern for testing back display on manufacturing line. They need to test 3 patterns:
1. Full white
2. Full black
3. Chess

They will switch patterns by pressing Start button

# Verification 

- The back display test app works as mentioned above

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
