### PR TITLE
[FW-414] Showing loading screen if 917 is not ready

### DIFF
--- a/applications/main/power_on/power_on.c
+++ b/applications/main/power_on/power_on.c
@@ -3,11 +3,13 @@
 
 #include <gui/gui.h>
 #include <gui/modules/anim_image.h>
+#include <gui/modules/label.h>
 
 #include <storage/storage.h>
 #include <back_display/back_display.h>
 #include <front_display/front_display.h>
 #include <power/power_service/power.h>
+#include <intercom/intercom.h>
 
 #define TAG "PowerON"
 
@@ -24,9 +26,10 @@
 typedef enum {
     PowerOnAppThreadFlagExitToMenu = 1 << 0,
     PowerOnAppThreadFlagExitToTransportMode = 1 << 1,
+    PowerOnAppThreadFlagSyncDone = 1 << 2,
 } PowerOnAppThreadFlag;
 
-#define POWER_ON_APP_FLAGS \
+#define POWER_ON_APP_ANIMATION_FLAGS \
     (PowerOnAppThreadFlagExitToMenu | PowerOnAppThreadFlagExitToTransportMode)
 
 typedef struct {
@@ -39,6 +42,9 @@ typedef struct {
 
     FuriThread* thread;
     FuriTimer* back_to_transport_timer;
+
+    Intercom* intercom;
+    FuriPubSubSubscription* intercom_event_sub;
 } PowerOnApp;
 
 static bool power_on_input_callback(const InputEvent* event, void* context) {
@@ -65,7 +71,21 @@ static void back_to_transport_timer_callback(void* ctx) {
     furi_thread_flags_set(instance->thread, PowerOnAppThreadFlagExitToTransportMode);
 }
 
-static PowerOnApp* power_on_app_alloc() {
+static void power_on_intercom_callback(const void* message, void* context) {
+    furi_assert(message);
+    furi_assert(context);
+
+    const IntercomEvent* event = message;
+    PowerOnApp* instance = context;
+
+    if(event->type == IntercomEventTypeSyncStateChanged) {
+        if(event->is_in_sync) {
+            furi_thread_flags_set(instance->thread, PowerOnAppThreadFlagSyncDone);
+        }
+    }
+}
+
+static PowerOnApp* power_on_app_alloc(void) {
     PowerOnApp* instance = malloc(sizeof(PowerOnApp));
 
     instance->gui = furi_record_open(RECORD_GUI);
@@ -80,16 +100,23 @@ static PowerOnApp* power_on_app_alloc() {
         furi_timer_alloc(back_to_transport_timer_callback, FuriTimerTypeOnce, instance);
     furi_timer_start(
         instance->back_to_transport_timer, furi_ms_to_ticks(MIN_TO_MS(POWER_ON_APP_TIMEOUT_MIN)));
+
+    instance->intercom = furi_record_open(RECORD_INTERCOM);
+    instance->intercom_event_sub = furi_pubsub_subscribe(
+        intercom_get_pubsub(instance->intercom), power_on_intercom_callback, instance);
     return instance;
 }
 
 static void power_on_app_free(PowerOnApp* instance) {
+    furi_pubsub_unsubscribe(intercom_get_pubsub(instance->intercom), instance->intercom_event_sub);
+
     furi_record_close(RECORD_STORAGE);
     furi_record_close(RECORD_POWER);
     furi_record_close(RECORD_INPUT);
     furi_record_close(RECORD_BACK_DISPLAY);
     furi_record_close(RECORD_FRONT_DISPLAY);
     furi_record_close(RECORD_GUI);
+    furi_record_open(RECORD_INTERCOM);
 
     furi_timer_free(instance->back_to_transport_timer);
     free(instance);
@@ -122,13 +149,43 @@ int32_t power_on_app(void* arg) {
 
     PowerOnApp* instance = power_on_app_alloc();
 
+    bool sync_done = intercom_is_in_sync(instance->intercom);
+
+    AnimImage* front_anim = NULL;
+    AnimImage* back_anim = NULL;
+
+    Label* label_front = NULL;
+    Label* label_back = NULL;
+
+    if(!sync_done) {
+        with_gui(instance->gui, {
+            GuiLayer* layer = gui_get_layer(instance->gui, GuiLayerIdMain);
+            Widget* front = gui_layer_get_root_widget(layer, GuiDisplayIdFront);
+            Widget* back = gui_layer_get_root_widget(layer, GuiDisplayIdBack);
+
+            label_front = label_alloc(front);
+            label_back = label_alloc(back);
+
+            label_set_text(label_front, "Starting...");
+            label_set_text(label_back, "Starting...");
+
+            widget_set_align(label_get_base(label_front), AlignCenter);
+            widget_set_align(label_get_base(label_back), AlignCenter);
+        });
+
+        furi_thread_flags_wait(PowerOnAppThreadFlagSyncDone, FuriFlagWaitAny, FuriWaitForever);
+    }
+
     do {
         if(power_on_done_flag_present(instance)) break;
 
-        AnimImage *front_anim, *back_anim;
         with_gui(instance->gui, {
             GuiLayer* layer = gui_get_layer(instance->gui, GuiLayerIdMain);
             gui_layer_add_input_callback(layer, power_on_input_callback, instance);
+
+            if(label_front) label_free(label_front);
+            if(label_back) label_free(label_back);
+
             Widget* front = gui_layer_get_root_widget(layer, GuiDisplayIdFront);
             front_anim =
                 power_on_animation_alloc(front, POWER_ON_ANIM_PATH("front_power_on_72x16.anim"));
@@ -139,7 +196,8 @@ int32_t power_on_app(void* arg) {
         });
 
         uint32_t flags =
-            furi_thread_flags_wait(POWER_ON_APP_FLAGS, FuriFlagWaitAny, FuriWaitForever);
+            furi_thread_flags_wait(POWER_ON_APP_ANIMATION_FLAGS, FuriFlagWaitAny, FuriWaitForever);
+
         if(flags & PowerOnAppThreadFlagExitToTransportMode) {
             power_off(instance->power);
         }
@@ -148,14 +206,18 @@ int32_t power_on_app(void* arg) {
             furi_timer_stop(instance->back_to_transport_timer);
             power_on_done_flag_create(instance);
         }
+    } while(0);
 
-        with_gui(instance->gui, {
-            anim_image_free(front_anim);
-            anim_image_free(back_anim);
-            GuiLayer* layer = gui_get_layer(instance->gui, GuiLayerIdMain);
-            gui_layer_remove_input_callback(layer, power_on_input_callback);
-        });
-    } while(false);
+    with_gui(instance->gui, {
+        if(front_anim) anim_image_free(front_anim);
+        if(back_anim) anim_image_free(back_anim);
+
+        if(label_front) label_free(label_front);
+        if(label_back) label_free(label_back);
+
+        GuiLayer* layer = gui_get_layer(instance->gui, GuiLayerIdMain);
+        gui_layer_remove_input_callback(layer, power_on_input_callback);
+    });
 
     power_on_app_free(instance);
     return 0;

--- a/applications/main/power_on/power_on.c
+++ b/applications/main/power_on/power_on.c
@@ -116,7 +116,7 @@ static void power_on_app_free(PowerOnApp* instance) {
     furi_record_close(RECORD_BACK_DISPLAY);
     furi_record_close(RECORD_FRONT_DISPLAY);
     furi_record_close(RECORD_GUI);
-    furi_record_open(RECORD_INTERCOM);
+    furi_record_close(RECORD_INTERCOM);
 
     furi_timer_free(instance->back_to_transport_timer);
     free(instance);


### PR DESCRIPTION
# What's new

- [FW-414] Power on: showing loading screen if 917 is not ready yet

# Verification 

- Start U5 while 917 is held in reset

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
