### PR TITLE
run: set target f21 as default

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -14,7 +14,7 @@ DEVICE_IP_REF = "10.0.5.20"
 DEVICE_PORT = 23
 
 # Firmware U5:
-U5_TARGET_HW = 20   # Default, can be overridden by -t / --target option.
+U5_TARGET_HW = 21   # Default, can be overridden by -t / --target option.
 
 # Firmware SI917:
 SI_TARGET_HW = 64


### PR DESCRIPTION
# What's new

- set default target f21 for `./run`

# Verification 

- [ Describe how to verify changes ]

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
