### PR TITLE
[FW-534] HTTP API access whitelist

### DIFF
--- a/applications/services/web_server/http_api/api_root.c
+++ b/applications/services/web_server/http_api/api_root.c
@@ -9,6 +9,15 @@
 #define ACCESS_KEY_LEN_MIN 4
 #define ACCESS_KEY_LEN_MAX 10
 
+// Always accessible API endpoints
+static const struct {
+    const char* uri;
+    const char* method;
+} api_access_whitelist[] = {
+    {"version", "GET"},
+    {"access", "GET"},
+};
+
 typedef struct {
     HttpHandlersList_t handlers;
     enum {
@@ -127,8 +136,16 @@ static bool http_api_access_callback(
 
 static bool http_api_is_access_allowed(
     ApiRootCtx* context,
+    FuriString* path,
     struct mg_connection* conn,
     struct mg_http_message* msg) {
+    for(size_t i = 0; i < COUNT_OF(api_access_whitelist); i++) {
+        if(furi_string_equal(path, api_access_whitelist[i].uri) &&
+           (mg_strcmp(msg->method, mg_str(api_access_whitelist[i].method)) == 0)) {
+            return true;
+        }
+    }
+
     uint8_t* ip = conn->rem.ip;
     UsbNetwork* usb_network = furi_record_open(RECORD_USB_NETWORK);
     bool is_usb_addr = usb_network_is_dhcp_addr(usb_network, ip);
@@ -419,7 +436,7 @@ bool http_api_root_hdr_callback(
         FURI_LOG_D(TAG, "Query %.*s", msg->query.len, msg->query.buf);
     }
 
-    if(!http_api_is_access_allowed(context, conn, msg)) {
+    if(!http_api_is_access_allowed(context, path, conn, msg)) {
         MG_REPLY_FORBIDDEN(conn);
         mg_iobuf_del(&conn->recv, 0, msg->head.len);
         conn->pfn = NULL;


### PR DESCRIPTION
# What's new
FW-534
- HTTP API access whitelist
- `GET version`, `GET access` are always accessible

# Verification 

- Disable API access over Wifi, check `GET version`, `GET access` endpoints

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
