### PR TITLE
CLI hotfix: `uptime` command

### DIFF
--- a/applications/services/cli_commands_common/cli_commands.c
+++ b/applications/services/cli_commands_common/cli_commands.c
@@ -11,8 +11,8 @@ void cli_command_uptime(PipeSide* pipe, FuriString* args, void* context) {
     printf(
         "Uptime: %02lud %02luh %02lum %02lus",
         uptime / 60 / 60 / 24,
-        uptime / 60 / 60,
-        uptime / 60 % 60,
+        (uptime / 60 / 60) % 24,
+        (uptime / 60) % 60,
         uptime % 60);
 }
 


### PR DESCRIPTION
# What's new
- Fix hours position in `uptime` command in the unlikely case that uptime is more than 1 day

# Verification 
- Start device
- Wait 24 hours or more
- Verify that `uptime` correctly reports the hours position

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
