### PR TITLE
Service class UUID added to BLE advertisement packet

### DIFF
--- a/applications/services/ble/worker/ble_advertise_config.c
+++ b/applications/services/ble/worker/ble_advertise_config.c
@@ -21,6 +21,11 @@ const BleAdvertiseConfig advertise_config = {
             .header = {.type = 0xFF, .length = 3},
             .data = 0x0E29,
         },
+    .service_class =
+        {
+            .header = {.type = 0x02, .length = 3},
+            .data = 0x308A,
+        },
 };
 
 static_assert(sizeof(advertise_config) <= BLE_ADVERTISE_PACKET_MAX_SIZE);

--- a/applications/services/ble/worker/ble_advertise_config.h
+++ b/applications/services/ble/worker/ble_advertise_config.h
@@ -26,10 +26,16 @@ typedef struct FURI_PACKED {
 } BleAdvertiseLocalName;
 
 typedef struct FURI_PACKED {
+    BleAdvertiseHeader header;
+    uint16_t data;
+} BleAdvertiseServiceClassUUID;
+
+typedef struct FURI_PACKED {
     BleAdvertiseByteData flags;
     BleAdvertiseWordData appearance;
     BleAdvertiseLocalName local_name;
     BleAdvertiseWordData manufacturer;
+    BleAdvertiseServiceClassUUID service_class;
 } BleAdvertiseConfig;
 
 extern const BleAdvertiseConfig advertise_config;


### PR DESCRIPTION
# What's new

- [ Describe changes here ]

# Verification 

- Start BLE over http api
- Scan and find busybar with BLE Scanner from mobile phone
- New field `Service class UUID` with value `0x308A` should appear in advertise information

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
