### PR TITLE
Wifi: reduce max wait time to 200 ms when transmitting Wi-Fi frames

### DIFF
--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -281,7 +281,8 @@ static void wifi_net_intercom_rx_callback(const void* data, size_t data_size, vo
     furi_assert(context);
     Wifi* instance = context;
 
-    const sl_status_t status = sl_wifi_send_raw_data_frame(SL_WIFI_CLIENT_INTERFACE, data, data_size);
+    const sl_status_t status =
+        sl_wifi_send_raw_data_frame(SL_WIFI_CLIENT_INTERFACE, data, data_size);
 
     if(status != SL_STATUS_OK) {
         ++instance->drop_count;

--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -278,8 +278,15 @@ static void wifi_intercom_rx_callback(const void* data, size_t data_size, void* 
 }
 
 static void wifi_net_intercom_rx_callback(const void* data, size_t data_size, void* context) {
-    UNUSED(context);
-    sl_wifi_send_raw_data_frame(SL_WIFI_CLIENT_INTERFACE, data, data_size);
+    furi_assert(context);
+    Wifi* instance = context;
+
+    const sl_status_t status = sl_wifi_send_raw_data_frame(SL_WIFI_CLIENT_INTERFACE, data, data_size);
+
+    if(status != SL_STATUS_OK) {
+        ++instance->drop_count;
+        FURI_LOG_W(TAG, "Dropped packet (%lu total), reason: 0x%lX", instance->drop_count, status);
+    }
 }
 
 static void

--- a/applications/services/wifi/wifi_backend_i.h
+++ b/applications/services/wifi/wifi_backend_i.h
@@ -22,6 +22,7 @@ struct Wifi {
     FuriSemaphore* tcpip_lock;
     FuriSemaphore* ipv6_ready_semaphore;
     struct netif netif;
+    uint32_t drop_count;
     WifiBackendState state;
     bool scan_in_progress;
 };


### PR DESCRIPTION
# What's new

- Reduce max wait time to 200 ms when transmitting Wi-Fi frames (potential fix for the infamous `Intercom error`)
- Add logging with packet drop count

# Verification 

1. Flash the firmware bundle
2. Ensure that there are no regressions
3. Use a BusyBar for a long time and hopefully observe a decrease in intermittent Intercom errors
4. Look for dropped packet warnings in the Si917 logs

> [!WARNING]
> Merge [this PR](https://github.com/flipperdevices/wiseconnect/pull/3) first and adjust the submodule commit

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
