### PR TITLE
[FW-551] ble init crash fix

### DIFF
--- a/applications/services/ble/ble_system_command_u5.c
+++ b/applications/services/ble/ble_system_command_u5.c
@@ -58,16 +58,14 @@ static bool ble_command_set_device_name_request(BleIntercomFrameGeneric* frame, 
     FuriString* name = furi_string_alloc();
     ble_get_name_from_record(name);
 
-    size_t name_size = furi_string_size(name) + 1;
-    const size_t new_msg_size = sizeof(BleIntercomFrameHeader) + name_size;
+    size_t name_size = furi_string_size(name);
+    size_t new_msg_size = sizeof(BleIntercomFrameHeader) + name_size + 1;
 
     BleIntercomFrameGeneric* name_frame = malloc(new_msg_size);
-
     memcpy(&name_frame->header, &frame->header, sizeof(BleIntercomFrameHeader));
     name_frame->header.command = BleCommandSetDeviceName;
     name_frame->header.data_size = name_size;
     memcpy(name_frame->data, furi_string_get_cstr(name), name_size);
-    name_frame->data[name_size] = 0;
 
     bool result = ble_command_request_process(name_frame, context);
     free(name_frame);

--- a/applications/services/device_name/device_name.c
+++ b/applications/services/device_name/device_name.c
@@ -111,9 +111,9 @@ static bool device_name_read_config(Storage* storage, FuriString* name) {
             FURI_LOG_W(TAG, "File is empty");
             break;
         }
+
+        char buf[MAX_NAME_LENGTH + 1] = {0};
         size_t name_size = MIN(file_size, MAX_NAME_LENGTH);
-        char buf[name_size + 1];
-        buf[name_size] = 0;
 
         if(!storage_file_read(file, buf, name_size)) {
             FURI_LOG_W(TAG, "Unable to read name from file");


### PR DESCRIPTION
# What's new

- [FW-551]
- Fix heap crash during ble init

# Verification 

- Flash and reboot device several times. Device must be connected to Wifi and MQTT
- Try change name

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-551]: https://flipper.atlassian.net/browse/FW-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ