### PR TITLE
[FW-397] HTTP: reference stock images

### DIFF
--- a/applications/services/web_server/http_api/api_display.c
+++ b/applications/services/web_server/http_api/api_display.c
@@ -10,7 +10,8 @@
 
 #define TAG "HttpDisplay"
 
-#define DISPLAY_ASSETS_DIR EXT_PATH("assets")
+#define DISPLAY_ASSETS_DIR               EXT_PATH("assets")
+#define DISPLAY_BUILTIN_IMAGES_FORMATTER EXT_PATH("apps_assets/%s/images/%s.bin")
 
 #define DISPLAY_BRIGHTNESS_MAX (100)
 
@@ -70,16 +71,45 @@ static bool api_display_draw_parse_image_element(
     const char* app_id,
     struct mg_str json_element) {
     bool result = false;
+
+    char* uploaded = mg_json_get_str(json_element, "$.path");
+    char* builtin = mg_json_get_str(json_element, "$.builtin_image");
+
     do {
         canvas_element->type = CanvasElementTypeImage;
-        char* image_file = mg_json_get_str(json_element, "$.path");
-        if(!image_file) break;
-        canvas_element->image.file_path =
-            furi_string_alloc_printf("%s/%s/%s", DISPLAY_ASSETS_DIR, app_id, image_file);
+        if(uploaded && builtin) break;
 
-        free(image_file);
-        result = true;
+        if(uploaded) {
+            canvas_element->image.file_path =
+                furi_string_alloc_printf("%s/%s/%s", DISPLAY_ASSETS_DIR, app_id, uploaded);
+
+            result = true;
+            break;
+        }
+
+        if(builtin) {
+            char* app_name = builtin;
+            char* image_name = NULL;
+
+            for(char* c = builtin; *c != 0; c++) {
+                if(*c == '/') {
+                    *c = '\0';
+                    image_name = c + 1;
+                }
+            }
+
+            if(!image_name) break;
+
+            canvas_element->image.file_path =
+                furi_string_alloc_printf(DISPLAY_BUILTIN_IMAGES_FORMATTER, app_name, image_name);
+            result = true;
+            break;
+        }
     } while(0);
+
+    free(uploaded);
+    free(builtin);
+
     return result;
 }
 

--- a/applications/services/web_server/resources/apps_assets/web_server/www/openapi.yaml
+++ b/applications/services/web_server/resources/apps_assets/web_server/www/openapi.yaml
@@ -1426,11 +1426,17 @@ components:
         - type: object
           required:
             - path
-          properties:
-            path:
-              type: string
-              pattern: "^[a-zA-Z0-9._/-]+$"
-              description: Path to the image file in the app's assets
+          oneOf:
+            - properties:
+                path:
+                  type: string
+                  pattern: "^[a-zA-Z0-9._/-]+$"
+                  description: Path to the image file in the app's assets
+            - properties:
+                builtin_image:
+                  type: string
+                  pattern: "^[a-z_]+/[a-z0-9_]+$"
+                  description: Identifier of builtin image
 
     DisplayBrightnessInfo:
       type: object


### PR DESCRIPTION
# What's new
- Builtin image parameter for HTTP API

# Verification 
should display all icons:
```python
import requests

DEVICE_IP = "10.0.4.20"
APP_ID = "test"
ICONS = [
    "apps_menu/clock_front_8x8",
    "brightness_settings/sun_front_7x7",
    "busy/theme_8x8",
    "debug_app_list/bug_front_7x7",
    "fw_update/microchip_front_8x8",
    "matter_settings/house_front_7x7",
    "settings/info_front_7x7",
    "settings/wifi_front_7x7",
    "sound_settings/speaker_front_7x7",
    "sound_settings/speaker_off_front_7x7",
    "sound_settings/speaker_on_front_7x7",
]

elements = []
x, y = 0, 0
for icon in ICONS:
    elements.append({
        "id": icon,
        "type": "image",
        "align": "top_left",
        "x": x,
        "y": y,
        "builtin_image": icon,
    })
    x += 8
    if x >= 72 - 7:
        x = 0
        y += 8

url = f"http://{DEVICE_IP}/api/display/draw"
data = {
    "app_id": APP_ID,
    "elements": elements
}
print(requests.post(url, json=data))
```

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
