### PR TITLE
[FW-594] Shutdown After Update Backport

### DIFF
--- a/applications/services/cli_f20/cli_command_factory_reset.c
+++ b/applications/services/cli_f20/cli_command_factory_reset.c
@@ -1,9 +1,13 @@
 #include "cli_command_factory_reset.h"
-#include "power/power_service/power.h"
-
 #include <furi_hal_nvm.h>
+#include <furi_hal_power.h>
+
 #include <storage/storage.h>
+#include <cli/cli_command.h>
 #include <cli/args.h>
+
+#include <toolbox/update_lib/update_config.h>
+#include <toolbox/update_lib/common_vals.h>
 
 typedef struct {
     bool shipping_mode;
@@ -40,15 +44,17 @@ static void print_command_help(void) {
     printf("  -h, --help             Show this help message\r\n");
 }
 
-static void cli_command_step_format_emmc() {
+static void cli_command_step_format_emmc(void) {
     Storage* storage = furi_record_open(RECORD_STORAGE);
-    printf("Format EMMC...\r\n");
+
+    printf("Formatting EMMC...\r\n");
+
     FS_Error error = storage_sd_format(storage, STORAGE_EXT_PATH_PREFIX);
 
     if(error != FSE_OK) {
-        printf("Error: %s", storage_error_get_desc(error));
+        printf("EMMC formatting error: %s\r\n", storage_error_get_desc(error));
     } else {
-        printf("EMMC was successfully formatted.\r\n");
+        printf("EMMC was successfully formatted\r\n");
     }
 
     furi_record_close(RECORD_STORAGE);
@@ -75,14 +81,10 @@ void cli_command_factory_reset(PipeSide* pipe, FuriString* args, void* context) 
 
     printf("Warning! This will wipe all the data from the device! Are you sure? y/n\r\n");
 
-    while(true) {
-        char answer;
-        if(pipe_receive(pipe, &answer, sizeof(answer)) != sizeof(answer)) break;
-        if(answer == 'n' || answer == 'N') {
-            printf("\r\nCancelled.");
-            break;
-        } else if(answer == 'y' || answer == 'Y') {
+    for(char response; pipe_receive(pipe, &response, sizeof(response)) == sizeof(response);) {
+        if(response == 'y' || response == 'Y') {
             printf("Performing factory reset...\r\n");
+
             cli_command_step_format_emmc();
             cli_command_step_reset_pairing();
             cli_command_step_wifi_ble_restore_default_config();
@@ -92,11 +94,42 @@ void cli_command_factory_reset(PipeSide* pipe, FuriString* args, void* context) 
                 furi_hal_nvm_set_flag(FuriHalNvmFlagRebootIntoShippingMode);
             }
 
-            printf("Done\r\nRebooting...\r\n");
-            furi_delay_ms(100);
-            Power* pwr = furi_record_open(RECORD_POWER);
-            power_reboot(pwr, PowerRebootNormal);
-            furi_record_close(RECORD_POWER);
+            const char* recovery_manifest = BACKUP_PATH("recovery/update.json");
+            printf("Setting up recovery installation from: %s...\r\n", recovery_manifest);
+
+            UpdateConfig* state = update_config_alloc();
+            Storage* storage = furi_record_open(RECORD_STORAGE);
+
+            do {
+                UpdateConfigValidation config_state = update_config_load(state, recovery_manifest);
+                if(config_state != UpdateConfigValidationOK) {
+                    printf(
+                        "Failed to load recovery configuration: %s\r\n",
+                        update_config_validation_get_error_str(config_state));
+                    printf("Continuing with factory reset anyway...\r\n");
+                    break;
+                }
+
+                printf("Recovery configuration valid...\r\n");
+
+                if(!update_config_write_pointer_file(storage, recovery_manifest)) {
+                    printf("Failed to write manifest path to pointer file\r\n");
+                    break;
+                }
+
+                printf("Pointer file written successfully...\r\n");
+
+                furi_hal_nvm_set_boot_mode(FuriHalNvmBootModeUpdate);
+                printf("Boot mode set to Update. Rebooting...\r\n");
+                furi_hal_power_reset();
+            } while(false);
+
+            furi_record_close(RECORD_STORAGE);
+            update_config_free(state);
+
+            break;
+        } else if(response == 'n' || response == 'N') {
+            printf("\r\nCancelled");
             break;
         }
     }

--- a/applications/services/cli_f20/cli_command_factory_reset.c
+++ b/applications/services/cli_f20/cli_command_factory_reset.c
@@ -3,6 +3,42 @@
 
 #include <furi_hal_nvm.h>
 #include <storage/storage.h>
+#include <cli/args.h>
+
+typedef struct {
+    bool shipping_mode;
+    bool help;
+} FactoryResetArgs;
+
+static bool parse_command_args(FuriString* args, FactoryResetArgs* parsed_args) {
+    parsed_args->shipping_mode = false;
+    parsed_args->help = false;
+
+    FuriString* arg = furi_string_alloc();
+
+    bool is_success = true;
+    while(args_read_string_and_trim(args, arg)) {
+        if(furi_string_equal_str(arg, "-s") || furi_string_equal_str(arg, "--shipping-mode")) {
+            parsed_args->shipping_mode = true;
+        } else if(furi_string_equal_str(arg, "-h") || furi_string_equal_str(arg, "--help")) {
+            parsed_args->help = true;
+        } else {
+            printf("Unknown argument: %s\r\n", furi_string_get_cstr(arg));
+            is_success = false;
+            break;
+        }
+    }
+
+    furi_string_free(arg);
+    return is_success;
+}
+
+static void print_command_help(void) {
+    printf("Usage: factory_reset [options]\r\n");
+    printf("Options:\r\n");
+    printf("  -s, --shipping-mode    Enter shipping mode after performing reset\r\n");
+    printf("  -h, --help             Show this help message\r\n");
+}
 
 static void cli_command_step_format_emmc() {
     Storage* storage = furi_record_open(RECORD_STORAGE);
@@ -29,8 +65,14 @@ static void cli_command_step_wifi_ble_restore_default_config() {
 }
 
 void cli_command_factory_reset(PipeSide* pipe, FuriString* args, void* context) {
-    UNUSED(args);
     UNUSED(context);
+
+    FactoryResetArgs _args;
+    if(!parse_command_args(args, &_args) || _args.help) {
+        print_command_help();
+        return;
+    }
+
     printf("Warning! This will wipe all the data from the device! Are you sure? y/n\r\n");
 
     while(true) {
@@ -45,6 +87,11 @@ void cli_command_factory_reset(PipeSide* pipe, FuriString* args, void* context) 
             cli_command_step_reset_pairing();
             cli_command_step_wifi_ble_restore_default_config();
             furi_hal_nvm_reset();
+
+            if(_args.shipping_mode) {
+                furi_hal_nvm_set_flag(FuriHalNvmFlagRebootIntoShippingMode);
+            }
+
             printf("Done\r\nRebooting...\r\n");
             furi_delay_ms(100);
             Power* pwr = furi_record_open(RECORD_POWER);

--- a/applications/services/power/power_service/power.c
+++ b/applications/services/power/power_service/power.c
@@ -2,6 +2,8 @@
 #include <toolbox/dsp.h>
 #include <drivers/bq25798/bq25798.h>
 
+#include <furi_hal_nvm.h>
+
 #define TAG "Power"
 
 #define POWER_IRQ_GPIO (&gpio_bq25798_irq)
@@ -388,6 +390,11 @@ static void power_update_info(Power* power) {
 
     power->state.usb_connected = status.vbus_present;
 
+    if(power->shipping_mode_wait && !status.vbus_present) {
+        FURI_LOG_I(TAG, "Entering shipping mode...");
+        power_handle_shutdown(power, false);
+    }
+
     if(power->info.voltage_battery < 2500.0f) {
         power->info.voltage_battery = adc_val.bat_v;
     } else {
@@ -525,6 +532,22 @@ void power_run(Power* power) {
     furi_hal_i2c_release(POWER_I2C);
 
     furi_record_create(RECORD_POWER, power);
+
+#ifndef FURI_RAM_EXEC
+    if(furi_hal_nvm_is_flag_set(FuriHalNvmFlagRebootIntoShippingMode)) {
+        furi_hal_nvm_reset_flag(FuriHalNvmFlagRebootIntoShippingMode);
+        power->shipping_mode_wait = true;
+
+        if(power->state.usb_connected) {
+            FURI_LOG_I(TAG, "Awaiting for USB to be disconnected to enter shipping mode...");
+        } else {
+            FURI_LOG_I(TAG, "Entering shipping mode...");
+            power_handle_shutdown(power, false);
+        }
+    } else {
+        power->shipping_mode_wait = false;
+    }
+#endif
 
     FURI_LOG_I(TAG, "Running event loop");
     furi_event_loop_run(power->event_loop);

--- a/applications/services/power/power_service/power_i.h
+++ b/applications/services/power/power_service/power_i.h
@@ -77,6 +77,7 @@ struct Power {
     uint32_t charger_current_limit;
     bool charger_enabled;
     PowerBatteryState battery_state;
+    bool shipping_mode_wait;
 };
 
 PowerUsbPd* power_usb_pd_alloc(FuriMessageQueue** pd_queue);

--- a/targets/f20/furi_hal/furi_hal_nvm.h
+++ b/targets/f20/furi_hal/furi_hal_nvm.h
@@ -6,6 +6,7 @@ typedef enum {
     FuriHalNvmFlagDebug,
     FuriHalNvmFlagDetailedFilename,
     FuriHalNvmFlagStorageFormatInternal,
+    FuriHalNvmFlagRebootIntoShippingMode,
     FuriHalNvmFlagCount, /**< Keep this last */
 } FuriHalNvmFlag;
 


### PR DESCRIPTION
# What's new

- backport shipping mode from dev
- make factory reset cli command start update from `/bkp/recovery/ `
- backport factory reset cli flags `-s`, `-h`

# Verification 

- `-s`, `-h` keys are available for `factory_reset` cli command 
- both keys behave same as in dev branch
- `factory_reset` starts update installation from /bkp/recovery/ 

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix