### PR TITLE
Intercom: Implement a watchdog service

### DIFF
--- a/applications/services/application.fam
+++ b/applications/services/application.fam
@@ -84,6 +84,7 @@ App(
         "cli_intercom",
         "ble",
         "tls_crypto_server",
+        "intercom_watchdog",
     ],
     targets=["f64", "f65"],
 )

--- a/applications/services/intercom/application.fam
+++ b/applications/services/intercom/application.fam
@@ -8,3 +8,14 @@ App(
     targets=["f20", "f21", "f22", "f64", "f65"],
     order=30,
 )
+
+App(
+    appid="intercom_watchdog",
+    name="IntercomWatchdogSrv",
+    apptype=FlipperAppType.SERVICE,
+    entry_point="intercom_watchdog_srv",
+    cdefines=["SRV_INTERCOM_WATCHDOG"],
+    stack_size=512,
+    targets=["f64", "f65"],
+    order=20,
+)

--- a/applications/services/intercom/intercom.c
+++ b/applications/services/intercom/intercom.c
@@ -87,7 +87,7 @@ static void intercom_serial_rx_callback(
     }
 }
 
-static void intercom_dump_frame(const IntercomFrame* frame) {
+void intercom_dump_frame(const IntercomFrame* frame) {
     FuriString* tmp = furi_string_alloc();
 
     furi_string_printf(
@@ -103,7 +103,7 @@ static void intercom_dump_frame(const IntercomFrame* frame) {
         furi_string_cat_printf(tmp, "%02X ", frame->data[i]);
     }
 
-    furi_string_cat_printf(tmp, "\r\ncheck: 0x%04X", frame->check);
+    furi_string_cat_printf(tmp, "\r\ncheck: 0x%04X\r\n", frame->check);
 
     furi_log_puts(furi_string_get_cstr(tmp));
 
@@ -222,6 +222,9 @@ static FURI_ALWAYS_INLINE void intercom_process_tx_data_event(Intercom* instance
 static FURI_ALWAYS_INLINE void intercom_process_rx_frame_event(Intercom* instance) {
     INTERCOM_LOG_D("Frame received");
 
+#ifdef SRV_INTERCOM_WATCHDOG
+    intercom_watchdog_arm(instance->watchdog);
+#endif
     const IntercomFrame* rx_frame = &instance->rx_frame;
 
     if(intercom_frame_is_valid(rx_frame)) {
@@ -235,6 +238,9 @@ static FURI_ALWAYS_INLINE void intercom_process_rx_frame_event(Intercom* instanc
 
     furi_hal_serial_dma_rx_start(
         instance->serial, (void*)&instance->rx_frame, sizeof(IntercomFrame));
+#ifdef SRV_INTERCOM_WATCHDOG
+    intercom_watchdog_disarm(instance->watchdog);
+#endif
 }
 
 static FURI_ALWAYS_INLINE void intercom_process_tx_frame_event(Intercom* instance) {
@@ -319,6 +325,10 @@ static Intercom* intercom_alloc(void) {
         instance->event_loop, intercom_tx_timer_callback, FuriEventLoopTimerTypeOnce, instance);
     instance->serial = furi_hal_serial_control_acquire(INTERCOM_SERIAL);
     instance->pubsub = furi_pubsub_alloc();
+#ifdef SRV_INTERCOM_WATCHDOG
+    instance->watchdog = furi_record_open(RECORD_INTERCOM_WATCHDOG);
+#endif
+
     intercom_error_handling_enable(instance);
 
     for(IntercomChannelId i = 0; i < IntercomChannelIdMax; i++) {

--- a/applications/services/intercom/intercom.c
+++ b/applications/services/intercom/intercom.c
@@ -236,11 +236,17 @@ static FURI_ALWAYS_INLINE void intercom_process_rx_frame_event(Intercom* instanc
         intercom_error_handler(IntercomErrorFraming, instance);
     }
 
+#ifdef SRV_INTERCOM_WATCHDOG
+    if(furi_hal_serial_rx_available(instance->serial)) {
+        // Some more data is already in FIFO, re-arm watchdog
+        intercom_watchdog_arm(instance->watchdog);
+    } else {
+        // No data in FIFO yet, disarm watchdog for now
+        intercom_watchdog_disarm(instance->watchdog);
+    }
+#endif
     furi_hal_serial_dma_rx_start(
         instance->serial, (void*)&instance->rx_frame, sizeof(IntercomFrame));
-#ifdef SRV_INTERCOM_WATCHDOG
-    intercom_watchdog_disarm(instance->watchdog);
-#endif
 }
 
 static FURI_ALWAYS_INLINE void intercom_process_tx_frame_event(Intercom* instance) {

--- a/applications/services/intercom/intercom_i.h
+++ b/applications/services/intercom/intercom_i.h
@@ -3,6 +3,10 @@
 #include "intercom.h"
 #include "intercom_frame.h"
 
+#ifdef SRV_INTERCOM_WATCHDOG
+#include "intercom_watchdog.h"
+#endif
+
 #include <furi.h>
 
 #include <furi_hal_serial.h>
@@ -37,12 +41,16 @@ struct Intercom {
     IntercomChannel handles[IntercomChannelIdMax];
     IntercomFrame tx_frame;
     IntercomFrame rx_frame;
+#ifdef SRV_INTERCOM_WATCHDOG
+    IntercomWatchdog* watchdog;
+#endif
 };
 
 // intercom.c:
 
 IntercomFrame* intercom_do_acquire_tx(Intercom* intercom);
 void intercom_do_tx(Intercom* intercom);
+void intercom_dump_frame(const IntercomFrame* frame);
 
 // intercom_sync.c:
 

--- a/applications/services/intercom/intercom_watchdog.c
+++ b/applications/services/intercom/intercom_watchdog.c
@@ -1,0 +1,88 @@
+#include "intercom_watchdog.h"
+
+#include "intercom_i.h"
+
+#define TAG "IntercomWatchdog"
+
+#define INTERCOM_WATCHDOG_QUEUE_SIZE (4)
+#define INTERCOM_WATCHDOG_TIMEOUT_MS (900)
+
+struct IntercomWatchdog {
+    FuriEventLoop* event_loop;
+    FuriMessageQueue* queue;
+    FuriEventLoopTimer* timer;
+};
+
+typedef enum {
+    IntercomWatchdogEventArm,
+    IntercomWatchdogEventDisarm,
+    IntercomWatchdogEventMax,
+} IntercomWatchdogEvent;
+
+static void intercom_watchdog_timer_callback(void* context) {
+    UNUSED(context);
+
+    FURI_LOG_E(TAG, "Stop condition reached");
+
+    Intercom* intercom = furi_record_open(RECORD_INTERCOM);
+    intercom_dump_frame(&intercom->rx_frame);
+
+    furi_delay_ms(100);
+    furi_crash("Stop condition reached");
+}
+
+static void intercom_watchdog_message_queue_callback(FuriEventLoopObject* obj, void* context) {
+    furi_assert(context);
+    IntercomWatchdog* instance = context;
+
+    furi_assert(instance->queue == obj);
+
+    IntercomWatchdogEvent event;
+    while(furi_message_queue_get(instance->queue, &event, 0) == FuriStatusOk) {
+        if(event == IntercomWatchdogEventArm) {
+            furi_event_loop_timer_start(instance->timer, INTERCOM_WATCHDOG_TIMEOUT_MS);
+        } else if(event == IntercomWatchdogEventDisarm) {
+            furi_event_loop_timer_stop(instance->timer);
+        } else {
+            furi_crash("Invalid IntercomWatchdogEvent value");
+        }
+    }
+}
+
+static IntercomWatchdog* intercom_watchdog_alloc(void) {
+    IntercomWatchdog* instance = malloc(sizeof(IntercomWatchdog));
+    instance->event_loop = furi_event_loop_alloc();
+    instance->queue =
+        furi_message_queue_alloc(INTERCOM_WATCHDOG_QUEUE_SIZE, sizeof(IntercomWatchdogEvent));
+    instance->timer = furi_event_loop_timer_alloc(
+        instance->event_loop, intercom_watchdog_timer_callback, FuriEventLoopTimerTypeOnce, NULL);
+
+    furi_event_loop_subscribe_message_queue(
+        instance->event_loop,
+        instance->queue,
+        FuriEventLoopEventIn,
+        intercom_watchdog_message_queue_callback,
+        instance);
+
+    furi_record_create(RECORD_INTERCOM_WATCHDOG, instance);
+    return instance;
+}
+
+void intercom_watchdog_arm(IntercomWatchdog* instance) {
+    const IntercomWatchdogEvent event = IntercomWatchdogEventArm;
+    furi_check(furi_message_queue_put(instance->queue, &event, FuriWaitForever) == FuriStatusOk);
+}
+
+void intercom_watchdog_disarm(IntercomWatchdog* instance) {
+    const IntercomWatchdogEvent event = IntercomWatchdogEventDisarm;
+    furi_check(furi_message_queue_put(instance->queue, &event, FuriWaitForever) == FuriStatusOk);
+}
+
+int32_t intercom_watchdog_srv(void* arg) {
+    UNUSED(arg);
+
+    IntercomWatchdog* instance = intercom_watchdog_alloc();
+    furi_event_loop_run(instance->event_loop);
+
+    return 0;
+}

--- a/applications/services/intercom/intercom_watchdog.h
+++ b/applications/services/intercom/intercom_watchdog.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#define RECORD_INTERCOM_WATCHDOG "intercom_watchdog"
+
+typedef struct IntercomWatchdog IntercomWatchdog;
+
+void intercom_watchdog_arm(IntercomWatchdog* instance);
+
+void intercom_watchdog_disarm(IntercomWatchdog* instance);


### PR DESCRIPTION
# What's new

- Implement a watchdog service that would intentionally crash the Si917 if processing of received data takes more than 900ms
- Runs only on Si917, U5 is unaffected

# Verification 

1. Install the firmware bundle
2. Everything should be working as usual
3. If the Si917 crashes, look for `Stop condition reached` in the logs (alongside with the offending Intercom frame dump).

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
