### PR TITLE
Animation hotfixes 2

### DIFF
--- a/applications/services/gui/modules/anim_player.c
+++ b/applications/services/gui/modules/anim_player.c
@@ -156,6 +156,7 @@ bool anim_player_start(AnimPlayer* instance) {
     furi_check(instance);
     if(!instance->file) return false;
     lv_timer_resume(instance->timer);
+    lv_timer_ready(instance->timer);
     return true;
 }
 

--- a/applications/services/web_server/http_api/api_display.c
+++ b/applications/services/web_server/http_api/api_display.c
@@ -204,9 +204,9 @@ static bool api_display_draw_parse_anim_player_element(
         char* json_str;
 
         if((json_str = mg_json_get_str(json_element, "$.section"))) {
-            canvas_element->anim_player.file_path = furi_string_alloc_set_str(json_str);
+            canvas_element->anim_player.section = furi_string_alloc_set_str(json_str);
         } else {
-            canvas_element->anim_player.file_path =
+            canvas_element->anim_player.section =
                 furi_string_alloc_set_str(ANIM_FILE_DEFAULT_SECTION);
         }
 


### PR DESCRIPTION
# What's new
- Example HTTP request from #382 actually works now
- Animated Bluetooth icon in #413 appears immediately, not after 250ms

# Verification 
- Run example HTTP request from #382
- Merge this branch into #413 locally, verify that the icon appears immediately and not like in this video: https://flipperdevices.slack.com/archives/C085L6FSP7Z/p1770832208949509

# Checklist (For Reviewer)
- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
