### PR TITLE
[FW-447] MQTT TLS certs on 917

### DIFF
--- a/applications/services/mqtt_client/mqtt_client.c
+++ b/applications/services/mqtt_client/mqtt_client.c
@@ -7,9 +7,7 @@
 
 #define TAG "MqttClient"
 
-#define CERT_FILE_CA_BUNDLE    EXT_PATH("apps_assets/ca/cacert.pem")
-#define CERT_FILE_INTERMEDIATE APP_ASSETS_PATH("signing-ca.crt")
-#define CERT_FILE_DEVICE       APP_ASSETS_PATH("device.crt")
+#define CERT_FILE_CA_BUNDLE EXT_PATH("apps_assets/ca/cacert.pem")
 
 #define SESSION_FILE APP_DATA_PATH("session.json")
 
@@ -46,6 +44,7 @@ static void mqtt_device_subscribe(MqttClient* mqtt) {
     const struct mg_mqtt_opts sub_opts = {
         .topic = mg_str(furi_string_get_cstr(topic)), .qos = MQTT_QOS};
     mg_mqtt_sub(mqtt->conn, &sub_opts);
+    FURI_LOG_D(TAG, "Subscribing to %s", furi_string_get_cstr(topic));
 
     furi_string_free(topic);
 }
@@ -141,12 +140,15 @@ static void mqtt_event_handler(struct mg_connection* conn, int ev, void* ev_data
             return;
         }
         const struct mg_str name = mg_url_host(MQTT_SERVER_ADDR);
-        const struct mg_tls_opts opts = {
+        const MqttTlsCfg opts = {
             .name = name,
             .ca = mg_str(mqtt->ca_bundle),
-            .cert = mg_str(mqtt->device_cert),
         };
-        mqtt_tls_init(conn, &opts);
+        if(!mqtt_tls_init(conn, &opts)) {
+            conn->is_draining = 1;
+            mqtt->status = MqttClientStatusError;
+            return;
+        }
     } else if(ev == MG_EV_TLS_HS) {
         FURI_LOG_D(TAG, "TLS handshake done!");
         // Free CA bundle data
@@ -296,59 +298,6 @@ static void mqtt_client_load_session(MqttClient* mqtt) {
     furi_assert(status != JsonConfigStatusError);
 }
 
-static bool mqtt_client_load_certs(MqttClient* mqtt) {
-    bool success = false;
-    Storage* storage = furi_record_open(RECORD_STORAGE);
-    File* file = storage_file_alloc(storage);
-
-    do {
-        if(!storage_file_exists(storage, CERT_FILE_CA_BUNDLE)) {
-            FURI_LOG_E(TAG, "CA bundle file missing");
-            break;
-        }
-
-        FileInfo file_info;
-        if(storage_common_stat(storage, CERT_FILE_INTERMEDIATE, &file_info) != FSE_OK) {
-            FURI_LOG_E(TAG, "Intermediate cert file error");
-            break;
-        }
-        uint64_t int_cert_size = file_info.size;
-
-        if(!storage_file_open(file, CERT_FILE_DEVICE, FSAM_READ, FSOM_OPEN_EXISTING)) {
-            FURI_LOG_E(TAG, "Device cert file error: %s", storage_file_get_error_desc(file));
-            break;
-        }
-        uint64_t file_size = storage_file_size(file);
-
-        // TODO: read device cert from 917
-        // TODO: verify key on 917
-        mqtt->device_cert = malloc(int_cert_size + file_size);
-        if(storage_file_read(file, mqtt->device_cert, file_size) != file_size) {
-            FURI_LOG_E(TAG, "Device cert file read error");
-            break;
-        }
-        storage_file_close(file);
-        // TODO: verify CN?
-
-        if(!storage_file_open(file, CERT_FILE_INTERMEDIATE, FSAM_READ, FSOM_OPEN_EXISTING)) {
-            FURI_LOG_E(TAG, "Intermediate cert file error: %s", storage_file_get_error_desc(file));
-            break;
-        }
-        if(storage_file_read(file, &(mqtt->device_cert[file_size]), int_cert_size) !=
-           int_cert_size) {
-            FURI_LOG_E(TAG, "Intermediate cert file read error");
-            break;
-        }
-        storage_file_close(file);
-
-        success = true;
-    } while(0);
-
-    storage_file_free(file);
-    furi_record_close(RECORD_STORAGE);
-    return success;
-}
-
 static bool mqtt_client_load_ca_bundle(MqttClient* mqtt) {
     furi_assert(mqtt->ca_bundle == NULL);
     bool success = false;
@@ -451,10 +400,7 @@ int32_t mqtt_client_start(void* p) {
     mqtt->session_id = furi_string_alloc();
     mqtt->link_token = furi_string_alloc();
 
-    if(!mqtt_client_load_certs(mqtt)) {
-        FURI_LOG_E(TAG, "Certificates load error");
-        mqtt->status = MqttClientStatusError;
-    }
+    // TODO: check certs + key on 917?
 
     mqtt_client_load_session(mqtt);
 

--- a/applications/services/mqtt_client/mqtt_client_i.h
+++ b/applications/services/mqtt_client/mqtt_client_i.h
@@ -33,7 +33,6 @@ struct MqttClient {
     bool fast_reconnect;
 
     char* ca_bundle;
-    char* device_cert;
 
     FuriString* device_serial;
     FuriString* client_id;
@@ -63,6 +62,11 @@ typedef struct {
     };
 } MqttClientMessage;
 
+typedef struct {
+    struct mg_str ca;
+    struct mg_str name;
+} MqttTlsCfg;
+
 void mqtt_topics_subscribe(MqttClient* mqtt);
 void mqtt_topics_on_message(MqttClient* mqtt, FuriString* topic_str, struct mg_mqtt_message* msg);
 void mqtt_topics_on_close(MqttClient* mqtt);
@@ -75,5 +79,5 @@ void mqtt_screen_streaming_on_message(
     struct mg_mqtt_message* msg);
 void mqtt_screen_streaming_on_close(MqttClient* mqtt);
 
-void mqtt_tls_init(struct mg_connection* conn, const struct mg_tls_opts* opts);
+bool mqtt_tls_init(struct mg_connection* conn, const MqttTlsCfg* opts);
 void mqtt_tls_free_ca(struct mg_connection* conn);

--- a/applications/services/mqtt_client/mqtt_tls_private.c
+++ b/applications/services/mqtt_client/mqtt_tls_private.c
@@ -7,7 +7,9 @@
 #define TAG "MqttTls"
 
 #define TLS_DEBUG_LEVEL 0
-#define TLS_KEY_SLOT    0
+
+#define TLS_KEY_SLOT_SIGN   0 // Intermediate cert slot (signing-ca.der)
+#define TLS_KEY_SLOT_DEVICE 1 // Device cert and key slot (device.der + device.key)
 
 static const char* mqtt_alpn_list[] = {"mqtt", NULL};
 
@@ -44,7 +46,8 @@ static int tls_pk_sign_full(
         FURI_LOG_E(TAG, "Unsupported MD algorithm 0x%02X", md_alg);
         return MBEDTLS_ERR_SSL_FEATURE_UNAVAILABLE;
     }
-    bool success = tls_crypto_client_sign(TLS_KEY_SLOT, data, data_len, sig, sig_size, sig_len);
+    bool success =
+        tls_crypto_client_sign(TLS_KEY_SLOT_DEVICE, data, data_len, sig, sig_size, sig_len);
     return (success ? 0 : MBEDTLS_ERR_SSL_INTERNAL_ERROR);
 }
 
@@ -72,12 +75,28 @@ static const mbedtls_pk_info_t tls_pk_wrap = {
     .debug_func = NULL,
 };
 
-static bool tls_load_cert(struct mg_str str, mbedtls_x509_crt* p) {
+static bool tls_load_ca(struct mg_str str, mbedtls_x509_crt* p) {
     if(str.buf == NULL || str.buf[0] == '\0' || str.buf[0] == '*') return true;
     if(str.buf[0] == '-') str.len++; // PEM, include trailing NUL
     int ret = mbedtls_x509_crt_parse(p, (uint8_t*)str.buf, str.len);
     if(ret != 0) {
-        FURI_LOG_E(TAG, "Cert load err -%04X", -ret);
+        FURI_LOG_E(TAG, "Cert parse error -0x%04X", -ret);
+        return false;
+    }
+    return true;
+}
+
+static bool tls_load_cert_from_917(uint8_t slot, mbedtls_x509_crt* crt) {
+    size_t cert_len = 0;
+    uint8_t* cert_buf = tls_crypto_client_get_cert(slot, &cert_len);
+    if(cert_buf == NULL) {
+        FURI_LOG_E(TAG, "Cert get error (slot %u)", slot);
+        return false;
+    }
+    int ret = mbedtls_x509_crt_parse(crt, cert_buf, cert_len);
+    free(cert_buf);
+    if(ret != 0) {
+        FURI_LOG_E(TAG, "Cert parse error -0x%04X", -ret);
         return false;
     }
     return true;
@@ -99,7 +118,7 @@ static int tls_net_recv(void* ctx, unsigned char* buf, size_t len) {
     return (int)n;
 }
 
-void mqtt_tls_init(struct mg_connection* conn, const struct mg_tls_opts* opts) {
+bool mqtt_tls_init(struct mg_connection* conn, const MqttTlsCfg* opts) {
     struct mg_tls* tls = (struct mg_tls*)calloc(1, sizeof(*tls));
     conn->tls = tls;
 
@@ -135,7 +154,7 @@ void mqtt_tls_init(struct mg_connection* conn, const struct mg_tls_opts* opts) {
         // ALPN
         mbedtls_ssl_conf_alpn_protocols(&tls->conf, mqtt_alpn_list);
 
-        if(tls_load_cert(opts->ca, &tls->ca) == false) {
+        if(tls_load_ca(opts->ca, &tls->ca) == false) {
             break;
         }
         mbedtls_ssl_conf_ca_chain(&tls->conf, &tls->ca, NULL);
@@ -145,7 +164,10 @@ void mqtt_tls_init(struct mg_connection* conn, const struct mg_tls_opts* opts) {
             free(host);
         }
         mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
-        if(!tls_load_cert(opts->cert, &tls->cert)) {
+        if(!tls_load_cert_from_917(TLS_KEY_SLOT_DEVICE, &tls->cert)) {
+            break;
+        }
+        if(!tls_load_cert_from_917(TLS_KEY_SLOT_SIGN, &tls->cert)) {
             break;
         }
 
@@ -175,10 +197,11 @@ void mqtt_tls_init(struct mg_connection* conn, const struct mg_tls_opts* opts) {
         conn->is_tls_hs = 1;
         mbedtls_ssl_set_bio(&tls->ssl, conn, tls_net_send, tls_net_recv, 0);
 
-        return;
+        return true;
     } while(0);
 
     mg_tls_free(conn);
+    return false;
 }
 
 void mqtt_tls_free_ca(struct mg_connection* c) {

--- a/applications/services/mqtt_client/mqtt_topics.c
+++ b/applications/services/mqtt_client/mqtt_topics.c
@@ -13,6 +13,7 @@ void mqtt_topics_subscribe(MqttClient* mqtt) {
     const struct mg_mqtt_opts opts = {
         .topic = mg_str(furi_string_get_cstr(topic)), .qos = MQTT_QOS};
     mg_mqtt_sub(mqtt->conn, &opts);
+    FURI_LOG_D(TAG, "Subscribing to %s", furi_string_get_cstr(topic));
 
     furi_string_free(topic);
 }

--- a/applications/services/tls_crypto/tls_crypto_client.c
+++ b/applications/services/tls_crypto/tls_crypto_client.c
@@ -7,14 +7,14 @@
 
 typedef struct {
     Intercom* intercom;
-    TlsCryptoSignMessage sign_msg;
+    TlsCryptoMessageGeneric msg;
     FuriMessageQueue* response_queue;
 } TlsCryptoClient;
 
 static void tls_crypto_client_rx_callback(const void* data, size_t data_size, void* context) {
     furi_assert(data);
-    furi_assert(
-        (data_size == sizeof(TlsCryptoSignMessage)) || (data_size == sizeof(TlsCryptoError)));
+    const TlsCryptoDataMessage* msg = data;
+    furi_assert((data_size == sizeof(TlsCryptoMessageHeader) + msg->header.data_size));
     furi_assert(context);
     TlsCryptoClient* instance = context;
 
@@ -35,38 +35,39 @@ bool tls_crypto_client_sign(
     bool success = false;
 
     TlsCryptoClient* instance = malloc(sizeof(TlsCryptoClient));
-    instance->response_queue = furi_message_queue_alloc(1, sizeof(TlsCryptoSignMessage));
+    instance->response_queue = furi_message_queue_alloc(1, sizeof(TlsCryptoMessageGeneric));
 
     instance->intercom = furi_record_open(RECORD_INTERCOM);
     intercom_set_rx_callback(
         instance->intercom, IntercomChannelTlsCrypto, tls_crypto_client_rx_callback, instance);
 
-    instance->sign_msg.cmd = TlsCryptoSignRequest;
-    instance->sign_msg.key_slot = key_slot;
-    instance->sign_msg.data_size = hash_len;
-    memcpy(instance->sign_msg.data, hash, hash_len);
+    instance->msg.header.type = TlsCryptoSignRequest;
+    instance->msg.header.key_slot = key_slot;
+    instance->msg.header.data_size = hash_len;
+    memcpy(instance->msg.data, hash, hash_len);
 
+    size_t packet_len = sizeof(TlsCryptoMessageHeader) + hash_len;
     size_t tx_size = intercom_tx(
         instance->intercom,
         IntercomChannelTlsCrypto,
-        &(instance->sign_msg),
-        sizeof(TlsCryptoSignMessage),
+        &(instance->msg),
+        packet_len,
         FuriWaitForever);
-    furi_check(tx_size == sizeof(TlsCryptoSignMessage), "Failed to send data");
+    furi_check(tx_size == packet_len, "Failed to send data");
 
-    if(furi_message_queue_get(instance->response_queue, &instance->sign_msg, RESPONSE_TIMEOUT) ==
+    if(furi_message_queue_get(instance->response_queue, &instance->msg, RESPONSE_TIMEOUT) ==
        FuriStatusOk) {
-        if(instance->sign_msg.cmd == TlsCryptoSignResponse) {
-            furi_assert(instance->sign_msg.key_slot == key_slot);
-            size_t resp_sign_len = instance->sign_msg.data_size;
+        if(instance->msg.header.type == TlsCryptoSignResponse) {
+            furi_assert(instance->msg.header.key_slot == key_slot);
+            size_t resp_sign_len = instance->msg.header.data_size;
             FURI_LOG_D(TAG, "TlsCryptoSignResponse len:%u", resp_sign_len);
             furi_assert(sign_buf_size >= resp_sign_len);
-            memcpy(sign_buf, instance->sign_msg.data, resp_sign_len);
+            memcpy(sign_buf, instance->msg.data, resp_sign_len);
             if(sign_len) {
                 *sign_len = resp_sign_len;
             }
             success = true;
-        } else if(instance->sign_msg.cmd == TlsCryptoError) {
+        } else if(instance->msg.header.type == TlsCryptoError) {
             FURI_LOG_E(TAG, "917 returned error");
         } else {
             furi_crash("Unsupported reponse");
@@ -80,6 +81,58 @@ bool tls_crypto_client_sign(
     free(instance);
 
     return success;
+}
+
+uint8_t* tls_crypto_client_get_cert(uint8_t key_slot, size_t* cert_len) {
+    furi_assert(cert_len);
+
+    uint8_t* cert_buf = NULL;
+
+    TlsCryptoClient* instance = malloc(sizeof(TlsCryptoClient));
+    instance->response_queue = furi_message_queue_alloc(1, sizeof(TlsCryptoMessageGeneric));
+
+    instance->intercom = furi_record_open(RECORD_INTERCOM);
+    intercom_set_rx_callback(
+        instance->intercom, IntercomChannelTlsCrypto, tls_crypto_client_rx_callback, instance);
+
+    instance->msg.header.type = TlsCryptoCertRequest;
+    instance->msg.header.key_slot = key_slot;
+    instance->msg.header.data_size = 0;
+
+    size_t packet_len = sizeof(TlsCryptoMessageHeader);
+    size_t tx_size = intercom_tx(
+        instance->intercom,
+        IntercomChannelTlsCrypto,
+        &(instance->msg),
+        packet_len,
+        FuriWaitForever);
+    furi_check(tx_size == packet_len, "Failed to send data");
+
+    if(furi_message_queue_get(instance->response_queue, &instance->msg, RESPONSE_TIMEOUT) ==
+       FuriStatusOk) {
+        if(instance->msg.header.type == TlsCryptoCertResponse) {
+            furi_assert(instance->msg.header.key_slot == key_slot);
+            size_t resp_cert_len = instance->msg.header.data_size;
+            FURI_LOG_D(TAG, "TlsCryptoCertResponse len:%u", resp_cert_len);
+
+            cert_buf = malloc(resp_cert_len);
+            memcpy(cert_buf, instance->msg.data, resp_cert_len);
+            *cert_len = resp_cert_len;
+
+        } else if(instance->msg.header.type == TlsCryptoError) {
+            FURI_LOG_E(TAG, "917 returned error");
+        } else {
+            furi_crash("Unsupported reponse");
+        }
+    }
+
+    intercom_set_rx_callback(instance->intercom, IntercomChannelTlsCrypto, NULL, NULL);
+    furi_record_close(RECORD_INTERCOM);
+
+    furi_message_queue_free(instance->response_queue);
+    free(instance);
+
+    return cert_buf;
 }
 
 int32_t tls_crypto_client_init(void* arg) {

--- a/applications/services/tls_crypto/tls_crypto_client.h
+++ b/applications/services/tls_crypto/tls_crypto_client.h
@@ -9,3 +9,5 @@ bool tls_crypto_client_sign(
     uint8_t* sign_buf,
     size_t sign_buf_size,
     size_t* sign_len);
+
+uint8_t* tls_crypto_client_get_cert(uint8_t key_slot, size_t* cert_len);

--- a/applications/services/tls_crypto/tls_crypto_common.h
+++ b/applications/services/tls_crypto/tls_crypto_common.h
@@ -2,21 +2,33 @@
 
 #include <furi.h>
 
-#define TLS_CRYPTO_DATA_SIZE_MAX 256
+#define TLS_CRYPTO_DATA_SIZE_MAX 800
 
 typedef enum {
     TlsCryptoSignRequest,
     TlsCryptoSignResponse,
-    TlsCryptoError = 0xFFFFFFFF, /**< Special value for error handling */
+    TlsCryptoCertRequest,
+    TlsCryptoCertResponse,
+    TlsCryptoError = 0xFFFFFFFF,
 } TlsCryptoCmd;
 
-typedef struct FURI_PACKED {
-    TlsCryptoCmd cmd; /**< Command type */
-    uint8_t key_slot;
+typedef struct {
+    TlsCryptoCmd type;
     size_t data_size;
-    uint8_t data[TLS_CRYPTO_DATA_SIZE_MAX];
-} TlsCryptoSignMessage;
+    uint8_t key_slot;
+} TlsCryptoMessageHeader;
 
-typedef struct FURI_PACKED {
-    TlsCryptoCmd cmd; /**< Command type */
+typedef struct {
+    TlsCryptoMessageHeader header;
+    uint8_t data[TLS_CRYPTO_DATA_SIZE_MAX];
+} TlsCryptoMessageGeneric;
+
+typedef struct {
+    TlsCryptoMessageHeader header;
+    uint8_t data[];
+} TlsCryptoDataMessage;
+
+typedef struct {
+    TlsCryptoMessageHeader header;
+    // TODO: error code?
 } TlsCryptoErrorMessage;

--- a/applications/services/tls_crypto/tls_crypto_server.c
+++ b/applications/services/tls_crypto/tls_crypto_server.c
@@ -7,7 +7,11 @@
 
 #define TAG "TlsCryptoServer"
 
-#define KEY_ID_OFFSET 0x10
+#define KEY_ID_OFFSET (0x10)
+#define KEY_SLOTS_MAX (2)
+
+#define SIGNATURE_LEN_MAX (80)
+static_assert(SIGNATURE_LEN_MAX <= TLS_CRYPTO_DATA_SIZE_MAX);
 
 typedef struct {
     Intercom* intercom;
@@ -15,52 +19,48 @@ typedef struct {
     FuriMessageQueue* command_queue;
 } TlsCryptoServer;
 
-static void tls_crypto_server_sign(
-    TlsCryptoServer* instance,
-    uint8_t key_slot,
-    uint8_t* hash,
-    size_t hash_len) {
-    furi_check(instance);
-
+static void tls_crypto_server_sign(TlsCryptoServer* instance, TlsCryptoMessageGeneric* msg) {
     bool success = false;
 
-    TlsCryptoSignMessage* sign_resp = malloc(sizeof(TlsCryptoSignMessage));
-    sign_resp->cmd = TlsCryptoSignResponse;
-    sign_resp->key_slot = key_slot;
+    uint8_t* signature_buf = malloc(SIGNATURE_LEN_MAX);
+    size_t signature_len = SIGNATURE_LEN_MAX;
 
-    uint32_t key_id = KEY_ID_OFFSET + key_slot;
-    FuriHalCryptoKey* key = furi_hal_crypto_storage_alloc(FuriHalCryptoPartitionMain);
-    FuriHalCryptoStatus status =
-        furi_hal_crypto_storage_read(key, FuriHalCryptoKeyTypeEcdsaPriv256, key_id);
+    do {
+        if(msg->header.key_slot >= KEY_SLOTS_MAX) break;
+        uint32_t key_id = KEY_ID_OFFSET + msg->header.key_slot;
 
-    if(status == FuriHalCryptoStatusOk) {
-        FuriHalCryptoEcdsa* sign_ctx = furi_hal_crypto_ecdsa_sign_init(
-            FuriHalCryptoEcdsaModeSha256,
-            key->data,
-            FURI_HAL_CRYPTO_ECDSA_PRIV_KEY_SIZE_256,
-            FuriHalCryptoWrappingModeOff);
+        FuriHalCryptoKey* key = furi_hal_crypto_storage_alloc(FuriHalCryptoPartitionMain);
+        FuriHalCryptoStatus status =
+            furi_hal_crypto_storage_read(key, FuriHalCryptoKeyTypeEcdsaPriv256, key_id);
 
-        size_t signature_len = sizeof(sign_resp->data);
-        success =
-            furi_hal_crypto_ecdsa_sign(sign_ctx, hash, hash_len, sign_resp->data, &signature_len);
-        sign_resp->data_size = signature_len;
+        if(status == FuriHalCryptoStatusOk) {
+            FuriHalCryptoEcdsa* sign_ctx = furi_hal_crypto_ecdsa_sign_init(
+                FuriHalCryptoEcdsaModeSha256,
+                key->data,
+                FURI_HAL_CRYPTO_ECDSA_PRIV_KEY_SIZE_256,
+                FuriHalCryptoWrappingModeOff);
 
-        furi_hal_crypto_ecdsa_deinit(sign_ctx);
-    }
-    furi_hal_crypto_storage_free(key);
+            success = furi_hal_crypto_ecdsa_sign(
+                sign_ctx, msg->data, msg->header.data_size, signature_buf, &signature_len);
+
+            furi_hal_crypto_ecdsa_deinit(sign_ctx);
+        }
+        furi_hal_crypto_storage_free(key);
+
+    } while(0);
 
     if(success) {
         FURI_LOG_D(TAG, "Sign done");
+        msg->header.type = TlsCryptoSignResponse;
+        msg->header.data_size = signature_len;
+        memcpy(msg->data, signature_buf, signature_len);
+        size_t packet_len = sizeof(TlsCryptoMessageHeader) + msg->header.data_size;
         size_t tx_size = intercom_tx(
-            instance->intercom,
-            IntercomChannelTlsCrypto,
-            sign_resp,
-            sizeof(TlsCryptoSignMessage),
-            FuriWaitForever);
-        furi_check(tx_size == sizeof(TlsCryptoSignMessage), "Failed to send data");
+            instance->intercom, IntercomChannelTlsCrypto, msg, packet_len, FuriWaitForever);
+        furi_check(tx_size == packet_len, "Failed to send data");
     } else {
         FURI_LOG_E(TAG, "Sign error");
-        TlsCryptoErrorMessage error_msg = {.cmd = TlsCryptoError};
+        TlsCryptoErrorMessage error_msg = {.header = {.type = TlsCryptoError}};
         size_t tx_size = intercom_tx(
             instance->intercom,
             IntercomChannelTlsCrypto,
@@ -69,25 +69,70 @@ static void tls_crypto_server_sign(
             FuriWaitForever);
         furi_check(tx_size == sizeof(TlsCryptoErrorMessage), "Failed to send data");
     }
+    free(signature_buf);
+}
 
-    free(sign_resp);
+static void tls_crypto_server_get_cert(TlsCryptoServer* instance, TlsCryptoMessageGeneric* msg) {
+    bool success = false;
+
+    do {
+        if(msg->header.key_slot >= KEY_SLOTS_MAX) break;
+        uint32_t key_id = KEY_ID_OFFSET + msg->header.key_slot;
+
+        FuriHalCryptoKey* key = furi_hal_crypto_storage_alloc(FuriHalCryptoPartitionMain);
+        FuriHalCryptoStatus status =
+            furi_hal_crypto_storage_read(key, FuriHalCryptoKeyTypeCrtDerEcdsa256, key_id);
+
+        if(status == FuriHalCryptoStatusOk) {
+            furi_check(key->header.size <= TLS_CRYPTO_DATA_SIZE_MAX);
+            msg->header.type = TlsCryptoCertResponse;
+            msg->header.data_size = key->header.size;
+            memcpy(msg->data, key->data, key->header.size);
+
+            size_t packet_len = sizeof(TlsCryptoMessageHeader) + msg->header.data_size;
+            size_t tx_size = intercom_tx(
+                instance->intercom, IntercomChannelTlsCrypto, msg, packet_len, FuriWaitForever);
+            furi_check(tx_size == packet_len, "Failed to send data");
+
+            success = true;
+        }
+        furi_hal_crypto_storage_free(key);
+    } while(0);
+
+    if(!success) {
+        FURI_LOG_E(TAG, "Get cert error");
+        TlsCryptoErrorMessage error_msg = {.header = {.type = TlsCryptoError}};
+        size_t tx_size = intercom_tx(
+            instance->intercom,
+            IntercomChannelTlsCrypto,
+            &error_msg,
+            sizeof(TlsCryptoErrorMessage),
+            FuriWaitForever);
+        furi_check(tx_size == sizeof(TlsCryptoErrorMessage), "Failed to send data");
+    }
 }
 
 static void tls_crypto_server_message_callback(FuriEventLoopObject* object, void* context) {
     TlsCryptoServer* instance = context;
+    furi_check(instance);
     furi_check(object == instance->command_queue);
 
-    TlsCryptoSignMessage msg;
-    furi_check(furi_message_queue_get(instance->command_queue, &msg, 0) == FuriStatusOk);
+    TlsCryptoMessageGeneric* msg = malloc(sizeof(TlsCryptoMessageGeneric));
+    furi_check(furi_message_queue_get(instance->command_queue, msg, 0) == FuriStatusOk);
 
-    if(msg.cmd == TlsCryptoSignRequest) {
-        tls_crypto_server_sign(instance, msg.key_slot, msg.data, msg.data_size);
+    if(msg->header.type == TlsCryptoSignRequest) {
+        tls_crypto_server_sign(instance, msg);
+    } else if(msg->header.type == TlsCryptoCertRequest) {
+        tls_crypto_server_get_cert(instance, msg);
     }
+
+    free(msg);
 }
 
 static void tls_crypto_server_rx_callback(const void* data, size_t data_size, void* context) {
     furi_assert(data);
-    furi_assert(data_size == sizeof(TlsCryptoSignMessage));
+    const TlsCryptoDataMessage* msg = data;
+    furi_assert((data_size == sizeof(TlsCryptoMessageHeader) + msg->header.data_size));
     furi_assert(context);
     TlsCryptoServer* instance = context;
 
@@ -99,7 +144,7 @@ int32_t tls_crypto_server_init(void* arg) {
     UNUSED(arg);
     TlsCryptoServer* instance = malloc(sizeof(TlsCryptoServer));
     instance->event_loop = furi_event_loop_alloc();
-    instance->command_queue = furi_message_queue_alloc(2, sizeof(TlsCryptoSignMessage));
+    instance->command_queue = furi_message_queue_alloc(1, sizeof(TlsCryptoMessageGeneric));
     furi_event_loop_subscribe_message_queue(
         instance->event_loop,
         instance->command_queue,

--- a/scripts/mqtt_provision.py
+++ b/scripts/mqtt_provision.py
@@ -18,41 +18,80 @@ CERTS_DIR_DEFAULT = Path("scripts/test_certs/mqtt")
 
 SIGN_CERT = "signing-ca.crt"
 SIGN_KEY = "signing-ca.key"
-DEVICE_CERT = "device.crt"
+SIGN_CERT_DER = "signing-ca.der"
+DEVICE_CERT = "device.der"
 DEVICE_KEY = "device.key"
 
 MQTT_DATA_DIR = "/ext/apps_assets/mqtt_client"
 
 PORT_NAME = ("10.0.4.20", 23)
-KEY_ID_TLS = 0x10
-KEY_TYPE_ECDSA256 = 8
+
+KEY_ID_OFFSET = 0x10
+KEY_ID_TLS_SIGN = KEY_ID_OFFSET + 0  # Sign cert slot
+KEY_ID_TLS_DEVICE = KEY_ID_OFFSET + 1  # Device cert + key slot
+
+KEY_TYPE_ECDSA256_KEY = 8
+KEY_TYPE_ECDSA256_CERT = 12
 
 
-def ensure_tls_slot_empty():
+def ensure_tls_slots_empty():
     with CryptoStorage(PORT_NAME) as crypto_storage:
         crypto_storage.ensure_key_absent(
             0,
-            KEY_TYPE_ECDSA256,
-            KEY_ID_TLS,
+            KEY_TYPE_ECDSA256_CERT,
+            KEY_ID_TLS_SIGN,
             echo=True,
-            error_message="TLS key slot already provisioned; refusing to overwrite",
+            error_message="TLS sign cert slot already provisioned; refusing to overwrite",
+        )
+
+        crypto_storage.ensure_key_absent(
+            0,
+            KEY_TYPE_ECDSA256_CERT,
+            KEY_ID_TLS_DEVICE,
+            echo=True,
+            error_message="TLS device cert slot already provisioned; refusing to overwrite",
+        )
+
+        crypto_storage.ensure_key_absent(
+            0,
+            KEY_TYPE_ECDSA256_KEY,
+            KEY_ID_TLS_DEVICE,
+            echo=True,
+            error_message="TLS device key slot already provisioned; refusing to overwrite",
         )
 
 
 def write_certs(certs_dir: Path):
-    with FlipperStorage(PORT_NAME) as storage:
-        if not storage.exist_dir(MQTT_DATA_DIR):
-            storage.mkdir(MQTT_DATA_DIR)
+    cert_path = certs_dir / SIGN_CERT_DER
+    with open(cert_path, "rb") as f:
+        sign_cert = f.read()
 
-        from_path = certs_dir / SIGN_CERT
-        to_path = MQTT_DATA_DIR + "/" + SIGN_CERT
-        print(f'Sending "{from_path}" to "{to_path}"')
-        storage.send_file(str(from_path), f"{to_path}")
+    cert_path = certs_dir / DEVICE_CERT
+    with open(cert_path, "rb") as f:
+        device_cert = f.read()
 
-        from_path = certs_dir / DEVICE_CERT
-        to_path = MQTT_DATA_DIR + "/" + DEVICE_CERT
-        print(f'Sending "{from_path}" to "{to_path}"')
-        storage.send_file(str(from_path), f"{to_path}")
+    with CryptoStorage(PORT_NAME) as crypto_storage:
+        ret = crypto_storage.write_key(
+            0,
+            KEY_TYPE_ECDSA256_CERT,
+            KEY_ID_TLS_SIGN,
+            0,
+            len(sign_cert),
+            sign_cert.hex(),
+        )
+        if ret != 0:
+            raise Exception(f"write_key failed with error {ret}")
+
+        ret = crypto_storage.write_key(
+            0,
+            KEY_TYPE_ECDSA256_CERT,
+            KEY_ID_TLS_DEVICE,
+            0,
+            len(device_cert),
+            device_cert.hex(),
+        )
+        if ret != 0:
+            raise Exception(f"write_key failed with error {ret}")
 
 
 def write_private_key(key_file, wrap=False):
@@ -71,18 +110,11 @@ def write_private_key(key_file, wrap=False):
 
     with CryptoStorage(PORT_NAME) as crypto_storage:
         flags = 1 if wrap else 0
-        crypto_storage.ensure_key_absent(
-            0,
-            KEY_TYPE_ECDSA256,
-            KEY_ID_TLS,
-            echo=False,
-            error_message="TLS key slot already provisioned; refusing to overwrite",
-        )
 
         ret = crypto_storage.write_key(
             0,
-            KEY_TYPE_ECDSA256,
-            KEY_ID_TLS,
+            KEY_TYPE_ECDSA256_KEY,
+            KEY_ID_TLS_DEVICE,
             flags,
             len(key_data),
             key_data.hex(),
@@ -92,10 +124,6 @@ def write_private_key(key_file, wrap=False):
 
 
 def cleanup():
-    with FlipperStorage(PORT_NAME) as storage:
-        storage.remove(MQTT_DATA_DIR + "/" + SIGN_CERT)
-        storage.remove(MQTT_DATA_DIR + "/" + DEVICE_CERT)
-
     with CryptoStorage(PORT_NAME) as crypto_storage:
         ret = crypto_storage.wipe_partition(0)
         if ret != 0:
@@ -207,8 +235,10 @@ def gen_device_cert(certs_dir: Path, device_uid):
         .sign(ca_private_key, hashes.SHA256())
     )
 
+    with open(certs_dir / SIGN_CERT_DER, "wb") as f:
+        f.write(ca_cert.public_bytes(serialization.Encoding.DER))
     with open(certs_dir / DEVICE_CERT, "wb") as f:
-        f.write(device_cert.public_bytes(serialization.Encoding.PEM))
+        f.write(device_cert.public_bytes(serialization.Encoding.DER))
 
 
 def parse_args(argv):
@@ -240,7 +270,7 @@ def main(argv=None):
     device_uid = get_device_uid()
     print("UID:", device_uid)
 
-    ensure_tls_slot_empty()
+    ensure_tls_slots_empty()
     gen_device_cert(certs_dir, device_uid)
     write_certs(certs_dir)
     write_private_key(certs_dir / DEVICE_KEY, False)

--- a/scripts/test_certs/mqtt/.gitignore
+++ b/scripts/test_certs/mqtt/.gitignore
@@ -1,3 +1,3 @@
-ca_bundle.crt
 device.key
-device.crt
+device.der
+signing-ca.der


### PR DESCRIPTION
# What's new

- Storing MQTT TLS certs in binary DER format on 917 crypto storage

# Verification 

- Flash both U5 and 917
- Run `./fbt TARGET_HW=21 mqtt_provision`
- Relink device to busy cloud, check MQTT still works

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
