### PR TITLE
Wifi: Hotfix: fix erroneous failure condition

### DIFF
--- a/applications/services/wifi/wifi_net.c
+++ b/applications/services/wifi/wifi_net.c
@@ -23,11 +23,13 @@ static err_t wifi_link_output_callback(struct netif* netif, struct pbuf* p) {
     const size_t tx_size =
         intercom_tx(instance->intercom_ch_data, p->payload, p->len, INTERCOM_TX_TIMEOUT_MS);
 
+    const bool success = (tx_size == p->len);
+
 #if(ETH_PAD_SIZE != 0)
     pbuf_header(p, ETH_PAD_SIZE); /* reclaim the padding word */
 #endif
 
-    if(tx_size != p->len) {
+    if(!success) {
         FURI_LOG_W(TAG, "intercom_tx timeout or incomplete send");
         return ERR_IF;
     }


### PR DESCRIPTION
# What's new

- fix `intercom_tx timeout or incomplete send` error

breaking changes: [[link](https://github.com/flipperdevices/bsb-firmware/commit/faa29d6dc32cfd6127bd85702dae140e50909011#diff-9e5c9a75c629c4b5d50faf36bc0d3e4013702855277e2ec6e2728d58a06ad8d1)] #415 

# Verification 

1. Flash the firmware
2. Connect to Wi-Fi
3. No `intercom_tx timeout or incomplete send` error messages should appear in the logs

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
