### PR TITLE
[FW-574] Do not crash if storage is not ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,11 +29,14 @@ __pycache__/
 *.pickle
 
 .obj/
-.stfolder/
 bindings/
 .DS_Store
 .mxproject
 Brewfile.lock.json
+
+# syncthing
+.stfolder/
+.stignore
 
 # Kate
 .kateproject

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ __pycache__/
 *.pickle
 
 .obj/
+.stfolder/
 bindings/
 .DS_Store
 .mxproject

--- a/applications/services/mqtt_client/mqtt_client.c
+++ b/applications/services/mqtt_client/mqtt_client.c
@@ -525,7 +525,11 @@ int32_t mqtt_client_start(void* p) {
     int default_profile = MqttClientProfileDev;
     JsonConfigStatus res =
         json_config_read_single_int(CONFIG_FILE, "profile", &mqtt->profile_id, &default_profile);
-    furi_assert(res != JsonConfigStatusError);
+    if(res == JsonConfigStatusError) {
+        FURI_LOG_E(TAG, "Storage error, service stopped");
+        furi_thread_suspend(furi_thread_get_current_id());
+    }
+
     if(mqtt->profile_id >= MqttClientProfileMax) {
         JsonConfigStatus res =
             json_config_write_single_int(CONFIG_FILE, "profile", default_profile);


### PR DESCRIPTION
# What's new
[FW-574]
- Fix MQTT service crash in "No partitions" storage state

# Verification 

- Erase storage partitions, the device should show "No partitions" screen

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-574]: https://flipper.atlassian.net/browse/FW-574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ