### PR TITLE
SDMMC unaligned write fix, mongoose io size change

### DIFF
--- a/targets/f20/config/mongoose_config.h
+++ b/targets/f20/config/mongoose_config.h
@@ -14,7 +14,10 @@
 #define MG_ENABLE_LOG               1
 #define MG_ENABLE_POSIX_FS          0
 #define MG_ENABLE_DIRLIST           1
-#define MG_DATA_SIZE                32
-#define MG_IO_SIZE                  1460 * 4
+
+#define MG_DATA_SIZE 32
+
+#define MG_MAX_RECV_SIZE (256 * 1024)
+#define MG_IO_SIZE       1460
 
 // #define MG_ENABLE_TCPIP_PRINT_DEBUG_STATS 1

--- a/targets/f20/furi_hal/furi_hal_sdmmc.c
+++ b/targets/f20/furi_hal/furi_hal_sdmmc.c
@@ -2361,11 +2361,13 @@ bool furi_hal_sdmmc_write_blocks(
         uint32_t blocks_in_current_operation;
 
         if(((uintptr_t)current_user_buffer_ptr % DMA_ALIGNMENT) == 0) {
-            // Current user buffer pointer is aligned. Read as many blocks as possible directly.
+            // Current user buffer pointer is aligned. Write as many blocks as possible directly.
             dma_target_buffer = current_user_buffer_ptr;
-            blocks_in_current_operation = remaining_blocks; // Attempt to read all remaining blocks
+            blocks_in_current_operation =
+                remaining_blocks; // Attempt to write all remaining blocks
         } else {
-            // Current user buffer pointer is unaligned. Read one block into the temporary aligned buffer.
+            // Current user buffer pointer is unaligned. Write one block from the temporary aligned buffer.
+            memcpy(temp_aligned_block_ptr, buffer, SD_BLOCKSIZE);
             dma_target_buffer = temp_aligned_block_ptr;
             blocks_in_current_operation = 1;
         }


### PR DESCRIPTION
# What's new

- SDMMC: unaligned write fix
- Mongoose: change IO size back to MTU

# Verification 

- [ Describe how to verify changes ]

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
