### PR TITLE
Matter hotfix: success flag for local requests

### DIFF
--- a/applications/services/matter/matter.c
+++ b/applications/services/matter/matter.c
@@ -159,6 +159,7 @@ static void matter_handle_api_request(FuriEventLoopObject* object, void* context
     switch(request->type) {
     case MatterApiRequestTypeGetSwitchState: {
         request->switch_state = matter->switch_state;
+        request->success = true;
         break;
     }
 
@@ -225,6 +226,7 @@ static void matter_handle_api_request(FuriEventLoopObject* object, void* context
 
     case MatterApiRequestTypeGetFabricCount: {
         request->fabric_count = matter->commissioned_fabrics;
+        request->success = true;
         break;
     }
     }


### PR DESCRIPTION
# What's new
- Local Matter requests (that u5 handles without intercom) now report correct success status

# Verification 
- Commission device to a Matter fabric
- Reboot device
- Go to Settings > Smart Home
- Verify that the option to reset Matter is there

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
