### PR TITLE
Matter certification fixes, round 3

### DIFF
--- a/lib/matter_glue/platform/bsb/ConfigurationManagerImpl.cpp
+++ b/lib/matter_glue/platform/bsb/ConfigurationManagerImpl.cpp
@@ -134,7 +134,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersionString(char * buf, size_t bufSize) {
+CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersionString(char* buf, size_t bufSize) {
     const Version* version = version_get();
     const char* version_str = version_get_version(version);
 
@@ -144,7 +144,7 @@ CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersionString(char * buf, size_t
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersion(uint32_t & softwareVer) {
+CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersion(uint32_t& softwareVer) {
     softwareVer = MATTER_SOFTWARE_VER_NUM;
     return CHIP_NO_ERROR;
 }

--- a/lib/matter_glue/platform/bsb/ConfigurationManagerImpl.cpp
+++ b/lib/matter_glue/platform/bsb/ConfigurationManagerImpl.cpp
@@ -29,6 +29,10 @@
 
 #include "SilabsConfig.h"
 
+#include <version/version.h>
+
+#define MATTER_SOFTWARE_VER_NUM 2ul
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -128,6 +132,21 @@ CHIP_ERROR ConfigurationManagerImpl::WritePersistedStorageValue(
 
 exit:
     return err;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersionString(char * buf, size_t bufSize) {
+    const Version* version = version_get();
+    const char* version_str = version_get_version(version);
+
+    if(strlen(version_str) + 1 > bufSize) return CHIP_ERROR_BUFFER_TOO_SMALL;
+
+    strcpy(buf, version_str);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersion(uint32_t & softwareVer) {
+    softwareVer = MATTER_SOFTWARE_VER_NUM;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadConfigValue(Key key, bool& val) {

--- a/lib/matter_glue/platform/bsb/ConfigurationManagerImpl.h
+++ b/lib/matter_glue/platform/bsb/ConfigurationManagerImpl.h
@@ -63,8 +63,8 @@ private:
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
     // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
-    CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override;
+    CHIP_ERROR GetSoftwareVersionString(char* buf, size_t bufSize) override;
+    CHIP_ERROR GetSoftwareVersion(uint32_t& softwareVer) override;
     CHIP_ERROR ReadConfigValue(Key key, bool& val) override;
     CHIP_ERROR ReadConfigValue(Key key, uint32_t& val) override;
     CHIP_ERROR ReadConfigValue(Key key, uint64_t& val) override;

--- a/lib/matter_glue/platform/bsb/ConfigurationManagerImpl.h
+++ b/lib/matter_glue/platform/bsb/ConfigurationManagerImpl.h
@@ -63,6 +63,8 @@ private:
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
     // ===== Members that implement the GenericConfigurationManagerImpl protected interface.
+    CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override;
     CHIP_ERROR ReadConfigValue(Key key, bool& val) override;
     CHIP_ERROR ReadConfigValue(Key key, uint32_t& val) override;
     CHIP_ERROR ReadConfigValue(Key key, uint64_t& val) override;

--- a/scripts/test_certs/matter/gen-creds.sh
+++ b/scripts/test_certs/matter/gen-creds.sh
@@ -5,10 +5,11 @@ set -e
 # Parse arguments
 
 usage() {
-  echo "Usage: gen-creds.sh <type>"
+  echo "Usage: gen-creds.sh <type> <ver>"
   echo "  type: test|certification"
-  echo "  Use \"test\" for regular testing."
-  echo "  Use \"certification\" for devices going into certification testing."
+  echo "    Use \"test\" for regular testing."
+  echo "    Use \"certification\" for devices going into certification testing."
+  echo "  ver: see \"MATTER_SOFTWARE_VERSION\" in \"matter_f64.cpp\""
   echo ""
   echo "Required env vars:"
   echo "  - MATTER_DIR: path to cloned repo:"
@@ -18,12 +19,13 @@ usage() {
   exit 1
 }
 
-if [[ $# -ne 1 ]]; then
+if [[ $# -ne 2 ]]; then
   usage
 fi
 
 certificate_type=$1
 if ! [[ "$certificate_type" =~ ^(test|certification)$ ]]; then usage; fi
+software_ver=$2
 
 if [[ ! -v MATTER_DIR ]]; then usage; fi
 if [[ ! -v CHIP_CERT ]]; then usage; fi
@@ -114,5 +116,5 @@ $chip_cert_tool gen-cd \
   --certificate-id "CSA00000SWC00000-00" \
   --security-level "0" \
   --security-info "0" \
-  --version-number "1" \
+  --version-number "${software_ver}" \
   --certification-type "$cd_certification_type"


### PR DESCRIPTION
# What's new
- PICS: https://github.com/flipperdevices/bsb-matter-pics/pull/5
- `SoftwareVersion` and `SoftwareVersionString` attributes in `BasicInformation` cluster now display correct information
- Certificates now have to be re-provisioned every time the Matter version is bumped (`MATTER_SOFTWARE_VER_NUM`)

# Verification 
- Verify that Matter works normally
- Verify that `basicinformation read software-version 123 0` in chip-tool interactive shell says `2` (after commissioning device with ID 123)
- Send device into certification testing

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
