### PR TITLE
[FW-591] Matter version reporting

### DIFF
--- a/applications/services/matter/matter.c
+++ b/applications/services/matter/matter.c
@@ -1,6 +1,7 @@
 #include <intercom/intercom.h>
 #include <toolbox/api_lock.h>
 #include <furi_hal_rtc.h>
+#include <furi_hal_version.h>
 
 #include "matter.h"
 #include "matter_common_i.h"
@@ -11,6 +12,9 @@
 #define REQUEST_Q_SIZE 1
 #define FIRST_TIMEOUT  (furi_ms_to_ticks(5000))
 #define TIMEOUT        (furi_ms_to_ticks(200))
+
+#define DEFAULT_HARDWARE_VERSION        4
+#define DEFAULT_HARDWARE_VERSION_STRING "4.F22.B7.C2"
 
 struct MatterSrv {
     FuriEventLoop* event_loop;
@@ -341,16 +345,26 @@ const char* matter_get_de_facto_cd_selection(MatterSrv* matter) {
 
 static bool matter_send_cd_and_await_ready(MatterSrv* matter) {
     furi_assert(matter);
-
-    MatterIntercomFrame cd_frame = {
-        .type = MatterIntercomFrameTypeCdCertificate,
-        .cd_certificate = {
-            .contents_length = 0,
-        }};
-
     matter_cd_init(&matter->cd);
 
-    matter_cd_prepare_initialization_frame(&matter->cd, &cd_frame);
+    MatterIntercomFrame cd_frame;
+    memset(&cd_frame, 0, sizeof(cd_frame));
+    cd_frame.type = MatterIntercomFrameTypeInitialization;
+    MatterIntercomInitializationFrame* init = &cd_frame.initialization;
+
+    matter_cd_prepare_initialization_frame(&matter->cd, init);
+
+    init->hardware_version_num = furi_hal_version_get_hw_version();
+    strcpy(init->hardware_version_str, furi_hal_version_get_hw_version_code());
+
+    // WARNING: this if block is a temporary solution just to pass certification testing,
+    // because our test lab doesn't have samples with provisioned OTP.
+    // TODO: remove this if block and associated defines after we pass certification testing.
+    if(!init->hardware_version_num) {
+        init->hardware_version_num = DEFAULT_HARDWARE_VERSION;
+        strcpy(init->hardware_version_str, DEFAULT_HARDWARE_VERSION_STRING);
+    }
+
     if(!matter_send_frame(matter, &cd_frame)) return false;
 
     if(!matter_pick_frame_of_type(

--- a/applications/services/matter/matter.c
+++ b/applications/services/matter/matter.c
@@ -343,7 +343,7 @@ const char* matter_get_de_facto_cd_selection(MatterSrv* matter) {
 // Service setup
 // =============
 
-static bool matter_send_cd_and_await_ready(MatterSrv* matter) {
+static bool matter_send_initialization_and_await_ready(MatterSrv* matter) {
     furi_assert(matter);
     matter_cd_init(&matter->cd);
 
@@ -397,7 +397,8 @@ MatterSrv* matter_srv_alloc(void) {
     matter->intercom_ch = intercom_channel_open(
         intercom, IntercomChannelIdMatter, matter_forward_frame_to_thread, matter);
 
-    if(!matter_send_cd_and_await_ready(matter)) FURI_LOG_E(TAG, "initialization timed out");
+    if(!matter_send_initialization_and_await_ready(matter))
+        FURI_LOG_E(TAG, "initialization timed out");
 
     furi_record_create(RECORD_MATTER, matter);
     return matter;

--- a/applications/services/matter/matter.c
+++ b/applications/services/matter/matter.c
@@ -117,7 +117,7 @@ static void matter_handle_frame(FuriEventLoopObject* object, void* context) {
         matter->fabrics.count = frame.fabric_count.fabric_count;
 
     } else {
-        furi_crash();
+        FURI_LOG_E(TAG, "Other side is using a different Intercom protocol version");
     }
 }
 

--- a/applications/services/matter/matter_cd.c
+++ b/applications/services/matter/matter_cd.c
@@ -18,7 +18,7 @@ void matter_cd_init(MatterCd* cd) {
     cd->storage = furi_record_open(RECORD_STORAGE);
 }
 
-bool matter_cd_prepare_initialization_frame(MatterCd* cd, MatterIntercomFrame* frame) {
+bool matter_cd_prepare_initialization_frame(MatterCd* cd, MatterIntercomInitializationFrame* frame) {
     furi_assert(cd);
     furi_assert(frame);
 
@@ -39,8 +39,6 @@ bool matter_cd_prepare_initialization_frame(MatterCd* cd, MatterIntercomFrame* f
     }
 
     cd->de_facto_selection = NULL;
-    frame->type = MatterIntercomFrameTypeCdCertificate;
-    MatterIntercomCdCertificateFrame* cert_frame = &frame->cd_certificate;
 
     for(size_t i = selected_idx; i < COUNT_OF(cd_certificates); i++) {
         const char* candidate = cd_certificates[i];
@@ -49,9 +47,9 @@ bool matter_cd_prepare_initialization_frame(MatterCd* cd, MatterIntercomFrame* f
         snprintf(candidate_path, sizeof(candidate_path), CERTIFICATE_PATH("%s"), candidate);
         FURI_LOG_D(TAG, "trying \"%s\" (idx %zu) at \"%s\"", candidate, i, candidate_path);
 
-        cert_frame->contents_length = storage_simply_read_entire_file(
-            cd->storage, candidate_path, cert_frame->contents, sizeof(cert_frame->contents));
-        bool candidate_valid = cert_frame->contents_length > 0;
+        frame->cd_certificate_length = storage_simply_read_entire_file(
+            cd->storage, candidate_path, frame->cd_certificate, sizeof(frame->cd_certificate));
+        bool candidate_valid = frame->cd_certificate_length > 0;
         if(!candidate_valid) continue;
 
         FURI_LOG_D(TAG, "success");

--- a/applications/services/matter/matter_cd.h
+++ b/applications/services/matter/matter_cd.h
@@ -22,7 +22,7 @@ void matter_cd_init(MatterCd* cd);
 /**
  * @returns true on success
  */
-bool matter_cd_prepare_initialization_frame(MatterCd* cd, MatterIntercomFrame* frame);
+bool matter_cd_prepare_initialization_frame(MatterCd* cd, MatterIntercomInitializationFrame* frame);
 
 const char* matter_cd_get_wanted_selection(MatterCd* cd);
 

--- a/applications/services/matter/matter_common_i.h
+++ b/applications/services/matter/matter_common_i.h
@@ -29,7 +29,7 @@ extern "C" {
 typedef struct FURI_PACKED {
     uint8_t hardware_version_num;
 
-    char hardware_version_str[16];
+    char hardware_version_str[20];
 
     uint16_t cd_certificate_length;
     uint8_t cd_certificate[512];

--- a/applications/services/matter/matter_common_i.h
+++ b/applications/services/matter/matter_common_i.h
@@ -92,7 +92,7 @@ typedef struct FURI_PACKED {
 
 typedef enum {
     MatterIntercomFrameTypeBase =
-        (MATTER_INTERCOM_PROTOCOL_VERSION * 16), //<! Used to enforce protocol versions
+        (MATTER_INTERCOM_PROTOCOL_VERSION * 256), //<! Used to enforce protocol versions
 
     MatterIntercomFrameTypeInitialization, //<! Initialization parameters. Direction: u5->917
     MatterIntercomFrameTypeBackendReady, //<! Backend has fully initialized. Direction: 917->u5

--- a/applications/services/matter/matter_common_i.h
+++ b/applications/services/matter/matter_common_i.h
@@ -22,12 +22,16 @@ extern "C" {
 // ===============
 
 /**
- * @brief Contents of CD
+ * @brief Initialization parameters
  */
 typedef struct {
-    size_t contents_length;
-    char contents[512];
-} MatterIntercomCdCertificateFrame;
+    uint8_t hardware_version_num;
+
+    char hardware_version_str[16];
+
+    uint16_t cd_certificate_length;
+    uint8_t cd_certificate[512];
+} MatterIntercomInitializationFrame;
 
 /**
  * @brief Backend has fully initialized
@@ -85,7 +89,7 @@ typedef struct {
 // =============
 
 typedef enum {
-    MatterIntercomFrameTypeCdCertificate, //<! Contents of CD. Direction: u5->917
+    MatterIntercomFrameTypeInitialization, //<! Initialization parameters. Direction: u5->917
     MatterIntercomFrameTypeBackendReady, //<! Backend has fully initialized. Direction: 917->u5
 
     MatterIntercomFrameTypeSwitchState, //<! Request to change state. Direction: u5<->917
@@ -104,7 +108,7 @@ typedef struct {
     MatterIntercomFrameType type;
     union {
         uint8_t frame_of_any_type;
-        MatterIntercomCdCertificateFrame cd_certificate;
+        MatterIntercomInitializationFrame initialization;
         MatterIntercomBackendReadyFrame backend_ready;
         MatterIntercomSwitchStateFrame switch_state;
         MatterIntercomStartupModeFrame startup;

--- a/applications/services/matter/matter_common_i.h
+++ b/applications/services/matter/matter_common_i.h
@@ -12,6 +12,8 @@
 extern "C" {
 #endif
 
+#define MATTER_INTERCOM_PROTOCOL_VERSION (1)
+
 #define MATTER_COMMISSION_TIME_SECONDS (60 * 15)
 #define MATTER_MAX_QR_CODE_LEN         (255) // Spec paragraph 5.1.3
 #define MATTER_MAX_MAN_CODE_LEN \
@@ -24,7 +26,7 @@ extern "C" {
 /**
  * @brief Initialization parameters
  */
-typedef struct {
+typedef struct FURI_PACKED {
     uint8_t hardware_version_num;
 
     char hardware_version_str[16];
@@ -36,51 +38,51 @@ typedef struct {
 /**
  * @brief Backend has fully initialized
  */
-typedef struct {
+typedef struct FURI_PACKED {
 } MatterIntercomBackendReadyFrame;
 
 /**
  * @brief Request to change state
  */
-typedef struct {
+typedef struct FURI_PACKED {
     bool value;
 } MatterIntercomSwitchStateFrame;
 
 /**
  * @brief Request to change startup mode
  */
-typedef struct {
+typedef struct FURI_PACKED {
     uint8_t mode;
 } MatterIntercomStartupModeFrame;
 
 /**
  * @brief Request to wipe all Matter-related data (factory reset)
  */
-typedef struct {
+typedef struct FURI_PACKED {
 } MatterIntercomResetFrame;
 
 /**
  * @brief Request to open basic commissioning window
  */
-typedef struct {
+typedef struct FURI_PACKED {
 } MatterIntercomCommissionFrame;
 
 /**
  * @brief Number of commissioned fabrics
  */
-typedef struct {
+typedef struct FURI_PACKED {
     uint8_t fabric_count;
 } MatterIntercomFabricCountUpdateFrame;
 
 /**
  * @brief Pairing codes
  */
-typedef struct {
+typedef struct FURI_PACKED {
     char qr_code[MATTER_MAX_QR_CODE_LEN + 1];
     char manual_code[MATTER_MAX_MAN_CODE_LEN + 1];
 } MatterIntercomPairingCodesFrame;
 
-typedef struct {
+typedef struct FURI_PACKED {
     MatterCommissioningStatus status;
 } MatterIntercomCommissionStatusFrame;
 
@@ -89,6 +91,9 @@ typedef struct {
 // =============
 
 typedef enum {
+    MatterIntercomFrameTypeBase =
+        (MATTER_INTERCOM_PROTOCOL_VERSION * 16), //<! Used to enforce protocol versions
+
     MatterIntercomFrameTypeInitialization, //<! Initialization parameters. Direction: u5->917
     MatterIntercomFrameTypeBackendReady, //<! Backend has fully initialized. Direction: 917->u5
 

--- a/applications/services/matter/matter_f64.cpp
+++ b/applications/services/matter/matter_f64.cpp
@@ -198,7 +198,7 @@ static void matter_handle_frame(const void* data, size_t data_size, void* contex
         matter_send_frame(matter, &frame);
 
     } else {
-        furi_crash(/* we shouldn't be receiving this frame */);
+        FURI_LOG_E(TAG, "Other side is using a different Intercom protocol version");
     }
 }
 

--- a/applications/services/matter/matter_f64.cpp
+++ b/applications/services/matter/matter_f64.cpp
@@ -52,7 +52,7 @@ public:
 
     IntercomChannel* m_intercom_ch;
     StatusLights* m_status_lights;
-    FuriSemaphore* m_cd_available;
+    FuriSemaphore* m_initialization_received;
 
 private:
     CommonCaseDeviceServerInitParams m_server_init_params;
@@ -133,11 +133,16 @@ static void matter_handle_frame(const void* data, size_t data_size, void* contex
     const auto* frame = static_cast<const MatterIntercomFrame*>(data);
     auto* matter = static_cast<MatterSrv*>(context);
 
-    if(frame->type == MatterIntercomFrameTypeCdCertificate) {
-        FURI_LOG_D(TAG, "CdCertificate frame");
+    if(frame->type == MatterIntercomFrameTypeInitialization) {
+        FURI_LOG_D(TAG, "Initialization frame");
+        auto init = &frame->initialization;
         Credentials::BSB::GetDeviceAttestationCredentialsProvider()->SetCertificationDeclaration(
-            frame->cd_certificate.contents, frame->cd_certificate.contents_length);
-        furi_check(furi_semaphore_release(matter->m_cd_available) == FuriStatusOk);
+            init->cd_certificate, init->cd_certificate_length);
+
+        DeviceLayer::BSB::GetDeviceInstanceInfoProvider()->SetHardwareVersion(
+            init->hardware_version_num, init->hardware_version_str);
+
+        furi_check(furi_semaphore_release(matter->m_initialization_received) == FuriStatusOk);
 
     } else if(frame->type == MatterIntercomFrameTypeSwitchState) {
         FURI_LOG_D(TAG, "SwitchState frame");
@@ -325,7 +330,7 @@ MatterSrv::MatterSrv(void)
           matter_stop_blinking,
           chip::app::Clusters::Identify::IdentifyTypeEnum::kVisibleIndicator)) {
     m_status_lights = static_cast<StatusLights*>(furi_record_open(RECORD_STATUS_LIGHTS));
-    m_cd_available = furi_semaphore_alloc(1, 0);
+    m_initialization_received = furi_semaphore_alloc(1, 0);
 }
 
 CHIP_ERROR MatterSrv::init(void) {
@@ -348,7 +353,7 @@ CHIP_ERROR MatterSrv::init(void) {
         m_intercom_ch =
             intercom_channel_open(intercom, IntercomChannelIdMatter, matter_handle_frame, this);
 
-        if(furi_semaphore_acquire(m_cd_available, CD_AWAIT_TIMEOUT) != FuriStatusOk) {
+        if(furi_semaphore_acquire(m_initialization_received, CD_AWAIT_TIMEOUT) != FuriStatusOk) {
             err = CHIP_ERROR_TIMEOUT;
             break;
         }

--- a/lib/matter_glue/platform/bsb/BSBDeviceInstanceInfoProvider.cpp
+++ b/lib/matter_glue/platform/bsb/BSBDeviceInstanceInfoProvider.cpp
@@ -106,7 +106,8 @@ CHIP_ERROR DeviceInstanceInfoProviderImpl::GetHardwareVersionString(char* buf, s
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DeviceInstanceInfoProviderImpl::SetHardwareVersion(uint16_t number, const char* string) {
+CHIP_ERROR
+    DeviceInstanceInfoProviderImpl::SetHardwareVersion(uint16_t number, const char* string) {
     m_hw_version = number;
     strncpy(m_hw_version_str, string, sizeof(m_hw_version_str) - 1);
     return CHIP_NO_ERROR;

--- a/lib/matter_glue/platform/bsb/BSBDeviceInstanceInfoProvider.cpp
+++ b/lib/matter_glue/platform/bsb/BSBDeviceInstanceInfoProvider.cpp
@@ -17,8 +17,6 @@ enum {
     ProductLabel,
     SerialNumber,
     ManufacturingDate,
-    HardwareVersion,
-    HardwareVersionString,
 };
 
 }; // namespace KeyId
@@ -34,22 +32,6 @@ struct ManufacturingDate {
 static_assert(sizeof(ManufacturingDate) == 4, "Invalid ManufacturingDate size");
 
 using namespace BSB;
-
-class DeviceInstanceInfoProviderImpl : public DeviceInstanceInfoProvider {
-public:
-    CHIP_ERROR GetVendorName(char* buf, size_t bufSize) override;
-    CHIP_ERROR GetVendorId(uint16_t& vendorId) override;
-    CHIP_ERROR GetProductName(char* buf, size_t bufSize) override;
-    CHIP_ERROR GetProductId(uint16_t& productId) override;
-    CHIP_ERROR GetPartNumber(char* buf, size_t bufSize) override;
-    CHIP_ERROR GetProductURL(char* buf, size_t bufSize) override;
-    CHIP_ERROR GetProductLabel(char* buf, size_t bufSize) override;
-    CHIP_ERROR GetSerialNumber(char* buf, size_t bufSize) override;
-    CHIP_ERROR GetManufacturingDate(uint16_t& year, uint8_t& month, uint8_t& day) override;
-    CHIP_ERROR GetHardwareVersion(uint16_t& hardwareVersion) override;
-    CHIP_ERROR GetHardwareVersionString(char* buf, size_t bufSize) override;
-    CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan& uniqueIdSpan) override;
-};
 
 CHIP_ERROR DeviceInstanceInfoProviderImpl::GetVendorName(char* buf, size_t bufSize) {
     auto out_span = ToMutableByteSpan(buf, bufSize);
@@ -113,15 +95,21 @@ CHIP_ERROR DeviceInstanceInfoProviderImpl::GetManufacturingDate(
 }
 
 CHIP_ERROR DeviceInstanceInfoProviderImpl::GetHardwareVersion(uint16_t& hardwareVersion) {
-    auto out_span = ToMutableByteSpan(hardwareVersion);
-    return LoadCryptoStorageKey(
-        FuriHalCryptoKeyTypeMatterDeviceInfo, KeyId::HardwareVersion, out_span);
+    if(!strlen(m_hw_version_str)) return CHIP_ERROR_INCORRECT_STATE;
+    hardwareVersion = m_hw_version;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DeviceInstanceInfoProviderImpl::GetHardwareVersionString(char* buf, size_t bufSize) {
-    auto out_span = ToMutableByteSpan(buf, bufSize);
-    return LoadCryptoStorageKey(
-        FuriHalCryptoKeyTypeMatterDeviceInfo, KeyId::HardwareVersionString, out_span);
+    if(!strlen(m_hw_version_str)) return CHIP_ERROR_INCORRECT_STATE;
+    strncpy(buf, m_hw_version_str, bufSize - 1);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeviceInstanceInfoProviderImpl::SetHardwareVersion(uint16_t number, const char* string) {
+    m_hw_version = number;
+    strncpy(m_hw_version_str, string, sizeof(m_hw_version_str) - 1);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR
@@ -131,7 +119,7 @@ DeviceInstanceInfoProviderImpl::GetRotatingDeviceIdUniqueId(MutableByteSpan& uni
 }
 
 namespace BSB {
-DeviceInstanceInfoProvider* GetDeviceInstanceInfoProvider(void) {
+DeviceInstanceInfoProviderImpl* GetDeviceInstanceInfoProvider(void) {
     static DeviceInstanceInfoProviderImpl provider;
     return &provider;
 }

--- a/lib/matter_glue/platform/bsb/BSBDeviceInstanceInfoProvider.cpp
+++ b/lib/matter_glue/platform/bsb/BSBDeviceInstanceInfoProvider.cpp
@@ -107,7 +107,7 @@ CHIP_ERROR DeviceInstanceInfoProviderImpl::GetHardwareVersionString(char* buf, s
 }
 
 CHIP_ERROR
-    DeviceInstanceInfoProviderImpl::SetHardwareVersion(uint16_t number, const char* string) {
+DeviceInstanceInfoProviderImpl::SetHardwareVersion(uint16_t number, const char* string) {
     m_hw_version = number;
     strncpy(m_hw_version_str, string, sizeof(m_hw_version_str) - 1);
     return CHIP_NO_ERROR;

--- a/lib/matter_glue/platform/bsb/BSBDeviceInstanceInfoProvider.hpp
+++ b/lib/matter_glue/platform/bsb/BSBDeviceInstanceInfoProvider.hpp
@@ -8,7 +8,7 @@ namespace BSB {
 class DeviceInstanceInfoProviderImpl : public DeviceInstanceInfoProvider {
 private:
     uint16_t m_hw_version;
-    char m_hw_version_str[16];
+    char m_hw_version_str[20];
 
 public:
     CHIP_ERROR GetVendorName(char* buf, size_t bufSize) override;

--- a/lib/matter_glue/platform/bsb/BSBDeviceInstanceInfoProvider.hpp
+++ b/lib/matter_glue/platform/bsb/BSBDeviceInstanceInfoProvider.hpp
@@ -5,7 +5,28 @@
 namespace chip {
 namespace DeviceLayer {
 namespace BSB {
-DeviceInstanceInfoProvider* GetDeviceInstanceInfoProvider(void);
+class DeviceInstanceInfoProviderImpl : public DeviceInstanceInfoProvider {
+private:
+    uint16_t m_hw_version;
+    char m_hw_version_str[16];
+
+public:
+    CHIP_ERROR GetVendorName(char* buf, size_t bufSize) override;
+    CHIP_ERROR GetVendorId(uint16_t& vendorId) override;
+    CHIP_ERROR GetProductName(char* buf, size_t bufSize) override;
+    CHIP_ERROR GetProductId(uint16_t& productId) override;
+    CHIP_ERROR GetPartNumber(char* buf, size_t bufSize) override;
+    CHIP_ERROR GetProductURL(char* buf, size_t bufSize) override;
+    CHIP_ERROR GetProductLabel(char* buf, size_t bufSize) override;
+    CHIP_ERROR GetSerialNumber(char* buf, size_t bufSize) override;
+    CHIP_ERROR GetManufacturingDate(uint16_t& year, uint8_t& month, uint8_t& day) override;
+    CHIP_ERROR GetHardwareVersion(uint16_t& hardwareVersion) override;
+    CHIP_ERROR GetHardwareVersionString(char* buf, size_t bufSize) override;
+    CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan& uniqueIdSpan) override;
+
+    CHIP_ERROR SetHardwareVersion(uint16_t number, const char* string);
+};
+DeviceInstanceInfoProviderImpl* GetDeviceInstanceInfoProvider(void);
 } // namespace BSB
 } // namespace DeviceLayer
 } // namespace Chip

--- a/lib/matter_glue/platform/bsb/ConfigurationManagerImpl.cpp
+++ b/lib/matter_glue/platform/bsb/ConfigurationManagerImpl.cpp
@@ -135,12 +135,8 @@ exit:
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersionString(char* buf, size_t bufSize) {
-    const Version* version = version_get();
-    const char* version_str = version_get_version(version);
-
-    if(strlen(version_str) + 1 > bufSize) return CHIP_ERROR_BUFFER_TOO_SMALL;
-
-    strcpy(buf, version_str);
+    size_t version_num = MATTER_SOFTWARE_VER_NUM;
+    snprintf(buf, bufSize, "%zu", version_num);
     return CHIP_NO_ERROR;
 }
 

--- a/scripts/credentials.py
+++ b/scripts/credentials.py
@@ -72,8 +72,6 @@ class DeviceInfoKeyID(IntEnum):
     PRODUCT_LABEL = 6
     SERIAL_NUMBER = 7
     MANUFACTURING_DATE = 8
-    HARDWARE_VERSION = 9
-    HARDWARE_VERSION_STRING = 10
 
 
 class Main(App):
@@ -289,12 +287,6 @@ class Main(App):
             DeviceInfoKeyID.PRODUCT_LABEL: to_terminated(self.args.product_label),
             DeviceInfoKeyID.SERIAL_NUMBER: to_terminated(serial),
             DeviceInfoKeyID.MANUFACTURING_DATE: pack_current_date(),
-            DeviceInfoKeyID.HARDWARE_VERSION: struct.pack(
-                "<H", self.args.hardware_version
-            ),
-            DeviceInfoKeyID.HARDWARE_VERSION_STRING: to_terminated(
-                self.args.hardware_version_string
-            ),
         }
         self.write_data(KeyType.DEVICE_INFO, data)
 

--- a/targets/f21/furi_hal/furi_hal_info.c
+++ b/targets/f21/furi_hal/furi_hal_info.c
@@ -188,6 +188,8 @@ void furi_hal_info_get(PropertyValueCallback out, char sep, void* context) {
             &property_context, "otp1", "target", furi_hal_version_get_hw_target_otp());
         property_out_int(&property_context, "otp1", "body", furi_hal_version_get_hw_body());
         property_out_int(&property_context, "otp1", "connect", furi_hal_version_get_hw_connect());
+        property_out_str(
+            &property_context, "otp1", "version_code", furi_hal_version_get_hw_version_code());
         property_out_long(
             &property_context, "otp1", "timestamp", furi_hal_version_get_hw_timestamp());
 

--- a/targets/f21/furi_hal/furi_hal_version.c
+++ b/targets/f21/furi_hal/furi_hal_version.c
@@ -15,7 +15,7 @@
 #define OTP1_MAC_SIZE   (6)
 #define OTP1_MODEL_SIZE (8)
 
-#define HW_VER_CODE_SIZE (16)
+#define HW_VER_CODE_SIZE (20)
 #define HW_UID_SIZE      (12)
 
 typedef struct {

--- a/targets/f21/furi_hal/furi_hal_version.c
+++ b/targets/f21/furi_hal/furi_hal_version.c
@@ -15,7 +15,8 @@
 #define OTP1_MAC_SIZE   (6)
 #define OTP1_MODEL_SIZE (8)
 
-#define HW_UID_SIZE (12)
+#define HW_VER_CODE_SIZE (16)
+#define HW_UID_SIZE      (12)
 
 typedef struct {
     bool otp1_valid;
@@ -25,6 +26,7 @@ typedef struct {
 
     // Cached/derived values
     char model_code[OTP1_MODEL_SIZE + 1]; // Null-terminated model
+    char hw_version_code[HW_VER_CODE_SIZE];
     uint8_t usb_mac[OTP1_MAC_SIZE];
     uint8_t hw_uid[HW_UID_SIZE];
 } FuriHalVersionState;
@@ -174,6 +176,24 @@ void furi_hal_version_init(void) {
             sizeof(furi_hal_version_state.model_code) - 1);
     }
 
+    // Initialize hardware version code
+    if(furi_hal_version_state.otp1_valid) {
+        const Otp1Data* otp1 = otp_get_otp1();
+        snprintf(
+            furi_hal_version_state.hw_version_code,
+            sizeof(furi_hal_version_state),
+            "%hhu.F%hhu.B%hhu.C%hhu",
+            otp1->hw_version,
+            otp1->hw_target,
+            otp1->hw_body,
+            otp1->hw_connect);
+    } else {
+        strncpy(
+            furi_hal_version_state.hw_version_code,
+            "Unknown",
+            sizeof(furi_hal_version_state.hw_version_code) - 1);
+    }
+
     // Initialize USB MAC address
     if(furi_hal_version_state.otp1_valid) {
         const Otp1Data* otp1 = otp_get_otp1();
@@ -236,6 +256,10 @@ uint8_t furi_hal_version_get_hw_connect(void) {
         return 0;
     }
     return otp_get_otp1()->hw_connect;
+}
+
+const char* furi_hal_version_get_hw_version_code(void) {
+    return furi_hal_version_state.hw_version_code;
 }
 
 uint32_t furi_hal_version_get_hw_timestamp(void) {

--- a/targets/f21/furi_hal/furi_hal_version.h
+++ b/targets/f21/furi_hal/furi_hal_version.h
@@ -113,6 +113,13 @@ FuriHalVersionColor furi_hal_version_get_hw_color(void);
  */
 uint8_t furi_hal_version_get_hw_connect(void);
 
+/** Get full hardware version code
+ * 
+ * @return     Version code (like `"4.F22.B7.C2"`).
+ *             Value is `"Unknown"` if OTP1 not provisioned.
+ */
+const char* furi_hal_version_get_hw_version_code(void);
+
 /** Get hardware region (raw value from OTP2)
  *
  * @return     Hardware Region value


### PR DESCRIPTION
# What's new
- FW-591:
  - `SoftwareVersionString` now identical to `SoftwareVersion`
  - `HardwareVersion` and `HardwareVersionString` now sourced from OTP with temporary fallback to default

# Verification 
- Using `chip-tool` after commissioning (123 is the node ID that the device was commissioned under)
  - `basicinformation read software-version 123 0` -> `SoftwareVersion: 3`
  - `basicinformation read software-version-string 123 0` -> `SoftwareVersionString: 3`
  - `basicinformation read hardware-version 123 0` -> `HardwareVersion: 4`
  - `basicinformation read hardware-version-string 123 0` -> `HardwareVersionString: 4.F22.B7.C2`
- Also verify with provisioned OTP (I don't have it and I'm scared to flash OTP)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
