### PR TITLE
[FW-307] Busyapp Reopens On Back Press

### DIFF
--- a/applications/main/busy/busy.c
+++ b/applications/main/busy/busy.c
@@ -32,10 +32,7 @@ static void busy_input_queue_callback(FuriEventLoopObject* object, void* context
     while(furi_message_queue_get(instance->input_queue, &event, 0) == FuriStatusOk) {
         if(event.type == InputTypeShort) {
             if(event.key == InputKeyBack) {
-                if(!scene_manager_handle_back_event(instance->scene_manager)) {
-                    furi_event_loop_stop(instance->event_loop);
-                    break;
-                }
+                scene_manager_handle_back_event(instance->scene_manager);
             }
         }
     }

--- a/applications/main/busy/scenes/busy_scene_start.c
+++ b/applications/main/busy/scenes/busy_scene_start.c
@@ -154,6 +154,8 @@ static bool busy_scene_start_on_event(const SceneManagerEvent* event, void* cont
         }
 
         consumed = true;
+    } else if(event->type == SceneManagerEventTypeBack) {
+        consumed = true;
     }
 
     return consumed;

--- a/applications/main/custom/custom.c
+++ b/applications/main/custom/custom.c
@@ -32,10 +32,7 @@ static void custom_input_queue_callback(FuriEventLoopObject* object, void* conte
     while(furi_message_queue_get(instance->input_queue, &event, 0) == FuriStatusOk) {
         if(event.type == InputTypeShort) {
             if(event.key == InputKeyBack) {
-                if(!scene_manager_handle_back_event(instance->scene_manager)) {
-                    furi_event_loop_stop(instance->event_loop);
-                    break;
-                }
+                scene_manager_handle_back_event(instance->scene_manager);
             }
         }
     }

--- a/applications/main/custom/scenes/custom_scene_start.c
+++ b/applications/main/custom/scenes/custom_scene_start.c
@@ -155,6 +155,8 @@ static bool custom_scene_start_on_event(const SceneManagerEvent* event, void* co
         }
 
         consumed = true;
+    } else if(event->type == SceneManagerEventTypeBack) {
+        consumed = true;
     }
 
     return consumed;

--- a/applications/system/apps_menu/apps_menu.c
+++ b/applications/system/apps_menu/apps_menu.c
@@ -40,12 +40,7 @@ static void apps_menu_input_queue_callback(FuriEventLoopObject* object, void* co
     while(furi_message_queue_get(app->input_queue, &event, 0) == FuriStatusOk) {
         if(event.type == InputTypeShort) {
             if(event.key == InputKeyBack) {
-                AppsMenuSceneId current_scene_id =
-                    scene_manager_get_current_scene_id(app->scene_manager);
-
-                if(current_scene_id != AppsMenuSceneIdStart) {
-                    scene_manager_handle_back_event(app->scene_manager);
-                }
+                scene_manager_handle_back_event(app->scene_manager);
             }
         }
     }

--- a/applications/system/apps_menu/scenes/apps_menu_scene_start.c
+++ b/applications/system/apps_menu/scenes/apps_menu_scene_start.c
@@ -213,7 +213,7 @@ static bool apps_menu_scene_start_on_event(const SceneManagerEvent* event, void*
         default:
             break;
         }
-
+    } else if(event->type == SceneManagerEventTypeBack) {
         consumed = true;
     }
 

--- a/applications/system/settings/scenes/settings_scene_start.c
+++ b/applications/system/settings/scenes/settings_scene_start.c
@@ -202,6 +202,8 @@ static bool settings_scene_start_on_event(const SceneManagerEvent* event, void* 
         default:
             break;
         }
+    } else if(event->type == SceneManagerEventTypeBack) {
+        consumed = true;
     }
 
     return consumed;

--- a/applications/system/settings/settings.c
+++ b/applications/system/settings/settings.c
@@ -34,12 +34,7 @@ static void settings_input_queue_callback(FuriEventLoopObject* object, void* con
     while(furi_message_queue_get(instance->input_queue, &event, 0) == FuriStatusOk) {
         if(event.type == InputTypeShort) {
             if(event.key == InputKeyBack) {
-                SettingsAppSceneId current_scene_id =
-                    scene_manager_get_current_scene_id(instance->scene_manager);
-
-                if(current_scene_id != SettingsAppSceneIdStart) {
-                    scene_manager_handle_back_event(instance->scene_manager);
-                }
+                scene_manager_handle_back_event(instance->scene_manager);
             }
         }
     }


### PR DESCRIPTION
# What's new

- busy & custom apps no longer react on back button press while on start scene

# Verification 

- busy & custom apps only react on back button press while on scenes except start one

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
