### PR TITLE
Matter: fix premature nvm access

### DIFF
--- a/applications/services/matter/matter.cpp
+++ b/applications/services/matter/matter.cpp
@@ -34,7 +34,7 @@ static void matter_wait_for_network(void) {
 
     FuriSemaphore* wifi_sem = furi_semaphore_alloc(1, 0);
 
-    FuriPubSubSubscription* sub = furi_pubsub_subscribe(
+    furi_pubsub_subscribe(
         wifi_pubsub,
         [](const void* message, void* context) {
             const auto state = *(static_cast<const WifiState*>(message));

--- a/applications/services/matter/matter.cpp
+++ b/applications/services/matter/matter.cpp
@@ -34,7 +34,7 @@ static void matter_wait_for_network(void) {
 
     FuriSemaphore* wifi_sem = furi_semaphore_alloc(1, 0);
 
-    furi_pubsub_subscribe(
+    FuriPubSubSubscription* sub = furi_pubsub_subscribe(
         wifi_pubsub,
         [](const void* message, void* context) {
             const auto state = *(static_cast<const WifiState*>(message));
@@ -47,7 +47,6 @@ static void matter_wait_for_network(void) {
         wifi_sem);
 
     furi_semaphore_acquire(wifi_sem, FuriWaitForever);
-    furi_semaphore_free(wifi_sem);
 
     // TODO: Find out why it doesn't work if connecting right away
     furi_delay_ms(3000);
@@ -62,6 +61,9 @@ private:
 };
 
 CHIP_ERROR MatterSrv::init(void) {
+    // TODO: Implement proper network handling
+    matter_wait_for_network();
+
     CHIP_ERROR err;
 
     do {
@@ -74,9 +76,6 @@ CHIP_ERROR MatterSrv::init(void) {
         if(err != CHIP_NO_ERROR) {
             break;
         }
-
-        // TODO: Implement proper network handling
-        matter_wait_for_network();
 
         StackLock lock;
 


### PR DESCRIPTION
# What's new

- Fix nvm access before sl_net_init() call

# Verification 

- Flash the Wireless firmware (on a f21 target)
- Disable wi-fi in settings
- Reboot the device. No crash should occur.
- Connect to wi-fi. No crash should occur.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
