### PR TITLE
[FL- 230] Fix updater to work with f21 target

### DIFF
--- a/targets/f21/target.json
+++ b/targets/f21/target.json
@@ -2,6 +2,7 @@
     "inherit": "f20",
     "sources": [
         "*/*.c",
-        "f20:!furi_hal/furi_hal_resources_pins.c"
+        "f20:!furi_hal/furi_hal_resources_pins.c",
+        "f20:!furi_hal/furi_hal_version_device.c"
     ]
 }


### PR DESCRIPTION
# What's new

- Override f20 furi_hal_version_device implementation for f21

# Verification 

- Updater works correctly

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
