### PR TITLE
[FW-431, FW-573] 917 brick target + u5 connectivity fix on intercom crash

### DIFF
--- a/.github/workflows/bricktest-build.yml
+++ b/.github/workflows/bricktest-build.yml
@@ -1,0 +1,108 @@
+name: "Brick test build"
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+  workflow_dispatch:
+
+env:
+  FBT_GIT_SUBMODULE_SHALLOW: 0
+  DEFAULT_TARGET_SPEC: 21_64
+  FBT_TOOLCHAIN_PATH: /runner/_work
+
+jobs:
+  brick-test-build:
+    runs-on: BsbShell
+    timeout-minutes: 20
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target_spec: ["21_64"]
+    outputs:
+      update_url: ${{ steps.set-url.outputs.update_url }}
+      target: ${{ steps.build-fw.outputs.u5_target_hw }}
+
+    steps:
+      - name: "Wipe workspace"
+        run: |
+          find ./ -mount -maxdepth 1 -exec rm -rf {} \;
+
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Bootstrap tooling submodule"
+        run: |
+          git submodule update --init --depth 1 fbt_layers/fbtng
+
+      - name: "Get commit details"
+        id: names
+        run: |
+          set -euo pipefail
+          PROFILE='debug'
+          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
+            TYPE="pull"
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            TYPE="tag"
+            PROFILE='release'
+          else
+            TYPE="other"
+          fi
+          echo "event_type=$TYPE" >> "$GITHUB_OUTPUT"
+          echo "build_profile=$PROFILE" >> "$GITHUB_OUTPUT"
+          python3 fbt_layers/fbtng/scripts/get_env.py "--event_file=${{ github.event_path }}" "--type=$TYPE" || (cat "${{ github.event_path }}" && exit 1)
+
+      - name: "Build firmware artifacts"
+        id: build-fw
+        uses: ./.github/actions/build-artifacts
+        with:
+          target_spec: ${{ matrix.target_spec }}
+          build_type: debug
+          firmware_app_set: 917_crash
+          artifact_path: brick-test-artifacts
+          custom_suffix: bricktest
+
+      - name: "Bundle artifacts into zip"
+        id: zip
+        shell: bash
+        run: |
+          set -euo pipefail
+          ARTIFACT_DIR="${{ steps.build-fw.outputs.artifact_path }}"
+          zip_name="busybar-f${U5_TARGET_HW}-bricktest-${{ steps.names.outputs.suffix }}.zip"
+          rm -f "$zip_name"
+          (cd "$ARTIFACT_DIR" && zip -qr "../$zip_name" .)
+          echo "zip_path=$zip_name" >> "$GITHUB_OUTPUT"
+
+      - name: "Upload bundle to build artifacts server"
+        if: ${{ !github.event.pull_request.head.repo.fork && steps.build-fw.outcome == 'success' }}
+        run: |
+          ZIP_PATH="${{ steps.zip.outputs.zip_path }}"
+          curl --fail -L -H "Token: ${{ secrets.INDEXER_TOKEN }}" \
+              -F "branch=${BRANCH_NAME}" \
+              -F "version_token=${COMMIT_SHA}" \
+              -F "files=@${ZIP_PATH}" \
+              "${{ secrets.INDEXER_URL }}"/busybar-firmware/uploadfiles
+
+      - name: "Set update URL output"
+        id: set-url
+        if: ${{ !github.event.pull_request.head.repo.fork && steps.build-fw.outcome == 'success' }}
+        run: |
+          echo "update_url=${{ steps.names.outputs.branch_name }}/${{ steps.zip.outputs.zip_path }}" >> "$GITHUB_OUTPUT"
+
+  # brick-tests:
+  #   needs: brick-test-build
+  #   if: ${{ needs.brick-test-build.result == 'success' && needs.brick-test-build.outputs.update_url != '' }}
+  #   uses: "./.github/workflows/brick-test.yml"
+  #   with:
+  #     branch_name: ${{ github.head_ref || github.ref_name }}
+  #     commit_sha: ${{ github.event.pull_request.head.sha || github.sha }}
+  #     update_url: ${{ needs.brick-test-build.outputs.update_url }}
+  #     target: ${{ needs.brick-test-build.outputs.target }}
+  #   secrets: inherit

--- a/applications/services/application.fam
+++ b/applications/services/application.fam
@@ -50,7 +50,16 @@ App(
     appid="basic_services",
     name="Basic services",
     apptype=FlipperAppType.METAPACKAGE,
-    provides=["cli", "input", "network", "wifi", "nvm", "matter", "startup_dfu_hook"],
+    provides=[
+        "cli",
+        "input",
+        "network",
+        "wifi",
+        "nvm",
+        "matter",
+        "startup_dfu_hook",
+        "crash_cmd",
+    ],
     targets=["f64", "f65"],
 )
 

--- a/applications/services/cli_u5/cli_command_sl_cli.c
+++ b/applications/services/cli_u5/cli_command_sl_cli.c
@@ -5,7 +5,12 @@
 #define TEMP_PIPE_SZ 128U
 #define CLI_PROMPT   "\r\n917>: "
 
-bool cli_command_sl_cli_send_command_get_response(PipeSide* pipe, const char* sl_cmd) {
+FURI_CHECK_RETURN bool
+    cli_command_sl_cli_send_command_get_response(PipeSide* pipe, const char* sl_cmd) {
+    if(!furi_record_exists(RECORD_CLI_INTERCOM)) {
+        return false;
+    }
+
     PipeSideBundle temp_bundle = pipe_alloc(TEMP_PIPE_SZ, 1);
     PipeSide* temp_own_pipe = temp_bundle.alices_side;
     PipeSide* temp_shell_pipe = temp_bundle.bobs_side;

--- a/applications/services/crash/application.fam
+++ b/applications/services/crash/application.fam
@@ -7,3 +7,12 @@ App(
     stack_size=1024 * 1,
     sources=["crash.c"],
 )
+
+App(
+    appid="crash_cmd",
+    name="crash",
+    targets=["f64", "f65"],
+    apptype=FlipperAppType.CLICMD,
+    entry_point="crash_cli_command",
+    sources=["crash_cli.c"],
+)

--- a/applications/services/crash/application.fam
+++ b/applications/services/crash/application.fam
@@ -1,0 +1,9 @@
+App(
+    appid="crash",
+    name="crash",
+    targets=["f64", "f65"],
+    apptype=FlipperAppType.SERVICE,
+    entry_point="crash_srv",
+    stack_size=1024 * 1,
+    sources=["crash.c"],
+)

--- a/applications/services/crash/crash.c
+++ b/applications/services/crash/crash.c
@@ -1,0 +1,5 @@
+#include <furi.h>
+
+int32_t crash_srv(void*) {
+    furi_crash("Crash service invoked");
+}

--- a/applications/services/crash/crash.c
+++ b/applications/services/crash/crash.c
@@ -1,5 +1,8 @@
 #include <furi.h>
 
+#define CRASH_DELAY_MS (3000)
+
 int32_t crash_srv(void*) {
+    furi_delay_ms(CRASH_DELAY_MS);
     furi_crash("Crash service invoked");
 }

--- a/applications/services/crash/crash.c
+++ b/applications/services/crash/crash.c
@@ -1,6 +1,6 @@
 #include <furi.h>
 
-#define CRASH_DELAY_MS (3000)
+#define CRASH_DELAY_MS (1)
 
 int32_t crash_srv(void*) {
     furi_delay_ms(CRASH_DELAY_MS);

--- a/applications/services/crash/crash_cli.c
+++ b/applications/services/crash/crash_cli.c
@@ -1,0 +1,11 @@
+
+#include <cli/cli_command.h>
+
+void crash_cli_command(PipeSide* pipe, FuriString* args, void* context) {
+    UNUSED(context);
+    UNUSED(pipe);
+    UNUSED(args);
+
+    printf("No regrets.");
+    furi_crash("Crash CLI command invoked");
+}

--- a/applications/services/intercom/intercom.c
+++ b/applications/services/intercom/intercom.c
@@ -6,6 +6,7 @@
 
 #define INTERCOM_TX_TIMEOUT_MS                 (1000UL)
 #define INTERCOM_INITIAL_SYNC_RETRY_LOCKOUT_MS (500UL)
+#define INTERCOM_INITIAL_SYNC_TIMEOUT_MS       (10000UL)
 
 #ifdef INTERCOM_DEBUG
 #define INTERCOM_LOG_D(...) FURI_LOG_D(TAG, __VA_ARGS__)
@@ -336,16 +337,24 @@ static Intercom* intercom_alloc(void) {
     // dont't hold up the rest of the system
     furi_record_create(RECORD_INTERCOM, instance);
 
-    while(1) {
+    int n_retry_sync_left =
+        INTERCOM_INITIAL_SYNC_TIMEOUT_MS / INTERCOM_INITIAL_SYNC_RETRY_LOCKOUT_MS / 2;
+
+    while(n_retry_sync_left-- > 0) {
         intercom_sync_request(&INTERCOM_GPIO);
         if(intercom_try_sync(instance)) break;
 
         FURI_LOG_E(
             TAG,
-            "Initial sync failed, retrying in %ld ms",
+            "Initial sync failed, retrying (#%d) in %ld ms",
+            n_retry_sync_left,
             INTERCOM_INITIAL_SYNC_RETRY_LOCKOUT_MS);
 
         furi_delay_ms(INTERCOM_INITIAL_SYNC_RETRY_LOCKOUT_MS);
+    }
+
+    if(!instance->is_in_sync) {
+        intercom_error_handler(IntercomErrorSync, instance);
     }
 
     return instance;

--- a/applications/services/web_server/http_api/api_wifi.c
+++ b/applications/services/web_server/http_api/api_wifi.c
@@ -115,6 +115,14 @@ static bool api_wifi_parse_ip_method(FuriString* method_str, WifiIpManagement* m
     return result;
 }
 
+static bool api_wifi_check_record_exists(struct mg_connection* conn) {
+    if(!furi_record_exists(RECORD_WIFI)) {
+        MG_REPLY_ERROR(conn, 500, "WiFi service not available");
+        return true;
+    }
+    return false;
+}
+
 static bool api_wifi_get_networks_callback(
     FuriString* path,
     struct mg_connection* conn,
@@ -124,6 +132,7 @@ static bool api_wifi_get_networks_callback(
     UNUSED(msg);
 
     if(!IS_HTTP_ENDPOINT(path)) return false;
+    if(!api_wifi_check_record_exists(conn)) return true;
 
     Wifi* wifi = furi_record_open(RECORD_WIFI);
     WifiScanResult* results = malloc(sizeof(WifiScanResult) * WIFI_SCAN_RESULT_COUNT);
@@ -329,6 +338,7 @@ static bool api_wifi_connect_callback(
     UNUSED(ctx);
 
     if(!IS_HTTP_ENDPOINT(path)) return false;
+    if(!api_wifi_check_record_exists(conn)) return true;
 
     WifiCredentials credentials = {0};
     WifiIpConfig ip_config = {0};
@@ -370,6 +380,7 @@ static bool api_wifi_disconnect_callback(
     UNUSED(ctx);
 
     if(!IS_HTTP_ENDPOINT(path)) return false;
+    if(!api_wifi_check_record_exists(conn)) return true;
 
     Wifi* wifi = furi_record_open(RECORD_WIFI);
     WifiStatus status = wifi_disconnect(wifi);
@@ -407,6 +418,7 @@ static bool api_wifi_get_status_callback(
     UNUSED(ctx);
 
     if(!IS_HTTP_ENDPOINT(path)) return false;
+    if(!api_wifi_check_record_exists(conn)) return true;
 
     WifiInfo info = {0};
     Wifi* wifi = furi_record_open(RECORD_WIFI);

--- a/applications/services/wifi/wifi_net.c
+++ b/applications/services/wifi/wifi_net.c
@@ -10,6 +10,8 @@
 #define WIRELESS_MTU (MAX_DATA_LEN - SIZEOF_ETH_HDR + ETH_PAD_SIZE)
 #define DHCP_WAIT_MS (30 * 1000)
 
+#define INTERCOM_TX_TIMEOUT_MS (500)
+
 static err_t wifi_link_output_callback(struct netif* netif, struct pbuf* p) {
     Wifi* instance = netif->state;
     furi_assert(instance);
@@ -19,12 +21,16 @@ static err_t wifi_link_output_callback(struct netif* netif, struct pbuf* p) {
 #endif
 
     const size_t tx_size =
-        intercom_tx(instance->intercom_ch_data, p->payload, p->len, FuriWaitForever);
-    furi_check(tx_size == p->len);
+        intercom_tx(instance->intercom_ch_data, p->payload, p->len, INTERCOM_TX_TIMEOUT_MS);
 
 #if(ETH_PAD_SIZE != 0)
     pbuf_header(p, ETH_PAD_SIZE); /* reclaim the padding word */
 #endif
+
+    if(tx_size != p->len) {
+        FURI_LOG_W(TAG, "intercom_tx timeout or incomplete send");
+        return ERR_IF;
+    }
 
     return ERR_OK;
 }

--- a/applications/system/updater/session/nwp_session.c
+++ b/applications/system/updater/session/nwp_session.c
@@ -17,10 +17,9 @@
 static int32_t nwp_get_active_version_thread_entry(void* context) {
     PipeSide* tx_pipe = context;
 
-    cli_command_sl_cli_send_command_get_response(tx_pipe, "device_info");
-
+    bool success = cli_command_sl_cli_send_command_get_response(tx_pipe, "device_info");
     pipe_free(tx_pipe);
-    return 0;
+    return success ? 0 : -1;
 }
 
 static bool nwp_get_active_version(FuriString* nwp_version) {

--- a/targets/f21/fbt_conf/stm32u595_vars.scons
+++ b/targets/f21/fbt_conf/stm32u595_vars.scons
@@ -19,6 +19,13 @@ _fw_default_apps_config = {
         "debug_apps",
         "unit_tests",
     ],
+    "917_crash": [
+        "basic_services",
+        "main_apps",
+        "settings",
+        "system_apps",
+        "debug_apps",
+    ],
 }
 
 fw_apps_configs_option = find_variable_config(VARS, "FIRMWARE_APPS")

--- a/targets/f64/fbt_conf/si917_vars.scons
+++ b/targets/f64/fbt_conf/si917_vars.scons
@@ -34,6 +34,12 @@ _fw_default_apps_config = {
         "cli",
         "cli_uart",
     ],
+    "917_crash": [
+        "basic_services",
+        "intercom_services",
+        "system_apps",
+        "crash",
+    ],
 }
 
 fw_apps_configs_option = find_variable_config(VARS, "FIRMWARE_APPS")


### PR DESCRIPTION
# What's new

- Added build configuration for 917 that crashes after boot
- Fixed deadlock on intercom_tx for WiFi on crashed 917, rendering USB network connectivity unusable
- Fixed deadlock in updater when 917 is unresponsive
- Added `crash` CLI command to sl_cli
- Added build artefact with brick target

# Verification 

- Connect to WiFi
- Flash brick target (`./fbt FIRMWARE_APP_SET=917_crash flash_usb`)
- Check that you can recover it over USB with `./fbt FIRMWARE_APP_SET=917_crash flash_usb`

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
