### PR TITLE
[FW-576, FW-503] DFU light indication fix

### DIFF
--- a/applications/services/input/input_f64.c
+++ b/applications/services/input/input_f64.c
@@ -33,18 +33,6 @@ typedef struct {
     bool level;
 } InputKeyState;
 
-typedef enum {
-    InputRequestTypeGetAbsState,
-} InputRequestType;
-
-typedef struct {
-    InputRequestType type;
-    FuriApiLock lock;
-    union {
-        InputAbsoluteState* abs_state;
-    };
-} InputRequest;
-
 struct Input {
     FuriPubSub* event_pubsub;
     FuriEventLoop* event_loop;
@@ -55,8 +43,7 @@ struct Input {
     Intercom* intercom_srv;
     IntercomChannel* intercom_ch;
 #endif
-    FuriMessageQueue* request_queue;
-    InputAbsoluteState absolute_state;
+    FuriState* absolute_state;
 };
 
 static void input_send(Input* instance, const InputPin* pin, InputAction input_action);
@@ -77,28 +64,6 @@ static void input_custom_event_callback(uint32_t events, void* context) {
     }
 }
 
-static void input_request_callback(FuriEventLoopObject* object, void* context) {
-    UNUSED(object);
-    furi_assert(context);
-
-    Input* instance = context;
-
-    InputRequest request;
-    furi_check(furi_message_queue_get(instance->request_queue, &request, 0) == FuriStatusOk);
-
-    switch(request.type) {
-    case InputRequestTypeGetAbsState:
-        *request.abs_state = instance->absolute_state;
-        break;
-    default:
-        furi_crash();
-    }
-
-    if(request.lock) {
-        api_lock_unlock(request.lock);
-    }
-}
-
 static void input_send(Input* instance, const InputPin* pin, InputAction input_action) {
     InputCommonEvent event;
     event.device = pin->device;
@@ -106,7 +71,9 @@ static void input_send(Input* instance, const InputPin* pin, InputAction input_a
     if(pin->device == InputDeviceSwitch) {
         if(input_action == InputActionPress) {
             event.switch_position = pin->pos;
-            instance->absolute_state.switch_position = pin->pos;
+            with_furi_state(instance->absolute_state, InputAbsoluteState * st, {
+                st->switch_position = pin->pos;
+            });
             furi_check(furi_message_queue_put(instance->input_queue, &event, 0) == FuriStatusOk);
         }
     } else {
@@ -114,9 +81,13 @@ static void input_send(Input* instance, const InputPin* pin, InputAction input_a
         event.button_event.action = input_action;
 
         if(input_action == InputActionPress) {
-            instance->absolute_state.buttons |= (1 << pin->button);
+            with_furi_state(instance->absolute_state, InputAbsoluteState * st, {
+                st->buttons |= (1 << pin->button);
+            });
         } else {
-            instance->absolute_state.buttons &= ~(1 << pin->button);
+            with_furi_state(instance->absolute_state, InputAbsoluteState * st, {
+                st->buttons &= ~(1 << pin->button);
+            });
         }
 
         furi_check(furi_message_queue_put(instance->input_queue, &event, 0) == FuriStatusOk);
@@ -235,7 +206,10 @@ int32_t input_srv(void* p) {
         FuriEventLoopTimerTypePeriodic,
         instance);
     instance->key_states = malloc(sizeof(InputKeyState) * input_pins_count);
-    instance->request_queue = furi_message_queue_alloc(REQUEST_QUEUE_SIZE, sizeof(InputRequest));
+    instance->absolute_state = furi_state_alloc(sizeof(InputAbsoluteState));
+
+    furi_record_create(RECORD_INPUT, instance);
+    furi_record_create(RECORD_INPUT_EVENTS, instance->event_pubsub);
 
     for(size_t i = 0; i < input_pins_count; i++) {
         const InputPin* pin = &input_pins[i];
@@ -272,15 +246,6 @@ int32_t input_srv(void* p) {
         FuriEventLoopEventIn,
         input_queue_callback,
         instance);
-    furi_event_loop_subscribe_message_queue(
-        instance->event_loop,
-        instance->request_queue,
-        FuriEventLoopEventIn,
-        input_request_callback,
-        instance);
-
-    furi_record_create(RECORD_INPUT, instance);
-    furi_record_create(RECORD_INPUT_EVENTS, instance->event_pubsub);
 
     furi_hal_qei_init();
     furi_hal_qei_set_delta_pos_callback(input_qei_callback, instance);
@@ -294,17 +259,8 @@ int32_t input_srv(void* p) {
 InputAbsoluteState input_get_absolute_state(Input* instance) {
     furi_assert(instance);
 
-    InputAbsoluteState abs_state;
-    InputRequest request = {
-        .type = InputRequestTypeGetAbsState,
-        .lock = api_lock_alloc_locked(),
-        .abs_state = &abs_state,
-    };
+    InputAbsoluteState state;
+    furi_state_get(instance->absolute_state, &state);
 
-    furi_check(
-        furi_message_queue_put(instance->request_queue, &request, FuriWaitForever) ==
-        FuriStatusOk);
-    api_lock_wait_unlock_and_free(request.lock);
-
-    return *request.abs_state;
+    return state;
 }

--- a/applications/services/input/input_f64.h
+++ b/applications/services/input/input_f64.h
@@ -13,7 +13,6 @@ extern "C" {
 #define RECORD_INPUT        "input"
 #define RECORD_INPUT_EVENTS "input_events"
 
-// TODO [FW-503]: replace this w/ furi_state
 /**
  * @brief Gets the state of all absolute controls, i.e. the buttons and the mode
  *        switch
@@ -22,7 +21,7 @@ extern "C" {
  * 
  * @returns State of all absolute controls
  */
-InputAbsoluteState FURI_DEPRECATED input_get_absolute_state(Input* instance);
+InputAbsoluteState input_get_absolute_state(Input* instance);
 
 #ifdef __cplusplus
 }

--- a/applications/services/status_lights/status_lights_backend.c
+++ b/applications/services/status_lights/status_lights_backend.c
@@ -11,12 +11,17 @@
 
 #define DEFAULT_BRIGHTNESS 1.f
 
+typedef enum {
+    StatusLightsEventSyncDone = 1UL << 0,
+} StatusLightsEvent;
+
 typedef void (*CommandHandler)(StatusLights* instance, const StatusLightsCommand* command);
 
 struct StatusLights {
     FuriEventLoop* event_loop;
     FuriMessageQueue* command_queue;
     FuriEventLoopTimer* timer;
+    Intercom* intercom;
     IntercomChannel* intercom_ch;
 
     StatusLightsGenericPreset* preset_instance;
@@ -91,6 +96,33 @@ static void status_lights_intercom_rx_callback(const void* data, size_t data_siz
         furi_message_queue_put(instance->command_queue, data, FuriWaitForever) == FuriStatusOk);
 }
 
+static void status_lights_intercom_events_callback(const void* message, void* context) {
+    furi_assert(message);
+    furi_assert(context);
+
+    const IntercomEvent* event = message;
+    StatusLights* instance = context;
+
+    if(event->type == IntercomEventTypeSyncStateChanged) {
+        if(event->is_in_sync) {
+            furi_event_loop_set_custom_event(instance->event_loop, StatusLightsEventSyncDone);
+        }
+    }
+}
+
+static void status_lights_event_callback(uint32_t events, void* context) {
+    furi_assert(context);
+    StatusLights* instance = context;
+
+    if(events & StatusLightsEventSyncDone) {
+        instance->intercom_ch = intercom_channel_open(
+            instance->intercom,
+            IntercomChannelIdStatusLights,
+            status_lights_intercom_rx_callback,
+            instance);
+    }
+}
+
 static StatusLights* status_lights_alloc() {
     StatusLights* instance = malloc(sizeof(StatusLights));
     instance->preset_instance = NULL;
@@ -98,6 +130,8 @@ static StatusLights* status_lights_alloc() {
     instance->active_color = (Color){0};
     instance->brightness = DEFAULT_BRIGHTNESS;
     instance->event_loop = furi_event_loop_alloc();
+    furi_event_loop_set_custom_event_callback(
+        instance->event_loop, status_lights_event_callback, instance);
     instance->command_queue = furi_message_queue_alloc(8, sizeof(StatusLightsCommand));
     furi_event_loop_subscribe_message_queue(
         instance->event_loop,
@@ -108,9 +142,17 @@ static StatusLights* status_lights_alloc() {
     instance->timer = furi_event_loop_timer_alloc(
         instance->event_loop, status_lights_run_pattern, FuriEventLoopTimerTypePeriodic, instance);
 
-    Intercom* intercom = furi_record_open(RECORD_INTERCOM);
-    instance->intercom_ch = intercom_channel_open(
-        intercom, IntercomChannelIdStatusLights, status_lights_intercom_rx_callback, instance);
+    instance->intercom = furi_record_open(RECORD_INTERCOM);
+    if(intercom_is_in_sync(instance->intercom)) {
+        instance->intercom_ch = intercom_channel_open(
+            instance->intercom,
+            IntercomChannelIdStatusLights,
+            status_lights_intercom_rx_callback,
+            instance);
+    } else {
+        FuriPubSub* intercom_events = intercom_get_pubsub(instance->intercom);
+        furi_pubsub_subscribe(intercom_events, status_lights_intercom_events_callback, instance);
+    }
 
     furi_record_create(RECORD_STATUS_LIGHTS, instance);
 


### PR DESCRIPTION
# What's new
FW-576, FW-503
- Input and light backend fixed to work without intercom sync
- input_get_absolute_state now uses furi_state

# Verification 

- Enter DFU mode, top leds should blink yellow and light red to indicate DFU mode

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
