### PR TITLE
http api: fixed wifi record check logic

### DIFF
--- a/applications/services/web_server/http_api/api_wifi.c
+++ b/applications/services/web_server/http_api/api_wifi.c
@@ -117,10 +117,10 @@ static bool api_wifi_parse_ip_method(FuriString* method_str, WifiIpManagement* m
 
 static bool api_wifi_check_record_exists(struct mg_connection* conn) {
     if(!furi_record_exists(RECORD_WIFI)) {
-        MG_REPLY_ERROR(conn, 500, "WiFi service not available");
-        return true;
+        MG_REPLY_ERROR(conn, 503, "WiFi service not available");
+        return false;
     }
-    return false;
+    return true;
 }
 
 static bool api_wifi_get_networks_callback(


### PR DESCRIPTION
# What's new

- fixed furi_record_exists() behaviour
- fixed wifi api being broken

# Verification 

- check that wifi works in regular build
- flash brick fw (`./fbt FIRMWARE_APP_SET=917_crash flash_usb_min`) and check that web api loads correctly

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
