### PR TITLE
[FW-445] Update bundling fixes for Windows

### DIFF
--- a/scripts/fbt_env_modules/bsbdist/update.scons
+++ b/scripts/fbt_env_modules/bsbdist/update.scons
@@ -9,7 +9,7 @@ update_tar = dist_env.Command(
     None,
     [
         [
-            "$PYTHON",
+            "${PYTHON3}",
             dist_env.Real("#scripts/update_bundle.py"),
             "--target",
             u5_env.subst("$TARGET_HW"),
@@ -59,7 +59,7 @@ min_update_tar = dist_env.Command(
     None,
     [
         [
-            "$PYTHON",
+            "${PYTHON3}",
             dist_env.Real("#scripts/update_bundle.py"),
             "--target",
             u5_env.subst("$TARGET_HW"),


### PR DESCRIPTION
# What's new

- fbt now correctly builds update bundle with `./fbt TARGET_HW=` on Windows

# Verification 

- Check that `./fbt TARGET_HW=` works on Windows

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
