### PR TITLE
[FW-659] Set Updater's Default Channel To Release

### DIFF
--- a/applications/system/updater/settings/interface_v1.c
+++ b/applications/system/updater/settings/interface_v1.c
@@ -2,7 +2,7 @@
 
 #define CHECK_URL_DEFAULT "https://update.flipperzero.one/busybar-firmware/directory.json"
 
-#define CHECK_CHANNEL_ID_DEFAULT "development"
+#define CHECK_CHANNEL_ID_DEFAULT "release"
 
 #define CHECK_STARTUP_INTERVAL_MIN     (1 * 1000 * 60)
 #define CHECK_STARTUP_INTERVAL_MAX     (20 * 1000 * 60)


### PR DESCRIPTION
# What's new
[FW-659]
- change updater's default channel to "release"

# Verification 

- any updates (except ones that are installed via user's links/files) are now installed from release channel by default

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-659]: https://flipper.atlassian.net/browse/FW-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ