### PR TITLE
Wifi: Add a delay before accessing the service on Si917

### DIFF
--- a/applications/services/wifi/wifi.c
+++ b/applications/services/wifi/wifi.c
@@ -215,7 +215,7 @@ static Wifi* wifi_alloc(void) {
     furi_event_loop_set_custom_event_callback(
         instance->event_loop, wifi_custom_event_callback, instance);
 
-    // TODO: Implement reliable Intercom channel opening
+    // TODO [FW-300]: Implement reliable Intercom channel opening
     furi_delay_ms(250); // Wait for the Wifi service to become ready on Si917
 
     intercom_set_rx_callback(

--- a/applications/services/wifi/wifi.c
+++ b/applications/services/wifi/wifi.c
@@ -153,8 +153,6 @@ static int32_t wifi_startup_thread_callback(void* arg) {
 
         wifi_load_settings(instance);
 
-        furi_record_create(RECORD_WIFI, instance);
-
         const WifiSettings* settings = &instance->settings;
         const char* ssid = settings->credentials.ssid;
 
@@ -190,6 +188,8 @@ static int32_t wifi_startup_thread_callback(void* arg) {
 
     } while(false);
 
+    furi_record_create(RECORD_WIFI, instance);
+
     return 0;
 }
 
@@ -214,6 +214,9 @@ static Wifi* wifi_alloc(void) {
 
     furi_event_loop_set_custom_event_callback(
         instance->event_loop, wifi_custom_event_callback, instance);
+
+    // TODO: Implement reliable Intercom channel opening
+    furi_delay_ms(250); // Wait for the Wifi service to become ready on Si917
 
     intercom_set_rx_callback(
         instance->intercom, IntercomChannelWifi, wifi_intercom_rx_callback, instance);

--- a/lib/matter_glue/platform/bsb/KeyValueStoreManagerImpl.cpp
+++ b/lib/matter_glue/platform/bsb/KeyValueStoreManagerImpl.cpp
@@ -74,7 +74,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::Init(void) {
     ReturnErrorOnFailure(error);
 
     FuriThread* cleanupThread =
-        furi_thread_alloc_ex("KvsKeyMapCleanupTask", 512, KvsKeyMapCleanup, NULL);
+        furi_thread_alloc_ex("KvsKeyMapCleanupTask", 2048, KvsKeyMapCleanup, NULL);
     furi_thread_set_priority(cleanupThread, FuriThreadPriorityLowest);
 
     furi_thread_set_state_callback(


### PR DESCRIPTION
# What's new

- Add a delay before accessing the service on Si917
- Increase stack size for the KVS cleanup thread

# Verification 

1. Flash the Main firmware.
2. Ensure that the WifiStartup thread always exits on startup and never hangs.

# Proper fix

- Implement reliable Intercom channel opening [FW-300]

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
