### PR TITLE
Fix sntp close connect by timeout

### DIFF
--- a/applications/services/sntp/sntp_time_update.c
+++ b/applications/services/sntp/sntp_time_update.c
@@ -94,17 +94,17 @@ static int32_t sntp_time_update_thread_callback(void* context) {
 
     struct mg_mgr mgr;
     mg_mgr_init(&mgr);
-    mg_sntp_connect(&mgr, settings.server_address, sntp_time_update_callback, &update_context);
+    struct mg_connection* conn =
+        mg_sntp_connect(&mgr, settings.server_address, sntp_time_update_callback, &update_context);
 
     uint32_t timeout_tick = furi_get_tick() + furi_ms_to_ticks(SNTP_UPDATE_TIMEOUT_MS);
     while(update_context.is_update_in_progress) {
-        mg_mgr_poll(&mgr, 1000);
-
         if(furi_get_tick() > timeout_tick) {
             FURI_LOG_W(TAG, "SNTP update timeout");
             update_context.update_status = SntpTimeUpdateStatusTimeout;
-            break;
+            conn->is_draining = 1;
         }
+        mg_mgr_poll(&mgr, 1000);
     }
 
     mg_mgr_free(&mgr);

--- a/lib/toolbox/fetch/fetch_client.c
+++ b/lib/toolbox/fetch/fetch_client.c
@@ -6,7 +6,7 @@
 
 #define TAG "FetchClient"
 
-//#define FETCH_CLIENT_DEBUG
+#define FETCH_CLIENT_DEBUG
 
 #ifdef FETCH_CLIENT_DEBUG
 #define FETCH_CLIENT_INFO(...)  FURI_LOG_I(__VA_ARGS__)
@@ -246,9 +246,9 @@ static void
 
     if(state == FuriThreadStateStopped) {
         furi_thread_free(thread);
+        instance->thread = NULL;
         FETCH_CLIENT_INFO(TAG, "Stop");
         furi_semaphore_release(instance->is_processing_semaphore);
-        instance->thread = NULL;
     }
 }
 

--- a/lib/toolbox/fetch/fetch_client.c
+++ b/lib/toolbox/fetch/fetch_client.c
@@ -6,7 +6,7 @@
 
 #define TAG "FetchClient"
 
-#define FETCH_CLIENT_DEBUG
+//#define FETCH_CLIENT_DEBUG
 
 #ifdef FETCH_CLIENT_DEBUG
 #define FETCH_CLIENT_INFO(...)  FURI_LOG_I(__VA_ARGS__)

--- a/lib/toolbox/fetch/fetch_loader.c
+++ b/lib/toolbox/fetch/fetch_loader.c
@@ -62,7 +62,6 @@ void fetch_loader_free(FetchLoader* instance) {
 void fetch_loader_forced_done(FetchLoader* instance) {
     furi_check(instance);
 
-    //todo: wait connect WiFi
     if(!fetch_client_is_processing_done(instance->fetch_client)) {
         fetch_client_forced_done(instance->fetch_client);
         int timeout = FETCH_LOADER_WAIT_FORCED_DONE_MS;


### PR DESCRIPTION
# What's new

- Fix sntp close connect by timeout

# Verification 

- Nothing has changed, but without the fix it may sometimes crash because the mongoose did not close the session
# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
