### PR TITLE
[FW-542] updater: use tgz file for downloads

### DIFF
--- a/applications/services/ble/settings/interface_v1.c
+++ b/applications/services/ble/settings/interface_v1.c
@@ -4,12 +4,7 @@ const SettingProviderSetting ble_v1_settings[] = {
     [BleSettingsV1IdxEnabled] =
         {
             .name = "enabled",
-            .interface =
-                &(const SettingProviderStructureInterface){
-                    .is_valid_callback = NULL,
-                    .inner_settings = NULL,
-                    .inner_settings_count = 0,
-                },
+            .interface = &(const SettingProviderBoolInterface){.default_value = false},
             .field_offset = offsetof(BleSettingsV1, enabled),
             .type = SettingProviderSettingTypeBool,
         },

--- a/applications/system/updater/helpers/update_parser.c
+++ b/applications/system/updater/helpers/update_parser.c
@@ -29,7 +29,7 @@
         snprintf(target, sizeof(target), "f%u", furi_hal_version_get_hw_target()); \
         target;                                                                    \
     })
-#define UPDATE_PARSER_BRANCH_FILE_NAME_FW_FOUND "update_tar"
+#define UPDATE_PARSER_BRANCH_FILE_NAME_FW_FOUND "update_tgz"
 
 static bool parse_update_json(cJSON* json_root, const char* branch_id, UpdateMetadata* metadata) {
     bool is_success = false;


### PR DESCRIPTION
# What's new

[FW-542] 
- updater: use now using .tgz file for downloads

# Verification 

- flash to this branch with `./fbt flash_usb_tar`
- Check that download size from Settings->FWUpdate is reduced compared to .tar size

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-542]: https://flipper.atlassian.net/browse/FW-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ