### PR TITLE
Busy: Hotfix: Delete screen mirroring widget on BUSY exit

### DIFF
--- a/applications/main/busy/busy.c
+++ b/applications/main/busy/busy.c
@@ -217,6 +217,7 @@ static void busy_free(BusyApp* instance) {
         transition_overlay_free(instance->transition_overlay);
 
         widget_free(instance->front_window);
+        timer_card_free(instance->timer_card);
         flex_layout_free(instance->back_container);
     });
 


### PR DESCRIPTION
# What's new

- Fix a bug that causes the screen mirroring widget not be deleted in some cases

# Verification 

1. Start the BUSY app
2. Run the timer (screen mirroring should be active)
3. Move the mode switch to another position
4. There should be no artifacts on the back display.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
