### PR TITLE
[FW-216] Tolerate non-flashed other side

### DIFF
--- a/applications/services/cli_uart/cli_uart.c
+++ b/applications/services/cli_uart/cli_uart.c
@@ -61,7 +61,7 @@ static void cli_uart_data_from_pipe(PipeSide* pipe, void* context) {
 
     uint8_t buffer[to_transfer];
     furi_check(pipe_receive(pipe, buffer, to_transfer) == to_transfer);
-    furi_hal_serial_tx(cli_uart->uart_handle, buffer, to_transfer);
+    furi_hal_serial_tx(cli_uart->uart_handle, buffer, to_transfer, FuriWaitForever);
 }
 
 // ============

--- a/applications/services/intercom/intercom.c
+++ b/applications/services/intercom/intercom.c
@@ -2,7 +2,8 @@
 
 #define TAG "IntercomSrv"
 
-#define INTERCOM_TX_TIMEOUT_MS (1000UL)
+#define INTERCOM_TX_TIMEOUT_MS                 (1000UL)
+#define INTERCOM_INITIAL_SYNC_RETRY_LOCKOUT_MS (1000UL)
 
 #ifdef INTERCOM_DEBUG
 #define INTERCOM_LOG_D(...) FURI_LOG_D(TAG, __VA_ARGS__)
@@ -40,6 +41,7 @@ typedef struct {
 struct Intercom {
     FuriThread* rx_thread;
     FuriSemaphore* sync_semaphore;
+    bool is_initial_sync_done;
     FuriEventLoop* event_loop;
     FuriSemaphore* tx_semaphore;
     FuriEventLoopTimer* tx_timer;
@@ -50,6 +52,11 @@ struct Intercom {
     IntercomErrorCallback error_callback;
     void* error_callback_context;
 };
+
+typedef enum {
+    IntercomSyncRequestExternal,
+    IntercomSyncRequestInitial,
+} IntercomSyncRequest;
 
 typedef enum {
     IntercomEventSyncRequested = 1UL << 0,
@@ -138,8 +145,7 @@ static void intercom_default_error_callback(IntercomError error, void* context) 
 #endif
 
     if(error == IntercomErrorSync) {
-        // TODO can't crash since 917 might not be flashed. Think what we really need to do
-        // furi_crash("Other side not in sync");
+        furi_crash("Externally requested sync failed");
 
     } else if(error == IntercomErrorFraming) {
         intercom_dump_frame(&instance->rx_frame);
@@ -153,14 +159,19 @@ static void intercom_default_error_callback(IntercomError error, void* context) 
     }
 }
 
-static FURI_ALWAYS_INLINE void intercom_process_sync_requested_event(Intercom* instance) {
+static bool intercom_try_sync(Intercom* instance, IntercomSyncRequest source) {
     INTERCOM_LOG_D("Sync requested");
+
+    FuriStatus expected_acq_status = instance->is_initial_sync_done ? FuriStatusOk :
+                                                                      FuriStatusErrorResource;
+    furi_check(furi_semaphore_acquire(instance->tx_semaphore, 0) == expected_acq_status);
 
     furi_thread_flags_set(furi_thread_get_id(instance->rx_thread), IntercomThreadFlagSyncStarted);
     furi_check(furi_semaphore_acquire(instance->sync_semaphore, FuriWaitForever) == FuriStatusOk);
 
-    if(intercom_sync_serial(instance->serial)) {
-// TODO: Unify function signatures
+    bool result = intercom_sync_serial(instance->serial);
+    if(result) {
+        // TODO: Unify function signatures
 #if defined(TARGET_F20)
         furi_hal_gpio_init_simple(&INTERCOM_GPIO, GpioModeInterruptFall);
         furi_hal_gpio_add_int_callback(&INTERCOM_GPIO, intercom_gpio_irq_callback, instance);
@@ -171,12 +182,17 @@ static FURI_ALWAYS_INLINE void intercom_process_sync_requested_event(Intercom* i
 #error "Unsupported target"
 #endif
         furi_hal_serial_clear(instance->serial, FuriHalSerialDirectionTxRx);
+        instance->is_initial_sync_done = true;
+        furi_check(furi_semaphore_release(instance->tx_semaphore) == FuriStatusOk);
     } else {
-        instance->error_callback(IntercomErrorSync, instance->error_callback_context);
+        if(source == IntercomSyncRequestExternal)
+            instance->error_callback(IntercomErrorSync, instance->error_callback_context);
     }
 
     furi_thread_flags_set(furi_thread_get_id(instance->rx_thread), IntercomThreadFlagSyncFinished);
     furi_check(furi_semaphore_acquire(instance->sync_semaphore, FuriWaitForever) == FuriStatusOk);
+
+    return result;
 }
 
 static FURI_ALWAYS_INLINE void intercom_send_tx_frame(Intercom* instance) {
@@ -221,7 +237,7 @@ static void intercom_custom_event_callback(uint32_t events, void* context) {
     Intercom* instance = context;
     if(events & IntercomEventSyncRequested) {
         INTERCOM_LOG_D("IntercomEventSyncRequested");
-        intercom_process_sync_requested_event(instance);
+        intercom_try_sync(instance, IntercomSyncRequestExternal);
     }
     if(events & IntercomEventFrameSent) {
         INTERCOM_LOG_D("IntercomEventFrameSent");
@@ -276,7 +292,7 @@ static Intercom* intercom_alloc(void) {
         furi_thread_alloc_service("IntercomRxSrv", 1024, intercom_rx_thread, instance);
     instance->sync_semaphore = furi_semaphore_alloc(1, 0);
     instance->event_loop = furi_event_loop_alloc();
-    instance->tx_semaphore = furi_semaphore_alloc(1, 1);
+    instance->tx_semaphore = furi_semaphore_alloc(1, 0);
     instance->tx_timer = furi_event_loop_timer_alloc(
         instance->event_loop, intercom_tx_timer_callback, FuriEventLoopTimerTypeOnce, instance);
     instance->serial = furi_hal_serial_control_acquire(INTERCOM_SERIAL);
@@ -290,14 +306,22 @@ static Intercom* intercom_alloc(void) {
     furi_hal_serial_set_hw_flow_control(instance->serial, FuriHalSerialHwFlowControlRtsCts);
     furi_hal_serial_set_callback(
         instance->serial, intercom_serial_tx_callback, intercom_serial_rx_callback, instance);
-    // Start RX thread
     furi_thread_start(instance->rx_thread);
-    // Pulse gpio_xxx_irq pin to request synchronisation procedure
-    intercom_sync_request(&INTERCOM_GPIO);
-    // Perform initial synchronisation procedure
-    intercom_process_sync_requested_event(instance);
 
+    // dont't hold up the rest of the system
     furi_record_create(RECORD_INTERCOM, instance);
+
+    while(1) {
+        intercom_sync_request(&INTERCOM_GPIO);
+        if(intercom_try_sync(instance, IntercomSyncRequestInitial)) break;
+
+        FURI_LOG_E(
+            TAG,
+            "Initial sync failed, retrying in %ld ms",
+            INTERCOM_INITIAL_SYNC_RETRY_LOCKOUT_MS);
+        furi_delay_ms(INTERCOM_INITIAL_SYNC_RETRY_LOCKOUT_MS);
+    }
+
     return instance;
 }
 

--- a/applications/services/intercom/intercom.c
+++ b/applications/services/intercom/intercom.c
@@ -3,7 +3,7 @@
 #define TAG "IntercomSrv"
 
 #define INTERCOM_TX_TIMEOUT_MS                 (1000UL)
-#define INTERCOM_INITIAL_SYNC_RETRY_LOCKOUT_MS (1000UL)
+#define INTERCOM_INITIAL_SYNC_RETRY_LOCKOUT_MS (500UL)
 
 #ifdef INTERCOM_DEBUG
 #define INTERCOM_LOG_D(...) FURI_LOG_D(TAG, __VA_ARGS__)
@@ -52,11 +52,6 @@ struct Intercom {
     IntercomErrorCallback error_callback;
     void* error_callback_context;
 };
-
-typedef enum {
-    IntercomSyncRequestExternal,
-    IntercomSyncRequestInitial,
-} IntercomSyncRequest;
 
 typedef enum {
     IntercomEventSyncRequested = 1UL << 0,
@@ -159,7 +154,7 @@ static void intercom_default_error_callback(IntercomError error, void* context) 
     }
 }
 
-static bool intercom_try_sync(Intercom* instance, IntercomSyncRequest source) {
+static bool intercom_try_sync(Intercom* instance) {
     INTERCOM_LOG_D("Sync requested");
 
     FuriStatus expected_acq_status = instance->is_initial_sync_done ? FuriStatusOk :
@@ -185,8 +180,9 @@ static bool intercom_try_sync(Intercom* instance, IntercomSyncRequest source) {
         instance->is_initial_sync_done = true;
         furi_check(furi_semaphore_release(instance->tx_semaphore) == FuriStatusOk);
     } else {
-        if(source == IntercomSyncRequestExternal)
+        if(instance->is_initial_sync_done) {
             instance->error_callback(IntercomErrorSync, instance->error_callback_context);
+        }
     }
 
     furi_thread_flags_set(furi_thread_get_id(instance->rx_thread), IntercomThreadFlagSyncFinished);
@@ -237,7 +233,7 @@ static void intercom_custom_event_callback(uint32_t events, void* context) {
     Intercom* instance = context;
     if(events & IntercomEventSyncRequested) {
         INTERCOM_LOG_D("IntercomEventSyncRequested");
-        intercom_try_sync(instance, IntercomSyncRequestExternal);
+        intercom_try_sync(instance);
     }
     if(events & IntercomEventFrameSent) {
         INTERCOM_LOG_D("IntercomEventFrameSent");
@@ -313,7 +309,7 @@ static Intercom* intercom_alloc(void) {
 
     while(1) {
         intercom_sync_request(&INTERCOM_GPIO);
-        if(intercom_try_sync(instance, IntercomSyncRequestInitial)) break;
+        if(intercom_try_sync(instance)) break;
 
         FURI_LOG_E(
             TAG,

--- a/applications/services/intercom/intercom.h
+++ b/applications/services/intercom/intercom.h
@@ -39,7 +39,7 @@ typedef enum {
  * @brief Enumeration of possible errors.
  */
 typedef enum {
-    IntercomErrorSync, /**< Failed to synchronise with the other side */
+    IntercomErrorSync, /**< Other side has requested synchronization, which failed */
     IntercomErrorFraming, /**< Invalid frame (incorrect structure or checksum) */
     IntercomErrorTransmit, /**< Transmission has been inhibited for too long by HW */
 } IntercomError;

--- a/applications/services/intercom/intercom_sync.c
+++ b/applications/services/intercom/intercom_sync.c
@@ -6,7 +6,8 @@
 #define INTERCOM_SYNC_INTERVAL_1_MS (5UL)
 #define INTERCOM_SYNC_INTERVAL_2_MS (1UL)
 
-#define INTERCOM_SYNC_TIMEOUT_MS (10000UL)
+#define INTERCOM_SYNC_CHAR_TIMEOUT_MS (1000UL)
+#define INTERCOM_SYNC_TIMEOUT_MS      (1000UL)
 
 typedef struct {
     uint8_t leader;
@@ -47,8 +48,11 @@ static bool
 
     while(furi_get_tick() - start_time < furi_ms_to_ticks(INTERCOM_SYNC_TIMEOUT_MS)) {
         if(send_leader) {
-            furi_hal_serial_tx(serial, &sequence->leader, 1);
-            if(!furi_hal_serial_tx_wait_complete(serial, INTERCOM_SYNC_TIMEOUT_MS)) {
+            if(furi_hal_serial_tx(serial, &sequence->leader, 1, INTERCOM_SYNC_CHAR_TIMEOUT_MS) !=
+               1) {
+                break;
+            }
+            if(!furi_hal_serial_tx_wait_complete(serial, INTERCOM_SYNC_CHAR_TIMEOUT_MS)) {
                 break;
             }
             // If repeat_leader is false, then the leader is sent only once

--- a/applications/system/updater/sl_updater.c
+++ b/applications/system/updater/sl_updater.c
@@ -111,7 +111,7 @@ static int32_t kermit_comms_send(void* context, const uint8_t* buffer, size_t le
     furi_string_free(str);
 #endif
 
-    furi_hal_serial_tx(app->serial_handle, buffer, length);
+    furi_hal_serial_tx(app->serial_handle, buffer, length, FuriWaitForever);
     return length;
 }
 
@@ -175,7 +175,7 @@ static void sl_updater_handle_rx(SlUpdater* instance) {
     case Si917BootloaderStateInit:
         if(sl_updater_check_rx_for(instance, "Enter 'U'")) {
             const uint8_t leader = 'U';
-            furi_hal_serial_tx(instance->serial_handle, &leader, sizeof(leader));
+            furi_hal_serial_tx(instance->serial_handle, &leader, sizeof(leader), FuriWaitForever);
             FURI_LOG_I(TAG, "Leader sent: %c", leader);
             instance->bootloader_state = Si917BootloaderStateBoot;
         }
@@ -189,7 +189,8 @@ static void sl_updater_handle_rx(SlUpdater* instance) {
         } else {
             if(sl_updater_check_rx_for(instance, "Change UART Baud Rate\r\n")) {
                 const uint8_t choice = 'b';
-                furi_hal_serial_tx(instance->serial_handle, &choice, sizeof(choice));
+                furi_hal_serial_tx(
+                    instance->serial_handle, &choice, sizeof(choice), FuriWaitForever);
                 FURI_LOG_I(TAG, "UART Baud Rate change request sent: %c", choice);
                 instance->bootloader_state = Si917BootloaderStateChangeBaudRate;
             }
@@ -201,7 +202,8 @@ static void sl_updater_handle_rx(SlUpdater* instance) {
             furi_hal_serial_tx(
                 instance->serial_handle,
                 (uint8_t*)sl_updater_baudrate[instance->baud_throttle].choice,
-                1);
+                1,
+                FuriWaitForever);
             FURI_LOG_I(
                 TAG,
                 "UART Baud Rate speed request sent: %s",
@@ -214,7 +216,7 @@ static void sl_updater_handle_rx(SlUpdater* instance) {
                 "Reference baud set %ld",
                 furi_hal_serial_get_baud_rate(instance->serial_handle));
             const uint8_t leader = 'U';
-            furi_hal_serial_tx(instance->serial_handle, &leader, sizeof(leader));
+            furi_hal_serial_tx(instance->serial_handle, &leader, sizeof(leader), FuriWaitForever);
             if(furi_hal_serial_set_auto_baud_rate(
                    instance->serial_handle,
                    FuriHalSerialAutoBaudRateMode0x55Frame,
@@ -232,7 +234,7 @@ static void sl_updater_handle_rx(SlUpdater* instance) {
 
     case Si917BootloaderStateChangeBaudRateNewLeader:
         const uint8_t leader = 'U';
-        furi_hal_serial_tx(instance->serial_handle, &leader, sizeof(leader));
+        furi_hal_serial_tx(instance->serial_handle, &leader, sizeof(leader), FuriWaitForever);
         FURI_LOG_I(TAG, "New Leader sent: %c", leader);
         // fall through
 
@@ -250,7 +252,8 @@ static void sl_updater_handle_rx(SlUpdater* instance) {
         if(sl_updater_check_rx_for(instance, "Enter Next Command")) {
             furi_delay_ms(10);
             const uint8_t image_type = instance->is_stack_image ? 'B' : '4';
-            furi_hal_serial_tx(instance->serial_handle, &image_type, sizeof(image_type));
+            furi_hal_serial_tx(
+                instance->serial_handle, &image_type, sizeof(image_type), FuriWaitForever);
 
             FURI_LOG_I(TAG, "Image type set to: %c", image_type);
             instance->bootloader_state = Si917BootloaderStateSetImageSlot;
@@ -262,7 +265,8 @@ static void sl_updater_handle_rx(SlUpdater* instance) {
                                                         "Enter M4 Image No(1-f)";
         if(sl_updater_check_rx_for(instance, needle)) {
             const uint8_t image_slot = instance->is_stack_image ? '0' : '1';
-            furi_hal_serial_tx(instance->serial_handle, &image_slot, sizeof(image_slot));
+            furi_hal_serial_tx(
+                instance->serial_handle, &image_slot, sizeof(image_slot), FuriWaitForever);
 
             FURI_LOG_I(TAG, "Image slot set to: %c", image_slot);
             instance->bootloader_state = Si917BootloaderStateKermitInit;
@@ -467,7 +471,7 @@ static bool
     furi_hal_power_reset_917(true);
 
     const uint8_t leader = 0;
-    furi_hal_serial_tx(instance->serial_handle, &leader, sizeof(leader));
+    furi_hal_serial_tx(instance->serial_handle, &leader, sizeof(leader), FuriWaitForever);
 
     furi_event_loop_run(instance->event_loop);
 

--- a/targets/f20/furi_hal/furi_hal_serial.c
+++ b/targets/f20/furi_hal/furi_hal_serial.c
@@ -644,20 +644,37 @@ void furi_hal_serial_set_callback(
     serial->callback_context = context;
 }
 
-void furi_hal_serial_tx(FuriHalSerialHandle* handle, const uint8_t* buffer, size_t buffer_size) {
+size_t furi_hal_serial_tx(
+    FuriHalSerialHandle* handle,
+    const uint8_t* buffer,
+    size_t buffer_size,
+    uint32_t timeout) {
     furi_check(handle);
+    furi_check(buffer);
+    furi_check(buffer_size);
 
+    bool wait_forever = timeout == FuriWaitForever;
+
+    size_t transmitted = 0;
+    FuriHalCortexTimer timer = furi_hal_cortex_timer_get(wait_forever ? 1 : (timeout * 1000));
     USART_TypeDef* periph = furi_hal_serial_resources[handle->id].periph;
 
     while(buffer_size > 0) {
-        while(!LL_USART_IsActiveFlag_TXE_TXFNF(periph))
-            ;
+        bool timed_out = furi_hal_cortex_timer_is_expired(timer);
+        while(!LL_USART_IsActiveFlag_TXE_TXFNF(periph) && (wait_forever || !timed_out)) {
+            timed_out = furi_hal_cortex_timer_is_expired(timer);
+        }
+
+        if(!wait_forever && timed_out) break;
 
         LL_USART_TransmitData8(periph, *buffer);
 
         buffer++;
         buffer_size--;
+        transmitted++;
     }
+
+    return transmitted;
 }
 
 bool furi_hal_serial_tx_wait_complete(FuriHalSerialHandle* handle, uint32_t timeout) {

--- a/targets/f20/furi_hal/furi_hal_serial.h
+++ b/targets/f20/furi_hal/furi_hal_serial.h
@@ -165,16 +165,24 @@ void furi_hal_serial_set_callback(
 /* Blocking API */
 
 /**
- * Transmit data over the serial interface.
+ * Put data into the UART transmit FIFO buffer
  *
  * @param handle Pointer to the serial handle.
  * @param buffer Pointer to the data buffer.
  * @param buffer_size Size of the data buffer.
+ * @param timeout Timeout in milliseconds, or `FuriWaitForever`.
+ * 
+ * @return Number of bytes put into the buffer within the specified timeout
  */
-void furi_hal_serial_tx(FuriHalSerialHandle* handle, const uint8_t* buffer, size_t buffer_size);
+size_t furi_hal_serial_tx(
+    FuriHalSerialHandle* handle,
+    const uint8_t* buffer,
+    size_t buffer_size,
+    uint32_t timeout);
 
 /**
- * Wait for the transmission to complete.
+ * Wait for the UART transmit FIFO buffer to empty, meaning all bytes have been
+ * transmitted
  *
  * @param handle Pointer to the serial handle.
  * @param timeout Timeout in milliseconds.

--- a/targets/f20/furi_hal/furi_hal_serial_control.c
+++ b/targets/f20/furi_hal/furi_hal_serial_control.c
@@ -45,7 +45,7 @@ FuriHalSerialControl* furi_hal_serial_control = NULL;
 
 static void furi_hal_serial_control_log_callback(const uint8_t* data, size_t size, void* context) {
     FuriHalSerialHandle* handle = context;
-    furi_hal_serial_tx(handle, data, size);
+    furi_hal_serial_tx(handle, data, size, FuriWaitForever);
 }
 
 static void furi_hal_serial_control_log_set_handle(FuriHalSerialHandle* handle) {

--- a/targets/f64/furi_hal/furi_hal_serial.c
+++ b/targets/f64/furi_hal/furi_hal_serial.c
@@ -347,22 +347,37 @@ void furi_hal_serial_resume(FuriHalSerialHandle* handle) {
     furi_check(handle);
 }
 
-void furi_hal_serial_tx(FuriHalSerialHandle* handle, const uint8_t* buffer, size_t buffer_size) {
+size_t furi_hal_serial_tx(
+    FuriHalSerialHandle* handle,
+    const uint8_t* buffer,
+    size_t buffer_size,
+    uint32_t timeout) {
     furi_check(handle);
     furi_check(buffer);
     furi_check(buffer_size);
 
+    bool wait_forever = timeout == FuriWaitForever;
+
+    size_t transmitted = 0;
+    FuriHalCortexTimer timer = furi_hal_cortex_timer_get(wait_forever ? 1 : (timeout * 1000));
     USART0_Type* periph = furi_hal_serial_resources[handle->id].periph;
 
     while(buffer_size > 0) {
-        while(!periph->USR_b.TFNF)
-            ;
+        bool timed_out = furi_hal_cortex_timer_is_expired(timer);
+        while(!periph->USR_b.TFNF && (wait_forever || !timed_out)) {
+            timed_out = furi_hal_cortex_timer_is_expired(timer);
+        }
+
+        if(!wait_forever && timed_out) break;
 
         periph->THR = *buffer;
 
-        ++buffer;
-        --buffer_size;
+        buffer++;
+        buffer_size--;
+        transmitted++;
     }
+
+    return transmitted;
 }
 
 bool furi_hal_serial_tx_wait_complete(FuriHalSerialHandle* handle, uint32_t timeout) {

--- a/targets/f64/furi_hal/furi_hal_serial.h
+++ b/targets/f64/furi_hal/furi_hal_serial.h
@@ -131,16 +131,24 @@ void furi_hal_serial_set_callback(
 /* Blocking API */
 
 /**
- * Transmit data over the serial interface.
+ * Put data into the UART transmit FIFO buffer
  *
  * @param handle Pointer to the serial handle.
  * @param buffer Pointer to the data buffer.
  * @param buffer_size Size of the data buffer.
+ * @param timeout Timeout in milliseconds, or `FuriWaitForever`.
+ * 
+ * @return Number of bytes put into the buffer within the specified timeout
  */
-void furi_hal_serial_tx(FuriHalSerialHandle* handle, const uint8_t* buffer, size_t buffer_size);
+size_t furi_hal_serial_tx(
+    FuriHalSerialHandle* handle,
+    const uint8_t* buffer,
+    size_t buffer_size,
+    uint32_t timeout);
 
 /**
- * Wait for the transmission to complete.
+ * Wait for the UART transmit FIFO buffer to empty, meaning all bytes have been
+ * transmitted
  *
  * @param handle Pointer to the serial handle.
  * @param timeout Timeout in milliseconds.

--- a/targets/f64/furi_hal/furi_hal_serial_control.c
+++ b/targets/f64/furi_hal/furi_hal_serial_control.c
@@ -45,7 +45,7 @@ FuriHalSerialControl* furi_hal_serial_control = NULL;
 
 static void furi_hal_serial_control_log_callback(const uint8_t* data, size_t size, void* context) {
     FuriHalSerialHandle* handle = context;
-    furi_hal_serial_tx(handle, data, size);
+    furi_hal_serial_tx(handle, data, size, FuriWaitForever);
 }
 
 static void furi_hal_serial_control_log_set_handle(FuriHalSerialHandle* handle) {


### PR DESCRIPTION
# What's new
  - HAL: UART TX function with a timeout
  - Intercom: can now start without a sync, without holding up the rest of the system

# Verification 
  - Flash both MCUs with this branch
  - Scenario 1:
    - Reset both MCUs simultaneously
    - Verify that intercom syncs
  - Scenario 2:
    - Hold u5 in reset
    - Reset 917
    - Verify (by looking at logs) that intercom sync on 917 is timing out
    - Release u5 reset
    - Verify that intercom syncs
  - Scenario 3:
    - Hold 917 in reset
    - Reset u5
    - Verify (by looking at logs) that intercom sync on u5 is timing out
    - Verify that the rest of the system functions correctly (as much as it can without intercom-dependent functionality)
  - Scenario 4:
    - Reset both MCUs simultaneously
    - Verify that intercom syncs
    - Reset u5
    - Verify that intercom syncs

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
