### PR TITLE
JSON config helper, display and audio settings save

### DIFF
--- a/applications/debug/unit_tests/json_helper_test/json_helper_test.c
+++ b/applications/debug/unit_tests/json_helper_test/json_helper_test.c
@@ -1,0 +1,299 @@
+/**
+ * @file test_test.c
+ * @brief Tests the tests. These tests tests should pass the tests.
+ */
+
+#include "../unit_tests.h"
+#include <toolbox/json_helper.h>
+
+#define JSON_UNIT_TESTS_NORMAL_PATH UNIT_TESTS_PATH("unit_test.json")
+#define JSON_UNIT_TESTS_SINGLE_PATH UNIT_TESTS_PATH("unit_test_single.json")
+
+static JsonConfig* json_config;
+
+static void json_config_setup(void) {
+    json_config = json_config_alloc();
+}
+
+static void json_config_teardown(void) {
+    furi_check(json_config_free(json_config) == JsonConfigStatusOk);
+    json_config = NULL;
+}
+
+MU_TEST(json_helper_test_read_default) {
+    mu_assert_int_eq(
+        JsonConfigStatusMissing, json_config_open(json_config, JSON_UNIT_TESTS_NORMAL_PATH));
+
+    {
+        int val = 0;
+        int default_val = 42;
+        mu_assert_int_eq(
+            JsonConfigStatusMissing,
+            json_config_read_int(json_config, "test_default_int_key", &val, &default_val));
+        mu_assert_int_eq(default_val, val);
+    }
+
+    {
+        float val = 0.0f;
+        float default_val = 3.14f;
+        mu_assert_int_eq(
+            JsonConfigStatusMissing,
+            json_config_read_number(json_config, "test_default_float_key", &val, &default_val));
+        mu_assert_double_eq(default_val, val);
+    }
+
+    {
+        bool val = false;
+        bool default_val = true;
+        mu_assert_int_eq(
+            JsonConfigStatusMissing,
+            json_config_read_bool(json_config, "test_default_bool_key", &val, &default_val));
+        mu_assert_int_eq(default_val, val);
+    }
+
+    {
+        FuriString* val = furi_string_alloc();
+        const char* default_val = "test_string_default_value";
+        mu_assert_int_eq(
+            JsonConfigStatusMissing,
+            json_config_read_str(json_config, "test_default_str_key", val, default_val));
+        mu_assert_string_eq(default_val, furi_string_get_cstr(val));
+        furi_string_free(val);
+    }
+}
+
+MU_TEST(json_helper_test_write) {
+    mu_assert_int_eq(
+        JsonConfigStatusOk, json_config_open(json_config, JSON_UNIT_TESTS_NORMAL_PATH));
+    mu_assert_int_eq(JsonConfigStatusOk, json_config_write_int(json_config, "test_int_key", 69));
+    mu_assert_int_eq(
+        JsonConfigStatusOk, json_config_write_number(json_config, "test_float_key", 22.8f));
+    mu_assert_int_eq(
+        JsonConfigStatusOk, json_config_write_bool(json_config, "test_bool_key", true));
+    mu_assert_int_eq(
+        JsonConfigStatusOk,
+        json_config_write_str(json_config, "test_str_key", "test_string_value"));
+}
+
+MU_TEST(json_helper_test_read) {
+    mu_assert_int_eq(
+        JsonConfigStatusOk, json_config_open(json_config, JSON_UNIT_TESTS_NORMAL_PATH));
+
+    // check that default values are written
+    {
+        int val = 0;
+        mu_assert_int_eq(
+            JsonConfigStatusOk,
+            json_config_read_int(json_config, "test_default_int_key", &val, NULL));
+        mu_assert_int_eq(42, val);
+    }
+
+    {
+        float val = 0.0f;
+        mu_assert_int_eq(
+            JsonConfigStatusOk,
+            json_config_read_number(json_config, "test_default_float_key", &val, NULL));
+        mu_assert_double_eq(3.14f, val);
+    }
+
+    {
+        bool val = false;
+        mu_assert_int_eq(
+            JsonConfigStatusOk,
+            json_config_read_bool(json_config, "test_default_bool_key", &val, NULL));
+        mu_assert_int_eq(true, val);
+    }
+
+    {
+        FuriString* val = furi_string_alloc();
+        mu_assert_int_eq(
+            JsonConfigStatusOk,
+            json_config_read_str(json_config, "test_default_str_key", val, NULL));
+        mu_assert_string_eq("test_string_default_value", furi_string_get_cstr(val));
+        furi_string_free(val);
+    }
+
+    // explicitly written values
+    {
+        int val = 0;
+        mu_assert_int_eq(
+            JsonConfigStatusOk, json_config_read_int(json_config, "test_int_key", &val, NULL));
+        mu_assert_int_eq(69, val);
+    }
+
+    {
+        float val = 0.0f;
+        mu_assert_int_eq(
+            JsonConfigStatusOk,
+            json_config_read_number(json_config, "test_float_key", &val, NULL));
+        mu_assert_double_eq(22.8f, val);
+    }
+
+    {
+        bool val = false;
+        mu_assert_int_eq(
+            JsonConfigStatusOk, json_config_read_bool(json_config, "test_bool_key", &val, NULL));
+        mu_assert_int_eq(true, val);
+    }
+
+    {
+        FuriString* val = furi_string_alloc();
+        mu_assert_int_eq(
+            JsonConfigStatusOk, json_config_read_str(json_config, "test_str_key", val, NULL));
+        mu_assert_string_eq("test_string_value", furi_string_get_cstr(val));
+        furi_string_free(val);
+    }
+}
+
+MU_TEST_SUITE(json_helper_test_suite_normal) {
+    MU_SUITE_CONFIGURE(&json_config_setup, &json_config_teardown);
+    MU_RUN_TEST(json_helper_test_read_default);
+    MU_RUN_TEST(json_helper_test_write);
+    MU_RUN_TEST(json_helper_test_read);
+}
+
+MU_TEST(json_helper_test_read_default_single) {
+    {
+        int val = 0;
+        int default_val = 42;
+        mu_assert_int_eq(
+            JsonConfigStatusMissing,
+            json_config_read_single_int(
+                JSON_UNIT_TESTS_SINGLE_PATH, "test_default_int_key", &val, &default_val));
+        mu_assert_int_eq(default_val, val);
+    }
+
+    {
+        float val = 0.0f;
+        float default_val = 3.14f;
+        mu_assert_int_eq(
+            JsonConfigStatusMissing,
+            json_config_read_single_number(
+                JSON_UNIT_TESTS_SINGLE_PATH, "test_default_float_key", &val, &default_val));
+        mu_assert_double_eq(default_val, val);
+    }
+
+    {
+        bool val = false;
+        bool default_val = true;
+        mu_assert_int_eq(
+            JsonConfigStatusMissing,
+            json_config_read_single_bool(
+                JSON_UNIT_TESTS_SINGLE_PATH, "test_default_bool_key", &val, &default_val));
+        mu_assert_int_eq(default_val, val);
+    }
+
+    {
+        FuriString* val = furi_string_alloc();
+        const char* default_val = "test_string_default_value";
+        mu_assert_int_eq(
+            JsonConfigStatusMissing,
+            json_config_read_single_str(
+                JSON_UNIT_TESTS_SINGLE_PATH, "test_default_str_key", val, default_val));
+        mu_assert_string_eq(default_val, furi_string_get_cstr(val));
+        furi_string_free(val);
+    }
+}
+
+MU_TEST(json_helper_test_write_single) {
+    mu_assert_int_eq(
+        JsonConfigStatusOk,
+        json_config_write_single_int(JSON_UNIT_TESTS_SINGLE_PATH, "test_int_key", 69));
+    mu_assert_int_eq(
+        JsonConfigStatusOk,
+        json_config_write_single_number(JSON_UNIT_TESTS_SINGLE_PATH, "test_float_key", 22.8f));
+    mu_assert_int_eq(
+        JsonConfigStatusOk,
+        json_config_write_single_bool(JSON_UNIT_TESTS_SINGLE_PATH, "test_bool_key", true));
+    mu_assert_int_eq(
+        JsonConfigStatusOk,
+        json_config_write_single_str(
+            JSON_UNIT_TESTS_SINGLE_PATH, "test_str_key", "test_string_value"));
+}
+
+MU_TEST(json_helper_test_read_single) {
+    // check that default values are written
+    {
+        int val = 0;
+        mu_assert_int_eq(
+            JsonConfigStatusOk,
+            json_config_read_single_int(
+                JSON_UNIT_TESTS_SINGLE_PATH, "test_default_int_key", &val, NULL));
+        mu_assert_int_eq(42, val);
+    }
+
+    {
+        float val = 0.0f;
+        mu_assert_int_eq(
+            JsonConfigStatusOk,
+            json_config_read_single_number(
+                JSON_UNIT_TESTS_SINGLE_PATH, "test_default_float_key", &val, NULL));
+        mu_assert_double_eq(3.14f, val);
+    }
+
+    {
+        bool val = false;
+        mu_assert_int_eq(
+            JsonConfigStatusOk,
+            json_config_read_single_bool(
+                JSON_UNIT_TESTS_SINGLE_PATH, "test_default_bool_key", &val, NULL));
+        mu_assert_int_eq(true, val);
+    }
+
+    {
+        FuriString* val = furi_string_alloc();
+        mu_assert_int_eq(
+            JsonConfigStatusOk,
+            json_config_read_single_str(
+                JSON_UNIT_TESTS_SINGLE_PATH, "test_default_str_key", val, NULL));
+        mu_assert_string_eq("test_string_default_value", furi_string_get_cstr(val));
+        furi_string_free(val);
+    }
+
+    // explicitly written values
+    {
+        int val = 0;
+        mu_assert_int_eq(
+            JsonConfigStatusOk,
+            json_config_read_single_int(JSON_UNIT_TESTS_SINGLE_PATH, "test_int_key", &val, NULL));
+        mu_assert_int_eq(69, val);
+    }
+
+    {
+        float val = 0.0f;
+        mu_assert_int_eq(
+            JsonConfigStatusOk,
+            json_config_read_single_number(
+                JSON_UNIT_TESTS_SINGLE_PATH, "test_float_key", &val, NULL));
+        mu_assert_double_eq(22.8f, val);
+    }
+
+    {
+        bool val = false;
+        mu_assert_int_eq(
+            JsonConfigStatusOk,
+            json_config_read_single_bool(JSON_UNIT_TESTS_SINGLE_PATH, "test_bool_key", &val, NULL));
+        mu_assert_int_eq(true, val);
+    }
+
+    {
+        FuriString* val = furi_string_alloc();
+        mu_assert_int_eq(
+            JsonConfigStatusOk,
+            json_config_read_single_str(JSON_UNIT_TESTS_SINGLE_PATH, "test_str_key", val, NULL));
+        mu_assert_string_eq("test_string_value", furi_string_get_cstr(val));
+        furi_string_free(val);
+    }
+}
+
+MU_TEST_SUITE(json_helper_test_suite_single) {
+    MU_RUN_TEST(json_helper_test_read_default_single);
+    MU_RUN_TEST(json_helper_test_write_single);
+    MU_RUN_TEST(json_helper_test_read_single);
+}
+
+int run_minunit_json_helper_test(void) {
+    MU_RUN_SUITE(json_helper_test_suite_normal);
+    MU_RUN_SUITE(json_helper_test_suite_single);
+    return MU_EXIT_CODE;
+}

--- a/applications/debug/unit_tests/json_helper_test/json_helper_test.h
+++ b/applications/debug/unit_tests/json_helper_test/json_helper_test.h
@@ -1,0 +1,7 @@
+#ifdef TEST_FUNCTION_DECLS
+extern int run_minunit_json_helper_test(void);
+#endif
+
+#ifdef TEST_FUNCTION_REFS
+run_minunit_json_helper_test,
+#endif

--- a/applications/debug/unit_tests/pipe_test/pipe_test.c
+++ b/applications/debug/unit_tests/pipe_test/pipe_test.c
@@ -2,7 +2,7 @@
  * @file pipe_test.c
  */
 
-#include "../minunit.h"
+#include "../unit_tests.h"
 #include <containers/pipe.h>
 #include <containers/pipe_util.h>
 

--- a/applications/debug/unit_tests/test_list.h
+++ b/applications/debug/unit_tests/test_list.h
@@ -14,6 +14,7 @@ extern "C" {
 #define TEST_FUNCTION_DECLS
 #include "test_test/test_test.h"
 #include "pipe_test/pipe_test.h"
+#include "json_helper_test/json_helper_test.h"
 #undef TEST_FUNCTION_DECLS
 
 typedef int (*TestCallback)(void);
@@ -22,6 +23,7 @@ static TestCallback unit_test_callbacks[] = {
 #define TEST_FUNCTION_REFS
 #include "test_test/test_test.h"
 #include "pipe_test/pipe_test.h"
+#include "json_helper_test/json_helper_test.h"
 #undef TEST_FUNCTION_REFS
 };
 

--- a/applications/debug/unit_tests/test_test/test_test.c
+++ b/applications/debug/unit_tests/test_test/test_test.c
@@ -3,7 +3,7 @@
  * @brief Tests the tests. These tests tests should pass the tests.
  */
 
-#include "../minunit.h"
+#include "../unit_tests.h"
 
 MU_TEST(test_test_basic) {
     mu_assert_int_eq(1, 1);

--- a/applications/debug/unit_tests/unit_tests.c
+++ b/applications/debug/unit_tests/unit_tests.c
@@ -3,11 +3,17 @@
 #include <cli/cli_command.h>
 #include <cli/cli_ansi.h>
 #include <FreeRTOSConfig.h>
+#include "unit_tests.h"
 
 void unit_tests_cli_command(PipeSide* pipe, FuriString* args, void* context) {
     UNUSED(pipe);
     UNUSED(args);
     UNUSED(context);
+
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    if(!storage_simply_mkdir(storage, UNIT_TESTS_FOLDER)) {
+        printf("ERROR: Failed to create \"" UNIT_TESTS_FOLDER "\" folder\r\n");
+    }
 
     int32_t heap_before = memmgr_get_free_heap();
     uint32_t time_before = furi_get_tick();
@@ -38,4 +44,9 @@ void unit_tests_cli_command(PipeSide* pipe, FuriString* args, void* context) {
         printf(ANSI_FG_BR_GREEN "PASSED");
     }
     printf(ANSI_RESET "\r\n");
+
+    if(!storage_simply_remove_recursive(storage, UNIT_TESTS_FOLDER)) {
+        printf("ERROR: Failed to remove \"" UNIT_TESTS_FOLDER "\" folder\r\n");
+    }
+    furi_record_close(RECORD_STORAGE);
 }

--- a/applications/debug/unit_tests/unit_tests.h
+++ b/applications/debug/unit_tests/unit_tests.h
@@ -2,5 +2,8 @@
 #include <storage/storage.h>
 #include "minunit.h"
 
-#define UNIT_TESTS_FOLDER     EXT_PATH("unit_tests")
+#define UNIT_TESTS_FOLDER EXT_PATH("unit_tests")
+
+// This macro is used to create a path for unit tests files
+// We guarantee that the unit_tests folder is always exists
 #define UNIT_TESTS_PATH(path) UNIT_TESTS_FOLDER "/" path

--- a/applications/debug/unit_tests/unit_tests.h
+++ b/applications/debug/unit_tests/unit_tests.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <storage/storage.h>
+#include "minunit.h"
+
+#define UNIT_TESTS_FOLDER     EXT_PATH("unit_tests")
+#define UNIT_TESTS_PATH(path) UNIT_TESTS_FOLDER "/" path

--- a/applications/services/audio/application.fam
+++ b/applications/services/audio/application.fam
@@ -4,7 +4,7 @@ App(
     apptype=FlipperAppType.SERVICE,
     entry_point="audio_srv",
     cdefines=["SRV_AUDIO"],
-    stack_size=1 * 1024,
+    stack_size=2 * 1024,
     order=80,
     # sdk_headers=["audio.h"],
 )

--- a/applications/services/audio/audio.c
+++ b/applications/services/audio/audio.c
@@ -6,6 +6,7 @@
 #include <api_lock.h>
 
 #include <storage/storage.h>
+#include <json_helper.h>
 
 #define TAG "Audio"
 
@@ -15,6 +16,8 @@
 #define AUDIO_VOLUME_MIN     (0.0F)
 #define AUDIO_VOLUME_MAX     (1.0F)
 #define AUDIO_VOLUME_DEFAULT (AUDIO_VOLUME_MAX)
+
+#define AUDIO_CONFIG_FILE APP_DATA_PATH("audio.json")
 
 typedef enum {
     AudioBufferIndexPing = (1UL << FuriHalSaiEventHalfTransfer),
@@ -165,6 +168,7 @@ static void audio_message_queue_callback(FuriEventLoopObject* object, void* cont
         instance->should_stop = true;
     } else if(msg.type == AudioMessageTypeSetVolume) {
         instance->volume = msg.volume;
+        json_config_write_single_number(AUDIO_CONFIG_FILE, "volume", instance->volume);
     } else {
         furi_crash("Invalid message type");
     }
@@ -210,7 +214,10 @@ static Audio* audio_alloc(void) {
     instance->message_queue = furi_message_queue_alloc(AUDIO_MAX_MESSAGES, sizeof(AudioMessage));
     instance->storage = furi_record_open(RECORD_STORAGE);
     instance->file = storage_file_alloc(instance->storage);
-    instance->volume = AUDIO_VOLUME_DEFAULT;
+
+    float default_volume = AUDIO_VOLUME_DEFAULT;
+    json_config_read_single_number(
+        AUDIO_CONFIG_FILE, "volume", &instance->volume, &default_volume);
 
     furi_event_loop_subscribe_message_queue(
         instance->event_loop,

--- a/applications/services/back_display/back_display.c
+++ b/applications/services/back_display/back_display.c
@@ -3,8 +3,12 @@
 #include <ssd1320/ssd1320.h>
 #include <light_sensor/light_sensor.h>
 #include "back_display.h"
+#include <storage/storage.h>
+#include <json_helper.h>
 
 #define TAG "BackDisplaySrv"
+
+#define DISPLAY_CONFIG_FILE APP_DATA_PATH("config.json")
 
 // Contrast curve parameters
 #define CONTRAST_CURVE_BASE        (1.324264735f)
@@ -24,6 +28,7 @@ typedef enum {
     BackDisplayEventDraw = 1 << 0,
     BackDisplayEventTearing = 1 << 1,
     BackDisplayEventLightLevelUpdate = 1 << 2,
+    BackDisplayEventSaveConfig = 1 << 3,
 } BackDisplayEvent;
 
 struct BackDisplaySrv {
@@ -37,7 +42,8 @@ struct BackDisplaySrv {
     bool dirty;
 
     FuriPubSub* light_sensor_events;
-    uint8_t sensor_contrast, brightness_override;
+    uint8_t sensor_contrast;
+    int brightness_override;
 };
 
 static uint8_t back_display_sensor_level_to_contrast(uint8_t level) {
@@ -121,6 +127,11 @@ static void back_display_event_callback(uint32_t events, void* context) {
     if(events & BackDisplayEventLightLevelUpdate) {
         back_display_update_brightness(instance);
     }
+
+    if(events & BackDisplayEventSaveConfig) {
+        json_config_write_single_int(
+            DISPLAY_CONFIG_FILE, "brightness", instance->brightness_override);
+    }
 }
 
 static void back_display_tearing_callback(void* context) {
@@ -141,7 +152,10 @@ static BackDisplaySrv* back_display_alloc(void) {
     instance->draw_buffer = instance->data[1];
     instance->dirty = false;
 
-    instance->brightness_override = BACK_DISPLAY_BRIGHTNESS_AUTO;
+    int default_brightness = BACK_DISPLAY_BRIGHTNESS_AUTO;
+    json_config_read_single_int(
+        DISPLAY_CONFIG_FILE, "brightness", &instance->brightness_override, &default_brightness);
+
     instance->sensor_contrast = back_display_sensor_level_to_contrast(0);
 
 #if defined(SRV_LIGHT_SENSOR)
@@ -190,7 +204,8 @@ void back_display_set_brightness(BackDisplaySrv* instance, uint8_t brightness) {
     furi_check(instance);
 
     instance->brightness_override = brightness;
-    furi_event_loop_set_custom_event(instance->event_loop, BackDisplayEventLightLevelUpdate);
+    furi_event_loop_set_custom_event(
+        instance->event_loop, BackDisplayEventLightLevelUpdate | BackDisplayEventSaveConfig);
 }
 
 uint8_t back_display_get_brightness(BackDisplaySrv* instance) {

--- a/applications/services/front_display/front_display.c
+++ b/applications/services/front_display/front_display.c
@@ -5,9 +5,12 @@
 #include <power/power_service/power.h>
 #include <light_sensor/light_sensor.h>
 
+#include <storage/storage.h>
+#include <json_helper.h>
+
 #define TAG "FrontDisplaySrv"
 
-#define REFRESH_PERIOD_MS (100)
+#define DISPLAY_CONFIG_FILE APP_DATA_PATH("config.json")
 
 #define AUTO_BRIGHTNESS_MIN_LEVEL (25)
 #define AUTO_BRIGHTNESS_MAX_LEVEL (100)
@@ -23,7 +26,8 @@
 #endif
 
 struct FrontDisplaySrv {
-    uint32_t sensor_level, brightness_override;
+    uint32_t sensor_level;
+    int brightness_override;
     Power* power;
     FuriEventLoop* event_loop;
     FuriMessageQueue* message_queue;
@@ -250,6 +254,8 @@ static void front_display_message_queue_callback(FuriEventLoopObject* object, vo
         break;
     case FrontDisplayMessageTypeBrightness:
         display->brightness_override = message.brightness;
+        json_config_write_single_int(
+            DISPLAY_CONFIG_FILE, "brightness", display->brightness_override);
         {
             uint32_t brightness =
                 front_display_get_brightness(display->brightness_override, display->sensor_level);
@@ -293,7 +299,10 @@ static void front_display_message_queue_callback(FuriEventLoopObject* object, vo
 static FrontDisplaySrv* front_display_alloc(void) {
     FrontDisplaySrv* instance = malloc(sizeof(FrontDisplaySrv));
 
-    instance->brightness_override = FRONT_DISPLAY_BRIGHTNESS_AUTO;
+    int default_brightness = FRONT_DISPLAY_BRIGHTNESS_AUTO;
+    json_config_read_single_int(
+        DISPLAY_CONFIG_FILE, "brightness", &instance->brightness_override, &default_brightness);
+
     instance->sensor_level = 0;
 
     instance->event_loop = furi_event_loop_alloc();

--- a/lib/toolbox/json_helper.c
+++ b/lib/toolbox/json_helper.c
@@ -181,8 +181,11 @@ JsonConfigStatus
     return status;
 }
 
-JsonConfigStatus
-    json_config_read_str(JsonConfig* inst, const char* key, char** val, char* val_default) {
+JsonConfigStatus json_config_read_str(
+    JsonConfig* inst,
+    const char* key,
+    FuriString* val,
+    const char* val_default) {
     furi_assert(inst);
     furi_assert(inst->root);
     furi_assert(key);
@@ -193,7 +196,7 @@ JsonConfigStatus
 
     if(item) {
         if(cJSON_IsString(item)) {
-            *val = item->valuestring;
+            furi_string_set(val, item->valuestring);
         } else {
             status = JsonConfigStatusMissing;
         }
@@ -203,7 +206,7 @@ JsonConfigStatus
 
     if((status == JsonConfigStatusMissing) && (val_default)) {
         json_config_write_str(inst, key, val_default);
-        *val = val_default;
+        furi_string_set(val, val_default);
     }
 
     return status;
@@ -318,19 +321,20 @@ JsonConfigStatus
     return status;
 }
 
-JsonConfigStatus
-    json_config_read_single_str(char* file_path, const char* key, char** val, char* val_default) {
+JsonConfigStatus json_config_read_single_str(
+    char* file_path,
+    const char* key,
+    FuriString* val,
+    const char* val_default) {
     JsonConfigStatus status = JsonConfigStatusOk;
 
     JsonConfig* cfg = json_config_alloc();
     status = json_config_open(cfg, file_path);
     if(status != JsonConfigStatusError) {
-        char* str_temp = NULL;
-        status = json_config_read_str(cfg, key, &str_temp, val_default);
-        *val = strdup(str_temp);
+        status = json_config_read_str(cfg, key, val, val_default);
     } else {
         if(val_default) {
-            *val = strdup(val_default);
+            furi_string_set(val, val_default);
         }
     }
     json_config_free(cfg);

--- a/lib/toolbox/json_helper.c
+++ b/lib/toolbox/json_helper.c
@@ -1,0 +1,393 @@
+#include "json_helper.h"
+#include <storage/storage.h>
+#include <cjson/cJSON.h>
+
+struct JsonConfig {
+    char* file_path;
+    cJSON* root;
+    bool write_pending;
+};
+
+JsonConfig* json_config_alloc(void) {
+    JsonConfig* inst = malloc(sizeof(JsonConfig));
+    return inst;
+}
+
+JsonConfigStatus json_config_free(JsonConfig* inst) {
+    JsonConfigStatus status = JsonConfigStatusOk;
+
+    if(inst->write_pending) {
+        Storage* storage = furi_record_open(RECORD_STORAGE);
+        File* file = storage_file_alloc(storage);
+
+        if(storage_file_open(file, inst->file_path, FSAM_WRITE, FSOM_CREATE_ALWAYS)) {
+            char* buffer = cJSON_Print(inst->root);
+            if(buffer) {
+                size_t buffer_len = strlen(buffer);
+                size_t bytes_written = storage_file_write(file, buffer, buffer_len);
+                if(buffer_len != bytes_written) {
+                    status = JsonConfigStatusError;
+                }
+            }
+            free(buffer);
+        } else {
+            status = JsonConfigStatusError;
+        }
+
+        storage_file_free(file);
+        furi_record_close(RECORD_STORAGE);
+    }
+
+    if(inst->file_path) {
+        free(inst->file_path);
+    }
+    if(inst->root) {
+        cJSON_Delete(inst->root);
+    }
+    free(inst);
+
+    return status;
+}
+
+JsonConfigStatus json_config_open(JsonConfig* inst, const char* file_path) {
+    furi_assert(inst);
+    furi_assert(file_path);
+    furi_assert(inst->file_path == NULL);
+
+    inst->file_path = strdup(file_path);
+
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    File* file = storage_file_alloc(storage);
+
+    JsonConfigStatus status = JsonConfigStatusOk;
+    do {
+        if(!storage_file_open(file, file_path, FSAM_READ_WRITE, FSOM_OPEN_ALWAYS)) {
+            status = JsonConfigStatusError;
+            break;
+        }
+
+        const size_t file_size = storage_file_size(file);
+        if(file_size == 0) {
+            inst->root = cJSON_CreateObject();
+            inst->write_pending = true;
+            status = JsonConfigStatusMissing;
+            break;
+        }
+
+        char* buffer = malloc(file_size + 1);
+        if(storage_file_read(file, buffer, file_size) != file_size) {
+            status = JsonConfigStatusError;
+            free(buffer);
+            break;
+        }
+
+        inst->root = cJSON_Parse(buffer);
+        if(!inst->root) {
+            inst->root = cJSON_CreateObject();
+            inst->write_pending = true;
+            status = JsonConfigStatusMissing;
+        }
+        free(buffer);
+
+    } while(false);
+
+    storage_file_free(file);
+    furi_record_close(RECORD_STORAGE);
+
+    return status;
+}
+
+JsonConfigStatus
+    json_config_read_int(JsonConfig* inst, const char* key, int* val, int* val_default) {
+    furi_assert(inst);
+    furi_assert(inst->root);
+    furi_assert(key);
+    furi_assert(val);
+
+    JsonConfigStatus status = JsonConfigStatusOk;
+    cJSON* item = cJSON_GetObjectItem(inst->root, key);
+
+    if(item) {
+        if(cJSON_IsNumber(item)) {
+            *val = item->valueint;
+        } else {
+            status = JsonConfigStatusMissing;
+        }
+    } else {
+        status = JsonConfigStatusMissing;
+    }
+
+    if((status == JsonConfigStatusMissing) && (val_default)) {
+        json_config_write_int(inst, key, *val_default);
+        *val = *val_default;
+    }
+
+    return status;
+}
+
+JsonConfigStatus
+    json_config_read_number(JsonConfig* inst, const char* key, float* val, float* val_default) {
+    furi_assert(inst);
+    furi_assert(inst->root);
+    furi_assert(key);
+    furi_assert(val);
+
+    JsonConfigStatus status = JsonConfigStatusOk;
+    cJSON* item = cJSON_GetObjectItem(inst->root, key);
+
+    if(item) {
+        if(cJSON_IsNumber(item)) {
+            *val = (float)item->valuedouble;
+        } else {
+            status = JsonConfigStatusMissing;
+        }
+    } else {
+        status = JsonConfigStatusMissing;
+    }
+
+    if((status == JsonConfigStatusMissing) && (val_default)) {
+        json_config_write_number(inst, key, *val_default);
+        *val = *val_default;
+    }
+
+    return status;
+}
+
+JsonConfigStatus
+    json_config_read_bool(JsonConfig* inst, const char* key, bool* val, bool* val_default) {
+    furi_assert(inst);
+    furi_assert(inst->root);
+    furi_assert(key);
+    furi_assert(val);
+
+    JsonConfigStatus status = JsonConfigStatusOk;
+    cJSON* item = cJSON_GetObjectItem(inst->root, key);
+
+    if(item) {
+        if(cJSON_IsBool(item)) {
+            *val = cJSON_IsTrue(item);
+        } else {
+            status = JsonConfigStatusMissing;
+        }
+    } else {
+        status = JsonConfigStatusMissing;
+    }
+
+    if((status == JsonConfigStatusMissing) && (val_default)) {
+        json_config_write_bool(inst, key, *val_default);
+        *val = *val_default;
+    }
+
+    return status;
+}
+
+JsonConfigStatus
+    json_config_read_str(JsonConfig* inst, const char* key, char** val, char* val_default) {
+    furi_assert(inst);
+    furi_assert(inst->root);
+    furi_assert(key);
+    furi_assert(val);
+
+    JsonConfigStatus status = JsonConfigStatusOk;
+    cJSON* item = cJSON_GetObjectItem(inst->root, key);
+
+    if(item) {
+        if(cJSON_IsString(item)) {
+            *val = item->string;
+        } else {
+            status = JsonConfigStatusMissing;
+        }
+    } else {
+        status = JsonConfigStatusMissing;
+    }
+
+    if((status == JsonConfigStatusMissing) && (val_default)) {
+        json_config_write_str(inst, key, val_default);
+        *val = val_default;
+    }
+
+    return status;
+}
+
+JsonConfigStatus json_config_write_int(JsonConfig* inst, const char* key, int val) {
+    furi_assert(inst);
+    furi_assert(inst->root);
+    furi_assert(key);
+    JsonConfigStatus status = JsonConfigStatusOk;
+
+    cJSON_DeleteItemFromObject(inst->root, key);
+    cJSON_AddNumberToObject(inst->root, key, val);
+    inst->write_pending = true;
+
+    return status;
+}
+
+JsonConfigStatus json_config_write_number(JsonConfig* inst, const char* key, float val) {
+    furi_assert(inst);
+    furi_assert(inst->root);
+    furi_assert(key);
+    JsonConfigStatus status = JsonConfigStatusOk;
+
+    cJSON_DeleteItemFromObject(inst->root, key);
+    cJSON_AddNumberToObject(inst->root, key, (double)val);
+    inst->write_pending = true;
+
+    return status;
+}
+
+JsonConfigStatus json_config_write_bool(JsonConfig* inst, const char* key, bool val) {
+    furi_assert(inst);
+    furi_assert(inst->root);
+    furi_assert(key);
+    JsonConfigStatus status = JsonConfigStatusOk;
+
+    cJSON_DeleteItemFromObject(inst->root, key);
+    cJSON_AddBoolToObject(inst->root, key, val);
+    inst->write_pending = true;
+
+    return status;
+}
+
+JsonConfigStatus json_config_write_str(JsonConfig* inst, const char* key, const char* val) {
+    furi_assert(inst);
+    furi_assert(inst->root);
+    furi_assert(key);
+    JsonConfigStatus status = JsonConfigStatusOk;
+
+    cJSON_DeleteItemFromObject(inst->root, key);
+    cJSON_AddStringToObject(inst->root, key, val);
+    inst->write_pending = true;
+
+    return status;
+}
+
+JsonConfigStatus
+    json_config_read_single_int(char* file_path, char* key, int* val, int* val_default) {
+    JsonConfigStatus status = JsonConfigStatusOk;
+
+    JsonConfig* cfg = json_config_alloc();
+    status = json_config_open(cfg, file_path);
+    if(status != JsonConfigStatusError) {
+        status = json_config_read_int(cfg, key, val, val_default);
+    } else {
+        if(val_default) {
+            *val = *val_default;
+        }
+    }
+    json_config_free(cfg);
+
+    return status;
+}
+
+JsonConfigStatus json_config_read_single_number(
+    char* file_path,
+    const char* key,
+    float* val,
+    float* val_default) {
+    JsonConfigStatus status = JsonConfigStatusOk;
+
+    JsonConfig* cfg = json_config_alloc();
+    status = json_config_open(cfg, file_path);
+    if(status != JsonConfigStatusError) {
+        status = json_config_read_number(cfg, key, val, val_default);
+    } else {
+        if(val_default) {
+            *val = *val_default;
+        }
+    }
+    json_config_free(cfg);
+
+    return status;
+}
+
+JsonConfigStatus
+    json_config_read_single_bool(char* file_path, const char* key, bool* val, bool* val_default) {
+    JsonConfigStatus status = JsonConfigStatusOk;
+
+    JsonConfig* cfg = json_config_alloc();
+    status = json_config_open(cfg, file_path);
+    if(status != JsonConfigStatusError) {
+        status = json_config_read_bool(cfg, key, val, val_default);
+    } else {
+        if(val_default) {
+            *val = *val_default;
+        }
+    }
+    json_config_free(cfg);
+
+    return status;
+}
+
+JsonConfigStatus
+    json_config_read_single_str(char* file_path, const char* key, char** val, char* val_default) {
+    JsonConfigStatus status = JsonConfigStatusOk;
+
+    JsonConfig* cfg = json_config_alloc();
+    status = json_config_open(cfg, file_path);
+    if(status != JsonConfigStatusError) {
+        status = json_config_read_str(cfg, key, val, val_default);
+    } else {
+        if(val_default) {
+            *val = val_default;
+        }
+    }
+    json_config_free(cfg);
+
+    return status;
+}
+
+JsonConfigStatus json_config_write_single_int(char* file_path, char* key, int val) {
+    JsonConfigStatus status = JsonConfigStatusOk;
+
+    JsonConfig* cfg = json_config_alloc();
+    status = json_config_open(cfg, file_path);
+    if(status != JsonConfigStatusError) {
+        json_config_write_int(cfg, key, val);
+        return json_config_free(cfg);
+    }
+    json_config_free(cfg);
+
+    return status;
+}
+
+JsonConfigStatus json_config_write_single_number(char* file_path, const char* key, float val) {
+    JsonConfigStatus status = JsonConfigStatusOk;
+
+    JsonConfig* cfg = json_config_alloc();
+    status = json_config_open(cfg, file_path);
+    if(status != JsonConfigStatusError) {
+        json_config_write_number(cfg, key, val);
+        return json_config_free(cfg);
+    }
+    json_config_free(cfg);
+
+    return status;
+}
+
+JsonConfigStatus json_config_write_single_bool(char* file_path, const char* key, bool val) {
+    JsonConfigStatus status = JsonConfigStatusOk;
+
+    JsonConfig* cfg = json_config_alloc();
+    status = json_config_open(cfg, file_path);
+    if(status != JsonConfigStatusError) {
+        json_config_write_bool(cfg, key, val);
+        return json_config_free(cfg);
+    }
+    json_config_free(cfg);
+
+    return status;
+}
+
+JsonConfigStatus json_config_write_single_str(char* file_path, const char* key, const char* val) {
+    JsonConfigStatus status = JsonConfigStatusOk;
+
+    JsonConfig* cfg = json_config_alloc();
+    status = json_config_open(cfg, file_path);
+    if(status != JsonConfigStatusError) {
+        json_config_write_str(cfg, key, val);
+        return json_config_free(cfg);
+    }
+    json_config_free(cfg);
+
+    return status;
+}

--- a/lib/toolbox/json_helper.c
+++ b/lib/toolbox/json_helper.c
@@ -193,7 +193,7 @@ JsonConfigStatus
 
     if(item) {
         if(cJSON_IsString(item)) {
-            *val = item->string;
+            *val = item->valuestring;
         } else {
             status = JsonConfigStatusMissing;
         }
@@ -325,10 +325,12 @@ JsonConfigStatus
     JsonConfig* cfg = json_config_alloc();
     status = json_config_open(cfg, file_path);
     if(status != JsonConfigStatusError) {
-        status = json_config_read_str(cfg, key, val, val_default);
+        char* str_temp = NULL;
+        status = json_config_read_str(cfg, key, &str_temp, val_default);
+        *val = strdup(str_temp);
     } else {
         if(val_default) {
-            *val = val_default;
+            *val = strdup(val_default);
         }
     }
     json_config_free(cfg);

--- a/lib/toolbox/json_helper.h
+++ b/lib/toolbox/json_helper.h
@@ -85,7 +85,7 @@ JsonConfigStatus
  * If value is missing, it will be written to default value (if val_default != NULL)
  * @param a pointer to the config instance.
  * @param object name.
- * @param a pointer to store the value.
+ * @param a pointer to store the string, valid untill the json_config_free or the next object modification
  * @param a pointer to default value (set to NULL to bypass default value write).
  * @return Operation status (JsonConfigStatus).
  */
@@ -180,7 +180,7 @@ JsonConfigStatus
  * If value is missing, it will be written to default value (if val_default != NULL)
  * @param a file path string.
  * @param object name.
- * @param a pointer to store the value.
+ * @param a pointer to store the string, you have to free it after use.
  * @param a pointer to default value (set to NULL to bypass default value write).
  * @return Operation status (JsonConfigStatus).
  */

--- a/lib/toolbox/json_helper.h
+++ b/lib/toolbox/json_helper.h
@@ -1,0 +1,231 @@
+#pragma once
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    JsonConfigStatusOk,
+    JsonConfigStatusMissing, /**< File or JSON object is missing, was created/set to default (if enabled) */
+    JsonConfigStatusError, /**< FS error */
+} JsonConfigStatus;
+
+typedef struct JsonConfig JsonConfig;
+
+/**
+ * @brief Allocate and initialize a config instance.
+ *
+ * @return pointer to the created instance.
+ */
+JsonConfig* json_config_alloc(void);
+
+/**
+ * @brief Free the config instance.
+ *
+ * If some changes were made using json_config_write_x, this function will write changes to the file.
+ * @param a pointer to the instance to be freed.
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus json_config_free(JsonConfig* inst);
+
+/**
+ * @brief Load config from a file.
+ *
+ * @param a pointer to the config instance.
+ * @param a file path string.
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus json_config_open(JsonConfig* inst, const char* file_path);
+
+/**
+ * @brief Read an integer value.
+ * 
+ * If value is missing, it will be written to default value (if val_default != NULL)
+ * @param a pointer to the config instance.
+ * @param object name.
+ * @param a pointer to store the value.
+ * @param a pointer to default value (set to NULL to bypass default value write).
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus
+    json_config_read_int(JsonConfig* inst, const char* key, int* val, int* val_default);
+
+/**
+ * @brief Read a number (float) value.
+ * 
+ * If value is missing, it will be written to default value (if val_default != NULL)
+ * @param a pointer to the config instance.
+ * @param object name.
+ * @param a pointer to store the value.
+ * @param a pointer to default value (set to NULL to bypass default value write).
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus
+    json_config_read_number(JsonConfig* inst, const char* key, float* val, float* val_default);
+
+/**
+ * @brief Read a boolean value.
+ * 
+ * If value is missing, it will be written to default value (if val_default != NULL)
+ * @param a pointer to the config instance.
+ * @param object name.
+ * @param a pointer to store the value.
+ * @param a pointer to default value (set to NULL to bypass default value write).
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus
+    json_config_read_bool(JsonConfig* inst, const char* key, bool* val, bool* val_default);
+
+/**
+ * @brief Read a string value.
+ * 
+ * If value is missing, it will be written to default value (if val_default != NULL)
+ * @param a pointer to the config instance.
+ * @param object name.
+ * @param a pointer to store the value.
+ * @param a pointer to default value (set to NULL to bypass default value write).
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus
+    json_config_read_str(JsonConfig* inst, const char* key, char** val, char* val_default);
+
+/**
+ * @brief Write an integer value.
+ * 
+ * @param a pointer to the config instance.
+ * @param object name.
+ * @param value to write.
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus json_config_write_int(JsonConfig* inst, const char* key, int val);
+
+/**
+ * @brief Write a number (float) value.
+ * 
+ * @param a pointer to the config instance.
+ * @param object name.
+ * @param value to write.
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus json_config_write_number(JsonConfig* inst, const char* key, float val);
+
+/**
+ * @brief Write a boolean value.
+ * 
+ * @param a pointer to the config instance.
+ * @param object name.
+ * @param value to write.
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus json_config_write_bool(JsonConfig* inst, const char* key, bool val);
+
+/**
+ * @brief Write a string.
+ * 
+ * @param a pointer to the config instance.
+ * @param object name.
+ * @param value to write.
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus json_config_write_str(JsonConfig* inst, const char* key, const char* val);
+
+/**
+ * @brief Read an integer value - simpler version for a single value.
+ * 
+ * If value is missing, it will be written to default value (if val_default != NULL)
+ * @param a file path string.
+ * @param object name.
+ * @param a pointer to store the value.
+ * @param a pointer to default value (set to NULL to bypass default value write).
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus
+    json_config_read_single_int(char* file_path, char* key, int* val, int* val_default);
+
+/**
+ * @brief Read a number (float) value - simpler version for a single value.
+ * 
+ * If value is missing, it will be written to default value (if val_default != NULL)
+ * @param a file path string.
+ * @param object name.
+ * @param a pointer to store the value.
+ * @param a pointer to default value (set to NULL to bypass default value write).
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus json_config_read_single_number(
+    char* file_path,
+    const char* key,
+    float* val,
+    float* val_default);
+
+/**
+ * @brief Read a boolean value - simpler version for a single value.
+ * 
+ * If value is missing, it will be written to default value (if val_default != NULL)
+ * @param a file path string.
+ * @param object name.
+ * @param a pointer to store the value.
+ * @param a pointer to default value (set to NULL to bypass default value write).
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus
+    json_config_read_single_bool(char* file_path, const char* key, bool* val, bool* val_default);
+
+/**
+ * @brief Read a string value - simpler version for a single value.
+ * 
+ * If value is missing, it will be written to default value (if val_default != NULL)
+ * @param a file path string.
+ * @param object name.
+ * @param a pointer to store the value.
+ * @param a pointer to default value (set to NULL to bypass default value write).
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus
+    json_config_read_single_str(char* file_path, const char* key, char** val, char* val_default);
+
+/**
+ * @brief Write an integer value - simpler version for a single value.
+ * 
+ * @param a file path string.
+ * @param object name.
+ * @param value to write.
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus json_config_write_single_int(char* file_path, char* key, int val);
+/**
+ * @brief Write a number (float) value - simpler version for a single value.
+ * 
+ * @param a file path string.
+ * @param object name.
+ * @param value to write.
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus json_config_write_single_number(char* file_path, const char* key, float val);
+
+/**
+ * @brief Write a boolean value - simpler version for a single value.
+ * 
+ * @param a file path string.
+ * @param object name.
+ * @param value to write.
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus json_config_write_single_bool(char* file_path, const char* key, bool val);
+
+/**
+ * @brief Write a string - simpler version for a single value.
+ * 
+ * @param a file path string.
+ * @param object name.
+ * @param value to write.
+ * @return Operation status (JsonConfigStatus).
+ */
+JsonConfigStatus json_config_write_single_str(char* file_path, const char* key, const char* val);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/toolbox/json_helper.h
+++ b/lib/toolbox/json_helper.h
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <furi/core/string.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -85,12 +86,15 @@ JsonConfigStatus
  * If value is missing, it will be written to default value (if val_default != NULL)
  * @param a pointer to the config instance.
  * @param object name.
- * @param a pointer to store the string, valid untill the json_config_free or the next object modification
+ * @param a FuriString pointer to valid and allocated string.
  * @param a pointer to default value (set to NULL to bypass default value write).
  * @return Operation status (JsonConfigStatus).
  */
-JsonConfigStatus
-    json_config_read_str(JsonConfig* inst, const char* key, char** val, char* val_default);
+JsonConfigStatus json_config_read_str(
+    JsonConfig* inst,
+    const char* key,
+    FuriString* val,
+    const char* val_default);
 
 /**
  * @brief Write an integer value.
@@ -180,12 +184,15 @@ JsonConfigStatus
  * If value is missing, it will be written to default value (if val_default != NULL)
  * @param a file path string.
  * @param object name.
- * @param a pointer to store the string, you have to free it after use.
+ * @param a FuriString pointer to valid and allocated string.
  * @param a pointer to default value (set to NULL to bypass default value write).
  * @return Operation status (JsonConfigStatus).
  */
-JsonConfigStatus
-    json_config_read_single_str(char* file_path, const char* key, char** val, char* val_default);
+JsonConfigStatus json_config_read_single_str(
+    char* file_path,
+    const char* key,
+    FuriString* val,
+    const char* val_default);
 
 /**
  * @brief Write an integer value - simpler version for a single value.


### PR DESCRIPTION
# What's new

- JSON config helper for simple config files
- Storing settings for displays, audio

# Verification 

- Change audio volume and displays brightness using HTTP API
- Reset device, check settings values

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
