### PR TITLE
[FW-529] MQTT connection fix; restored pre-OTP serial number byte order

### DIFF
--- a/applications/services/mqtt_client/mqtt_client.c
+++ b/applications/services/mqtt_client/mqtt_client.c
@@ -4,6 +4,7 @@
 #include <json_helper.h>
 #include <furi_hal_random.h>
 #include <furi_hal_version.h>
+#include <toolbox/hex.h>
 
 #define TAG "MqttClient"
 
@@ -535,7 +536,7 @@ int32_t mqtt_client_start(void* p) {
     mqtt_client_load_profile(mqtt, mqtt->profile_id);
 
     mqtt->device_serial = furi_string_alloc();
-    furi_hal_version_get_uid_str(mqtt->device_serial);
+    hex_bytes_to_string(furi_hal_version_uid(), furi_hal_version_uid_size(), mqtt->device_serial);
 
     mqtt->client_id = furi_string_alloc();
     mqtt->session_id = furi_string_alloc();

--- a/applications/services/usb_network/usb_descriptors.c
+++ b/applications/services/usb_network/usb_descriptors.c
@@ -1,9 +1,12 @@
+#include "usb_network_settings.h"
+
 #include <furi.h>
 #include <furi_hal_version.h>
+#include <toolbox/hex.h>
+
 #include <tusb.h>
 #include <class/net/net_device.h>
 #include <class/net/ncm.h>
-#include "usb_network_settings.h"
 
 #define VERSION_BCD(maj, min, rev) (((maj & 0xFF) << 8) | ((min & 0x0F) << 4) | (rev & 0x0F))
 
@@ -179,7 +182,8 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
 
     case UsbStrSerial:
         FuriString* uid = furi_string_alloc();
-        furi_hal_version_get_uid_str(uid);
+        hex_bytes_to_string(furi_hal_version_uid(), furi_hal_version_uid_size(), uid);
+
         size_t uid_len = furi_string_size(uid);
         furi_assert(uid_len < COUNT_OF(desc_string_temp));
         for(uint8_t i = 0; i < uid_len; i++) {

--- a/lib/cli/args.c
+++ b/lib/cli/args.c
@@ -1,7 +1,6 @@
 #include "args.h"
 #include <toolbox/hex.h>
 #include <toolbox/strint.h>
-#include "m-core.h"
 
 size_t args_get_first_word_length(FuriString* args) {
     size_t ws = furi_string_search_char(args, ' ');
@@ -66,34 +65,28 @@ bool args_read_probably_quoted_string_and_trim(FuriString* args, FuriString* wor
 }
 
 bool args_char_to_hex(char hi_nibble, char low_nibble, uint8_t* byte) {
-    uint8_t hi_nibble_value = 0;
-    uint8_t low_nibble_value = 0;
-    bool result = false;
-
-    if(hex_char_to_hex_nibble(hi_nibble, &hi_nibble_value)) {
-        if(hex_char_to_hex_nibble(low_nibble, &low_nibble_value)) {
-            result = true;
-            *byte = (hi_nibble_value << 4) | low_nibble_value;
-        }
-    }
-
-    return result;
+    return hex_char_to_uint8(hi_nibble, low_nibble, byte);
 }
 
 bool args_read_hex_bytes(FuriString* args, uint8_t* bytes, size_t bytes_count) {
-    bool result = true;
-    const char* str_pointer = furi_string_get_cstr(args);
+    const size_t expected_length = bytes_count * 2;
+    const size_t word_length = args_get_first_word_length(args);
 
-    if(args_get_first_word_length(args) == (bytes_count * 2)) {
-        for(size_t i = 0; i < bytes_count; i++) {
-            if(!args_char_to_hex(str_pointer[i * 2], str_pointer[i * 2 + 1], &(bytes[i]))) {
-                result = false;
-                break;
-            }
-        }
-    } else {
-        result = false;
+    if(word_length != expected_length) {
+        return false;
     }
 
-    return result;
+    if(bytes_count == 0) {
+        return true;
+    }
+
+    FuriString* hex_word = furi_string_alloc();
+    furi_string_set_n(hex_word, args, 0, word_length);
+
+    size_t parsed = 0;
+    bool success = hex_string_to_bytes(hex_word, bytes, bytes_count, &parsed);
+
+    furi_string_free(hex_word);
+
+    return success && (parsed == bytes_count);
 }

--- a/lib/toolbox/hex.c
+++ b/lib/toolbox/hex.c
@@ -68,3 +68,36 @@ void uint8_to_hex_chars(const uint8_t* src, uint8_t* target, int length) {
     while(--length >= 0)
         target[length] = chars[(src[length >> 1] >> ((1 - (length & 1)) << 2)) & 0xF];
 }
+
+void hex_bytes_to_string(const uint8_t* bytes, size_t bytes_length, FuriString* string) {
+    furi_check(bytes);
+    furi_check(string);
+
+    furi_string_reset(string);
+    for(size_t i = 0; i < bytes_length; i++) {
+        furi_string_cat_printf(string, "%02x", bytes[i]);
+    }
+}
+
+bool hex_string_to_bytes(
+    const FuriString* string,
+    uint8_t* bytes,
+    size_t bytes_count,
+    size_t* bytes_written) {
+    furi_check(string);
+    furi_check(bytes);
+
+    size_t str_size = furi_string_size(string);
+    size_t max_bytes = str_size / 2;
+    if(bytes_written) *bytes_written = 0;
+    bool parse_success = false;
+
+    const char* str_pointer = furi_string_get_cstr(string);
+
+    for(size_t i = 0; i < max_bytes && i < bytes_count; i++) {
+        parse_success = hex_char_to_uint8(str_pointer[i * 2], str_pointer[i * 2 + 1], &bytes[i]);
+        if(!parse_success) break;
+        if(bytes_written) (*bytes_written)++;
+    }
+    return parse_success;
+}

--- a/lib/toolbox/hex.h
+++ b/lib/toolbox/hex.h
@@ -1,6 +1,7 @@
 #pragma once
-#include "stdint.h"
-#include "stdbool.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include <core/string.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,6 +47,27 @@ bool hex_chars_to_uint64(const char* value_str, uint64_t* value);
  * 
  */
 void uint8_to_hex_chars(const uint8_t* src, uint8_t* target, int length);
+
+/** Convert bytes to hex string
+ * @param bytes         source bytes
+ * @param bytes_length  length of source bytes
+ * @param string        output string
+ */
+void hex_bytes_to_string(const uint8_t* bytes, size_t bytes_length, FuriString* string);
+
+/** Convert hex string to bytes
+ * @param string        source string
+ * @param bytes         output bytes
+ * @param bytes_count   max bytes to write
+ * @param bytes_written actual bytes written
+ *
+ * @return              bool conversion status
+ */
+bool hex_string_to_bytes(
+    const FuriString* string,
+    uint8_t* bytes,
+    size_t bytes_count,
+    size_t* bytes_written);
 
 #ifdef __cplusplus
 }

--- a/lib/toolbox_f64/hex.c
+++ b/lib/toolbox_f64/hex.c
@@ -68,3 +68,36 @@ void uint8_to_hex_chars(const uint8_t* src, uint8_t* target, int length) {
     while(--length >= 0)
         target[length] = chars[(src[length >> 1] >> ((1 - (length & 1)) << 2)) & 0xF];
 }
+
+void hex_bytes_to_string(const uint8_t* bytes, size_t bytes_length, FuriString* string) {
+    furi_check(bytes);
+    furi_check(string);
+
+    furi_string_reset(string);
+    for(size_t i = 0; i < bytes_length; i++) {
+        furi_string_cat_printf(string, "%02x", bytes[i]);
+    }
+}
+
+bool hex_string_to_bytes(
+    const FuriString* string,
+    uint8_t* bytes,
+    size_t bytes_count,
+    size_t* bytes_written) {
+    furi_check(string);
+    furi_check(bytes);
+
+    size_t str_size = furi_string_size(string);
+    size_t max_bytes = str_size / 2;
+    if(bytes_written) *bytes_written = 0;
+    bool parse_success = false;
+
+    const char* str_pointer = furi_string_get_cstr(string);
+
+    for(size_t i = 0; i < max_bytes && i < bytes_count; i++) {
+        parse_success = hex_char_to_uint8(str_pointer[i * 2], str_pointer[i * 2 + 1], &bytes[i]);
+        if(!parse_success) break;
+        if(bytes_written) (*bytes_written)++;
+    }
+    return parse_success;
+}

--- a/lib/toolbox_f64/hex.h
+++ b/lib/toolbox_f64/hex.h
@@ -1,6 +1,7 @@
 #pragma once
-#include "stdint.h"
-#include "stdbool.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include <core/string.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,6 +47,27 @@ bool hex_chars_to_uint64(const char* value_str, uint64_t* value);
  * 
  */
 void uint8_to_hex_chars(const uint8_t* src, uint8_t* target, int length);
+
+/** Convert bytes to hex string
+ * @param bytes         source bytes
+ * @param bytes_length  length of source bytes
+ * @param string        output string
+ */
+void hex_bytes_to_string(const uint8_t* bytes, size_t bytes_length, FuriString* string);
+
+/** Convert hex string to bytes
+ * @param string        source string
+ * @param bytes         output bytes
+ * @param bytes_count   max bytes to write
+ * @param bytes_written actual bytes written
+ *
+ * @return              bool conversion status
+ */
+bool hex_string_to_bytes(
+    const FuriString* string,
+    uint8_t* bytes,
+    size_t bytes_count,
+    size_t* bytes_written);
 
 #ifdef __cplusplus
 }

--- a/targets/f21/furi_hal/furi_hal_info.c
+++ b/targets/f21/furi_hal/furi_hal_info.c
@@ -1,20 +1,18 @@
+#include <furi.h>
+
+#include <furi_hal_version.h>
 #include <furi_hal_info.h>
 
 #include <version/version.h>
-#include <furi_hal_version.h>
-#include <stm32u5xx_ll_utils.h>
-#include <furi.h>
+#include <toolbox/hex.h>
 
 FURI_WEAK void furi_hal_info_get_api_version(uint16_t* major, uint16_t* minor) {
     *major = 0;
     *minor = 0;
 }
 
-static void format_bytes_hex(FuriString* str, const uint8_t* data, size_t len) {
-    furi_string_reset(str);
-    for(size_t i = 0; i < len; i++) {
-        furi_string_cat_printf(str, "%02x", data[i]);
-    }
+static inline void format_bytes_hex(FuriString* str, const uint8_t* data, size_t len) {
+    hex_bytes_to_string(data, len, str);
 }
 
 static void format_mac(FuriString* str, const uint8_t* mac) {
@@ -178,8 +176,7 @@ void furi_hal_info_get(PropertyValueCallback out, char sep, void* context) {
         }
 
         // Hardware UID
-        furi_string_printf(
-            temp_str, "%08lx%08lx%08lx", LL_GetUID_Word2(), LL_GetUID_Word1(), LL_GetUID_Word0());
+        format_bytes_hex(temp_str, furi_hal_version_uid(), furi_hal_version_uid_size());
         property_out_str(&property_context, "hardware", "uid", furi_string_get_cstr(temp_str));
 
         // OTP1 - Hardware/Production info

--- a/targets/f21/furi_hal/furi_hal_version.c
+++ b/targets/f21/furi_hal/furi_hal_version.c
@@ -15,6 +15,8 @@
 #define OTP1_MAC_SIZE   (6)
 #define OTP1_MODEL_SIZE (8)
 
+#define HW_UID_SIZE (12)
+
 typedef struct {
     bool otp1_valid;
     bool otp2_valid;
@@ -24,6 +26,7 @@ typedef struct {
     // Cached/derived values
     char model_code[OTP1_MODEL_SIZE + 1]; // Null-terminated model
     uint8_t usb_mac[OTP1_MAC_SIZE];
+    uint8_t hw_uid[HW_UID_SIZE];
 } FuriHalVersionState;
 
 static FuriHalVersionState furi_hal_version_state = {0};
@@ -148,6 +151,11 @@ static bool otp_is_otp4_provisioned(void) {
 /*** Initialization ***/
 
 void furi_hal_version_init(void) {
+    // Copy MCU UID, reversing byte order
+    for(size_t i = 0; i < HW_UID_SIZE; i++) {
+        furi_hal_version_state.hw_uid[i] = ((uint8_t*)UID_BASE_ADDRESS)[HW_UID_SIZE - 1 - i];
+    }
+
     // Check OTP provisioning status
     furi_hal_version_state.otp1_valid = otp_is_otp1_provisioned();
     furi_hal_version_state.otp2_valid = otp_is_otp2_provisioned();
@@ -351,22 +359,14 @@ const uint8_t* furi_hal_version_get_usb_mac(void) {
     return furi_hal_version_state.usb_mac;
 }
 
-/*** MCU UID ***/
+/*** Hardware UID ***/
 
 size_t furi_hal_version_uid_size(void) {
-    return 12; // STM32U5 has 96-bit (12-byte) UID
+    return HW_UID_SIZE;
 }
 
 const uint8_t* furi_hal_version_uid(void) {
-    return (const uint8_t*)UID_BASE;
-}
-
-void furi_hal_version_get_uid_str(FuriString* serial) {
-    const uint8_t* uid = furi_hal_version_uid();
-    furi_string_reset(serial);
-    for(size_t i = 0; i < furi_hal_version_uid_size(); i++) {
-        furi_string_cat_printf(serial, "%02X", uid[i]);
-    }
+    return furi_hal_version_state.hw_uid;
 }
 
 /*** OTP Validity Status ***/

--- a/targets/f21/furi_hal/furi_hal_version.h
+++ b/targets/f21/furi_hal/furi_hal_version.h
@@ -155,12 +155,6 @@ size_t furi_hal_version_uid_size(void);
  */
 const uint8_t* furi_hal_version_uid(void);
 
-/** Get device serial number (UID) as a string
-  *
-  * @param[in]  uid     a string to store the value
-  */
-void furi_hal_version_get_uid_str(FuriString* uid);
-
 // ============================================================================
 // OTP Validity Status
 // ============================================================================


### PR DESCRIPTION
# What's new

- hal: dropped furi_hal_version_get_uid_str; changed byte order in furi…_hal_version_uid(); 
- toolbox: added hex<>str helpers
- cli: now using new helpers

# Verification 

- Test that UID value is the same as before the OTP PR changes
- Test that MQTT works

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
