### PR TITLE
[FW-297] Updater: smoother progress

### DIFF
--- a/applications/system/updater/sl_updater.c
+++ b/applications/system/updater/sl_updater.c
@@ -62,6 +62,7 @@ struct SlUpdater {
 
 #define KERMIT_TIMEOUT_SECONDS               (2)
 #define SL_UPDATER_AUTO_BAUD_RATE_TIMEOUT_MS (13000U) // 13s
+#define EVENT_LOOP_TICK_PERIOD_MS            (100)
 
 typedef struct {
     const char* choice;
@@ -369,6 +370,24 @@ static void sl_update_idle_timer_callback(void* context) {
     furi_event_loop_stop(instance->event_loop);
 }
 
+static void sl_updater_tick(void* context) {
+    SlUpdater* instance = context;
+
+    if(instance->bootloader_state == Si917BootloaderStateWaitInstall) {
+        size_t expected_interval = furi_ms_to_ticks(instance->install_timeout_seconds * 1000);
+        size_t interval = furi_event_loop_timer_get_interval(instance->idle_timer);
+        if(interval != expected_interval) return;
+
+        size_t remaining = furi_event_loop_timer_get_remaining_time(instance->idle_timer);
+        size_t passed = interval - remaining;
+
+        instance->progress_callback(
+            SL_UPDATER_PROGRESS_PHASE_AWAITING_INSTALL,
+            (passed * 100) / interval,
+            instance->progress_callback_context);
+    }
+}
+
 SlUpdater* sl_updater_alloc(void) {
     FURI_LOG_I(TAG, "Starting");
 
@@ -399,6 +418,12 @@ SlUpdater* sl_updater_alloc(void) {
         instance->rx_buffer,
         FuriEventLoopEventIn,
         sl_updater_rx_buffer_callback,
+        instance);
+
+    furi_event_loop_tick_set(
+        instance->event_loop,
+        furi_ms_to_ticks(EVENT_LOOP_TICK_PERIOD_MS),
+        sl_updater_tick,
         instance);
 
     return instance;

--- a/applications/system/updater/worker/update_task.c
+++ b/applications/system/updater/worker/update_task.c
@@ -168,23 +168,36 @@ typedef struct {
         .weight = (WEIGHT),      \
     }
 
+// Stage                 Measured time  Weight
+// ReadManifest:         252 ms         0
+// ValidateDFUImage:     5536 ms        15
+// FlashWrite:           1669 ms        5
+// FlashValidate:        1323 ms        4
+// 917RadioWrite:        70893 ms       202
+// 917RadioInstall:      18049 ms       52
+// 917Write:             34993 ms       98
+// 917Install:           9272 ms        26
+// ResourcesFileCleanup: 1124 ms        3
+// ResourcesDirCleanup:  1459 ms        4
+// ResourcesFileUnpack:  6173 ms        18
+
 static const UpdateTaskStageGroupMap update_task_stage_progress[] = {
     [UpdateTaskStageProgress] = STAGE_DEF(UpdateTaskStageGroupMisc, 0),
 
-    [UpdateTaskStageReadManifest] = STAGE_DEF(UpdateTaskStageGroupPrepare, 5),
+    [UpdateTaskStageReadManifest] = STAGE_DEF(UpdateTaskStageGroupPrepare, 0),
 
-    [UpdateTaskStageValidateDFUImage] = STAGE_DEF(UpdateTaskStageGroupFirmware, 20),
-    [UpdateTaskStageFlashWrite] = STAGE_DEF(UpdateTaskStageGroupFirmware, 20),
-    [UpdateTaskStageFlashValidate] = STAGE_DEF(UpdateTaskStageGroupFirmware, 5),
+    [UpdateTaskStageValidateDFUImage] = STAGE_DEF(UpdateTaskStageGroupFirmware, 15),
+    [UpdateTaskStageFlashWrite] = STAGE_DEF(UpdateTaskStageGroupFirmware, 5),
+    [UpdateTaskStageFlashValidate] = STAGE_DEF(UpdateTaskStageGroupFirmware, 4),
 
-    [UpdateTaskStage917RadioWrite] = STAGE_DEF(UpdateTaskStageGroup917Radio, 240),
-    [UpdateTaskStage917RadioInstall] = STAGE_DEF(UpdateTaskStageGroup917Radio, 90),
+    [UpdateTaskStage917RadioWrite] = STAGE_DEF(UpdateTaskStageGroup917Radio, 202),
+    [UpdateTaskStage917RadioInstall] = STAGE_DEF(UpdateTaskStageGroup917Radio, 52),
 
-    [UpdateTaskStage917Write] = STAGE_DEF(UpdateTaskStageGroup917, 45),
-    [UpdateTaskStage917Install] = STAGE_DEF(UpdateTaskStageGroup917, 15),
+    [UpdateTaskStage917Write] = STAGE_DEF(UpdateTaskStageGroup917, 98),
+    [UpdateTaskStage917Install] = STAGE_DEF(UpdateTaskStageGroup917, 26),
 
-    [UpdateTaskStageResourcesFileCleanup] = STAGE_DEF(UpdateTaskStageGroupResources, 5),
-    [UpdateTaskStageResourcesDirCleanup] = STAGE_DEF(UpdateTaskStageGroupResources, 5),
+    [UpdateTaskStageResourcesFileCleanup] = STAGE_DEF(UpdateTaskStageGroupResources, 3),
+    [UpdateTaskStageResourcesDirCleanup] = STAGE_DEF(UpdateTaskStageGroupResources, 4),
     [UpdateTaskStageResourcesFileUnpack] = STAGE_DEF(UpdateTaskStageGroupResources, 18),
 
     [UpdateTaskStageCompleted] = STAGE_DEF(UpdateTaskStageGroupMisc, 1),

--- a/applications/system/updater/worker/update_task_general.c
+++ b/applications/system/updater/worker/update_task_general.c
@@ -42,6 +42,7 @@ static void update_task_sl_updater_progress_callback(
         } else if(current_stage == UpdateTaskStage917Write) {
             update_task_set_progress(update_task, UpdateTaskStage917Install, 0);
         }
+        update_task_set_progress(update_task, UpdateTaskStageProgress, percentage);
         break;
     default:
         break;
@@ -315,7 +316,7 @@ static bool update_task_write_917(UpdateTask* update_task, bool use_stack_image)
     if(success) {
         update_task_set_progress(
             update_task,
-            use_stack_image ? UpdateTaskStage917RadioWrite : UpdateTaskStage917Write,
+            use_stack_image ? UpdateTaskStage917RadioInstall : UpdateTaskStage917Install,
             100);
     }
 


### PR DESCRIPTION
# What's new
- Better weights for Updater stages
- 917 update await stages now report the timeout percentage
- Both resulting in a smooth-er update progress bar

# Verification 
- Update to this firmware through the Updater
- Confirm that the progress bar animation is visually smoother than before

# Checklist (For Reviewer)
- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
