### PR TITLE
[FW-311] BLE: change default name to BUSY Bar

### DIFF
--- a/applications/services/ble/worker/ble_advertise_config.h
+++ b/applications/services/ble/worker/ble_advertise_config.h
@@ -2,7 +2,7 @@
 
 #include <furi.h>
 
-#define BLE_LOCAL_NAME                "Busybar"
+#define BLE_LOCAL_NAME                "BUSY Bar"
 #define BLE_ADVERTISE_PACKET_MAX_SIZE (32)
 
 typedef struct FURI_PACKED {


### PR DESCRIPTION
# What's new

- changed default BLE advertise name to BUSY Bar

# Verification 

- default BLE advertise name is BUSY Bar

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
