### PR TITLE
[FW-669] CLI pipe lifecycle fixes

### DIFF
--- a/applications/debug/ble_per_test/helpers/ble_per_cli.c
+++ b/applications/debug/ble_per_test/helpers/ble_per_cli.c
@@ -232,7 +232,8 @@ static int32_t ble_per_cli_thread_event_loop_callback(void* context) {
     instance->shell_pipe = temp_bundle.bobs_side;
 
     CliIntercom* cli_intercom = furi_record_open(RECORD_CLI_INTERCOM);
-    furi_check(cli_intercom_spawn(cli_intercom, instance->shell_pipe) == CliIntercomSpawnStatusOk);
+    furi_check(
+        cli_intercom_spawn(cli_intercom, instance->shell_pipe, true) == CliIntercomSpawnStatusOk);
 
     pipe_attach_to_event_loop(instance->own_pipe, instance->event_loop);
     pipe_set_callback_context(instance->own_pipe, instance);

--- a/applications/debug/wifi_per_test/helpers/wifi_per_cli.c
+++ b/applications/debug/wifi_per_test/helpers/wifi_per_cli.c
@@ -228,7 +228,8 @@ static int32_t wifi_per_cli_thread_event_loop_callback(void* context) {
     instance->shell_pipe = temp_bundle.bobs_side;
 
     CliIntercom* cli_intercom = furi_record_open(RECORD_CLI_INTERCOM);
-    furi_check(cli_intercom_spawn(cli_intercom, instance->shell_pipe) == CliIntercomSpawnStatusOk);
+    furi_check(
+        cli_intercom_spawn(cli_intercom, instance->shell_pipe, true) == CliIntercomSpawnStatusOk);
 
     pipe_attach_to_event_loop(instance->own_pipe, instance->event_loop);
     pipe_set_callback_context(instance->own_pipe, instance);

--- a/applications/services/cli_intercom/cli_intercom.c
+++ b/applications/services/cli_intercom/cli_intercom.c
@@ -33,6 +33,7 @@ struct CliIntercom {
 
     CliShell* cli_shell;
     PipeSide* own_pipe;
+    bool close_pipe_on_detach;
 
     FuriThread* tx_thread;
     FuriSemaphore* tx_data_available;
@@ -59,6 +60,7 @@ typedef struct {
         struct {
             PipeSide* pipe;
             CliIntercomSpawnStatus* spawn_status;
+            bool close_pipe_on_detach;
         };
     };
 } CliIntercomInternalEvent;
@@ -196,10 +198,13 @@ static void cli_intercom_detach_own_pipe(CliIntercom* cli_intercom) {
     // on SLAVE (917), own_pipe is created by us in do_protocol_spawn
     pipe_free(cli_intercom->own_pipe);
 #else
-    // on MASTER (U5), own_pipe is provided externally via cli_intercom_spawn;
-    // mark it broken so the caller's pipe_receive/pipe_send exit promptly,
-    // but don't free it — the caller is responsible for pipe_free.
-    pipe_close(cli_intercom->own_pipe);
+    // on MASTER (U5), own_pipe is provided externally via cli_intercom_spawn.
+    // Only close/break the pipe if the caller requested it (e.g. programmatic
+    // callers blocked in pipe_copy_until that need to be unblocked on disconnect).
+    // Interactive callers (sl_cli) pass their outer shell pipe and need it intact.
+    if(cli_intercom->close_pipe_on_detach) {
+        pipe_close(cli_intercom->own_pipe);
+    }
 #endif
     cli_intercom->own_pipe = NULL;
 }
@@ -282,6 +287,7 @@ static void cli_intercom_do_api_spawn(CliIntercom* cli_intercom, CliIntercomInte
             break;
         }
 
+        cli_intercom->close_pipe_on_detach = event->close_pipe_on_detach;
         cli_intercom_attach_own_pipe(cli_intercom, event->pipe);
 
         if(!cli_intercom_send_protocol_status(
@@ -494,13 +500,15 @@ static void cli_intercom_api_call(CliIntercom* cli_intercom, CliIntercomInternal
     api_lock_wait_unlock_and_free(event->api_lock);
 }
 
-CliIntercomSpawnStatus cli_intercom_spawn(CliIntercom* cli_intercom, PipeSide* pipe) {
+CliIntercomSpawnStatus
+    cli_intercom_spawn(CliIntercom* cli_intercom, PipeSide* pipe, bool close_pipe_on_detach) {
     furi_check(pipe);
     CliIntercomSpawnStatus spawn_status;
     CliIntercomInternalEvent event = {
         .type = CliIntercomInternalEventTypeApiSpawn,
         .pipe = pipe,
         .spawn_status = &spawn_status,
+        .close_pipe_on_detach = close_pipe_on_detach,
     };
     cli_intercom_api_call(cli_intercom, &event);
     return spawn_status;

--- a/applications/services/cli_intercom/cli_intercom.h
+++ b/applications/services/cli_intercom/cli_intercom.h
@@ -36,12 +36,18 @@ typedef enum {
  * @brief Spawns a shell on f64. Relays data and status information in both
  *        directions using the given pipe.
  * 
- * @param[in] cli_intercom CliIntercom instance
- * @param[in] pipe         Local PipeSide instance
+ * @param[in] cli_intercom         CliIntercom instance
+ * @param[in] pipe                 Local PipeSide instance
+ * @param[in] close_pipe_on_detach If true, call pipe_close() on the pipe when the intercom
+ *                                 session ends. Set to true for programmatic callers that may be
+ *                                 blocked in pipe operations on the other side of a temp pipe;
+ *                                 set to false for interactive callers that pass an outer shell
+ *                                 pipe that must survive the session.
  * 
  * @returns Spawn status: OK or error.
  */
-CliIntercomSpawnStatus cli_intercom_spawn(CliIntercom* cli_intercom, PipeSide* pipe);
+CliIntercomSpawnStatus
+    cli_intercom_spawn(CliIntercom* cli_intercom, PipeSide* pipe, bool close_pipe_on_detach);
 
 /**
  * @brief Blocks until the shell on f64 exits.

--- a/applications/services/cli_u5/cli_command_sl_cli.c
+++ b/applications/services/cli_u5/cli_command_sl_cli.c
@@ -19,7 +19,7 @@ FURI_CHECK_RETURN bool
     bool is_success = false;
 
     do {
-        if(cli_intercom_spawn(cli_intercom, temp_shell_pipe) != CliIntercomSpawnStatusOk) {
+        if(cli_intercom_spawn(cli_intercom, temp_shell_pipe, true) != CliIntercomSpawnStatusOk) {
             pipe_free(temp_shell_pipe);
             break;
         }
@@ -47,7 +47,7 @@ void cli_command_sl_cli(PipeSide* pipe, FuriString* args, void* context) {
     UNUSED(context);
 
     CliIntercom* cli_intercom = furi_record_open(RECORD_CLI_INTERCOM);
-    furi_check(cli_intercom_spawn(cli_intercom, pipe) == CliIntercomSpawnStatusOk);
+    furi_check(cli_intercom_spawn(cli_intercom, pipe, false) == CliIntercomSpawnStatusOk);
     cli_intercom_join(cli_intercom);
     furi_record_close(RECORD_CLI_INTERCOM);
 }


### PR DESCRIPTION
[FW-669] 

# What's new

- cli_intercom_spawn: added close_pipe_on_detach for proper lifecycling of cli pipes

# Verification 

- check that exiting `sl_cli` session does not terminate outer shell
- check that `./fbt crypto_provision` works

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-669]: https://flipper.atlassian.net/browse/FW-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ