### PR TITLE
[FW-638] BusyTimer: Fix systematic time discrepancy

### DIFF
--- a/applications/services/busy_timer/busy_timer.c
+++ b/applications/services/busy_timer/busy_timer.c
@@ -288,7 +288,8 @@ static void busy_timer_update(BusyTimer* instance, time_t timestamp_ms) {
             break;
         }
 
-        const uint32_t dt_s = MS_TO_S(timestamp_ms - instance->prev_tick_timestamp_ms);
+        const uint32_t dt_ms = timestamp_ms - instance->prev_tick_timestamp_ms;
+        const uint32_t dt_s = MS_TO_S(dt_ms);
 
         // Too early for a tick
         if(dt_s == 0) {
@@ -317,7 +318,9 @@ static void busy_timer_update(BusyTimer* instance, time_t timestamp_ms) {
             }
         }
 
-        instance->prev_tick_timestamp_ms = timestamp_ms;
+        const uint32_t remainder_ms = dt_ms - S_TO_MS(dt_s);
+        instance->prev_tick_timestamp_ms = timestamp_ms - remainder_ms;
+
     } while(false);
 }
 


### PR DESCRIPTION
# What's new

-  Fix systematic time discrepancy that led to differing time readings on BSB and mobile after a while

# Verification 

1. Install the firmware
2. Link BSB to cloud account, if not already
3. From a mobile app (should be linked as well) start a timer
4. Ensure that the difference between time readings on BSB and mobile never increases (should be within a second at all times)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
