### PR TITLE
[FW-291] Wait for initial absolute state to arrive

### DIFF
--- a/applications/services/input/input.c
+++ b/applications/services/input/input.c
@@ -9,13 +9,20 @@
 #include <intercom/intercom.h>
 #endif
 
+#define TAG "Input"
+
 #define INPUT_PRESS_TICKS       150
 #define INPUT_LONG_PRESS_COUNTS 2
+#define ABS_STATE_WAIT_TIMEOUT  furi_ms_to_ticks(500)
 
 #define INPUT_KEY_PRESS(key)   (1UL << key)
 #define INPUT_KEY_RELEASE(key) (1UL << (key + InputKeyMAX))
 
 #define INPUT_REQUEST_QUEUE_SIZE 4
+
+typedef enum {
+    InputApiEventAbsStateAvailable = (1 << 0), // <! Absolute state can be queried now
+} InputApiEvent;
 
 /** Input pin state */
 typedef struct {
@@ -28,9 +35,12 @@ typedef struct {
 
 /** Input state */
 struct Input {
-    FuriPubSub* event_pubsub;
     FuriEventLoop* event_loop;
+
+    FuriPubSub* event_pubsub;
     FuriMessageQueue* request_queue;
+    FuriEventFlag* event_flag;
+
     InputPinState* pin_states;
     volatile uint32_t sequence;
     InputAbsoluteState absolute_state;
@@ -189,12 +199,9 @@ static void input_custom_event_callback(uint32_t events, void* context) {
 }
 
 #ifdef SRV_INTERCOM
-static void input_intercom_rx_callback(const void* data, size_t data_size, void* context) {
-    furi_assert(context);
-    furi_assert(data_size == sizeof(InputCommonEvent));
-
-    Input* input = context;
-    const InputCommonEvent* event = data;
+static void input_handle_intercom_input(Input* input, const InputCommonEventInput* event) {
+    furi_assert(input);
+    furi_assert(event);
 
     if(event->device == InputDeviceButton) {
         const InputKey key = event->button_event.button + InputKeyOk;
@@ -212,6 +219,38 @@ static void input_intercom_rx_callback(const void* data, size_t data_size, void*
     } else if(event->device == InputDeviceEncoder) {
         const InputKey key = event->encoder_delta > 0 ? InputKeyUp : InputKeyDown;
         input_key_toggle(input, key);
+
+    } else {
+        furi_crash();
+    }
+}
+
+static void
+    input_handle_intercom_abs_send_done(Input* input, const InputCommonEventAbsSendDone* event) {
+    furi_assert(input);
+    furi_assert(event);
+
+    uint32_t flags = furi_event_flag_set(input->event_flag, InputApiEventAbsStateAvailable);
+    furi_check(!(flags & FuriFlagError));
+}
+
+static void input_intercom_rx_callback(const void* data, size_t data_size, void* context) {
+    furi_assert(context);
+    furi_assert(data_size == sizeof(InputCommonEvent));
+
+    Input* input = context;
+    const InputCommonEvent* event = data;
+
+    if(event->packet_type == InputPacketTypeInput) {
+        const InputCommonEventInput* specific_event = &event->input;
+        input_handle_intercom_input(input, specific_event);
+
+    } else if(event->packet_type == InputPacketTypeAbsSendDone) {
+        const InputCommonEventAbsSendDone* specific_event = &event->abs_send_done;
+        input_handle_intercom_abs_send_done(input, specific_event);
+
+    } else {
+        furi_crash();
     }
 }
 #endif
@@ -248,6 +287,8 @@ int32_t input_srv(void* p) {
         FuriEventLoopEventIn,
         input_request_handler,
         input);
+
+    input->event_flag = furi_event_flag_alloc();
 
     furi_record_create(RECORD_INPUT_EVENTS, input->event_pubsub);
 
@@ -311,6 +352,15 @@ InputAbsoluteState input_get_absolute_state(Input* input) {
     InputRequest request = {
         .type = InputRequestTypeGetAbsState,
     };
+
+    uint32_t flags = furi_event_flag_wait(
+        input->event_flag, InputApiEventAbsStateAvailable, FuriFlagNoClear, ABS_STATE_WAIT_TIMEOUT);
+    if(flags == FuriFlagErrorTimeout) {
+        FURI_LOG_W(TAG, "Timed out waiting for absolute state");
+    } else {
+        furi_check(!(flags & FuriFlagError));
+    }
+
     input_synchronous_request(input, &request);
     return request.abs_state;
 }

--- a/applications/services/input/input_common_i.h
+++ b/applications/services/input/input_common_i.h
@@ -10,9 +10,14 @@
 extern "C" {
 #endif
 
-/**
- * @brief Input event coming from the input controller chip.
- */
+typedef enum {
+    InputPacketTypeInput, // <! Input event
+    InputPacketTypeAbsSendDone, // <! Done sending initial absolute state
+} InputPacketType;
+
+typedef struct {
+} InputCommonEventAbsSendDone;
+
 typedef struct {
     InputDevice device; /**< Identifier of the device that emitted the event */
     union {
@@ -22,6 +27,17 @@ typedef struct {
         } button_event; /**< Button event */
         InputSwitchPosition switch_position; /**< New mode switch position */
         int16_t encoder_delta; /**< Speed and direction of encoder rotation */
+    };
+} InputCommonEventInput;
+
+/**
+ * @brief Input event coming from the input controller chip.
+ */
+typedef struct {
+    InputPacketType packet_type;
+    union {
+        InputCommonEventAbsSendDone abs_send_done;
+        InputCommonEventInput input;
     };
 } InputCommonEvent;
 

--- a/applications/services/input/input_f64.c
+++ b/applications/services/input/input_f64.c
@@ -58,17 +58,18 @@ static void input_custom_event_callback(uint32_t events, void* context) {
 
 static void input_send(InputSrv* instance, const InputPin* pin, InputAction input_action) {
     InputCommonEvent event;
-    event.device = pin->device;
+    event.packet_type = InputPacketTypeInput;
+    event.input.device = pin->device;
 
     if(pin->device == InputDeviceSwitch) {
         if(input_action == InputActionPress) {
-            event.switch_position = pin->pos;
+            event.input.switch_position = pin->pos;
             furi_check(furi_message_queue_put(instance->input_queue, &event, 0) == FuriStatusOk);
         }
 
     } else {
-        event.button_event.button = pin->button;
-        event.button_event.action = input_action;
+        event.input.button_event.button = pin->button;
+        event.input.button_event.action = input_action;
         furi_check(furi_message_queue_put(instance->input_queue, &event, 0) == FuriStatusOk);
     }
 }
@@ -114,8 +115,12 @@ static void input_qei_callback(int16_t delta_pos, void* context) {
     InputSrv* instance = context;
 
     InputCommonEvent event = {
-        .device = InputDeviceEncoder,
-        .encoder_delta = delta_pos,
+        .packet_type = InputPacketTypeInput,
+        .input =
+            {
+                .device = InputDeviceEncoder,
+                .encoder_delta = delta_pos,
+            },
     };
 
     furi_check(furi_message_queue_put(instance->input_queue, &event, 0) == FuriStatusOk);
@@ -131,26 +136,33 @@ static void input_queue_callback(FuriEventLoopObject* object, void* context) {
 
 #ifdef INPUT_DEBUG
 
-    if(event.device == InputDeviceButton) {
-        const InputButton button = event.button_event.button;
-        const InputAction action = event.button_event.action;
+    if(event.packet_type == InputPacketTypeInput) {
+        const InputCommonEventInput* specific_event = &event.input;
 
-        const char* name = input_pins[button].name;
-        const char* action_str = action == InputActionPress ? "press" : "release";
+        if(specific_event->device == InputDeviceButton) {
+            const InputButton button = specific_event->button_event.button;
+            const InputAction action = specific_event->button_event.action;
 
-        INPUT_LOG("Key %s, event %s", name, action_str);
+            const char* name = input_pins[button].name;
+            const char* action_str = action == InputActionPress ? "press" : "release";
 
-    } else if(event.device == InputDeviceEncoder) {
-        INPUT_LOG("Encoder turn %d", event.encoder_delta);
+            INPUT_LOG("Key %s, event %s", name, action_str);
 
-    } else if(event.device == InputDeviceSwitch) {
-        const InputSwitchPosition pos = event.switch_position;
-        const char* name = input_pins[pos + InputButtonMAX].name;
+        } else if(specific_event->device == InputDeviceEncoder) {
+            INPUT_LOG("Encoder turn %d", specific_event->encoder_delta);
 
-        INPUT_LOG("Switch %s %d, event %s", name, pos, "press");
+        } else if(specific_event->device == InputDeviceSwitch) {
+            const InputSwitchPosition pos = specific_event->switch_position;
+            const char* name = input_pins[pos + InputButtonMAX].name;
 
-    } else {
-        furi_crash();
+            INPUT_LOG("Switch %s %d, event %s", name, pos, "press");
+
+        } else {
+            furi_crash();
+        }
+
+    } else if(event.packet_type == InputPacketTypeAbsSendDone) {
+        INPUT_LOG("Done sending initial absolute state");
     }
 
 #endif
@@ -199,6 +211,11 @@ int32_t input_srv(void* p) {
 
         furi_hal_gpio_add_int_callback(pin->gpio, pin->cond, input_isr_key, instance);
     }
+
+    InputCommonEvent abs_done_event = {
+        .packet_type = InputPacketTypeAbsSendDone,
+    };
+    furi_check(furi_message_queue_put(instance->input_queue, &abs_done_event, 0) == FuriStatusOk);
 
     furi_event_loop_set_custom_event_callback(
         instance->event_loop, input_custom_event_callback, instance);


### PR DESCRIPTION
# What's new
  - Timing bug fix for #206

# Verification 
  - Move mode switch to any position except BUSY and OFF (so, CUSTOM, APPS or SETTINGS)
  - Reset device (both MCUs)
  - Verify that the BUSY app is not shown intermittently (for <200 ms) on startup
  - Repeat for other positions of the switch, multiple times for each position

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
