### PR TITLE
[FW-507] Fix name endpoint CORS

### DIFF
--- a/applications/services/web_server/http_api/api_root.c
+++ b/applications/services/web_server/http_api/api_root.c
@@ -317,7 +317,13 @@ static const HttpHandler handlers_api_root[] = {
     },
     {
         .uri = "name",
-        .method = "*",
+        .method = "GET",
+        .type = HttpHandlerCustom,
+        .on_request = http_api_name_callback,
+    },
+    {
+        .uri = "name",
+        .method = "POST",
         .type = HttpHandlerCustom,
         .on_request = http_api_name_callback,
     },


### PR DESCRIPTION
# What's new

[FW-507] 
- Fix name endpoint CORS

# Verification 

- Open http://10.0.4.20/docs/ then open browser console and send GET request to http://busybar.local/api/name
- In U5 logs there will be two requests instead of one:
```
355742 [D][HttpApi] OPTIONS /api/name
355748 [D][HttpApi] GET /api/name
```

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
