### PR TITLE
fbt: default target=21, http client fixes

### DIFF
--- a/applications/debug/https_test/https_test.c
+++ b/applications/debug/https_test/https_test.c
@@ -56,7 +56,7 @@ static void http_test_mg_handler(struct mg_connection* connection, int event, vo
 
         mg_printf(
             connection,
-            "GET %s HTTP/1.1\r\nHost: %.*s\r\n\r\n",
+            "GET %s HTTP/1.0\r\nHost: %.*s\r\n\r\n",
             mg_url_uri(HTTP_URL),
             name.len,
             name.buf);

--- a/applications/system/fetch/helpers/fetch_client.c
+++ b/applications/system/fetch/helpers/fetch_client.c
@@ -141,7 +141,7 @@ static FURI_ALWAYS_INLINE void
 
     mg_printf(
         conn,
-        "GET %s HTTP/1.1\r\nHost: %.*s\r\nUser-Agent: %s\r\nAccept: */*\r\n\r\n",
+        "GET %s HTTP/1.0\r\nHost: %.*s\r\nUser-Agent: %s\r\nAccept: */*\r\n\r\n",
         mg_url_uri(furi_string_get_cstr(instance->url)),
         name.len,
         name.buf,

--- a/project.scons
+++ b/project.scons
@@ -6,7 +6,7 @@ commandline_vars = _instantiate_vars()
 
 commandline_vars.AddVariables(
     ("SIL_TARGET_HW", "Target definition for Silabs chip", "64"),
-    ("U5_TARGET_HW", "Target definition for STM32U5 chip", "20"),
+    ("U5_TARGET_HW", "Target definition for STM32U5 chip", "21"),
 )
 
 ###################


### PR DESCRIPTION
# What's new

- fbt: swiched default u5 target to 21
- http client: make requests as http/1.0

# Verification 

- check that `./fbt TARGET_HW=` builds f21 update bundle 
- check http client 

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
