### PR TITLE
[FW-666] Busy Timer: snapshot handling improvements

### DIFF
--- a/applications/services/busy_timer/busy_timer.c
+++ b/applications/services/busy_timer/busy_timer.c
@@ -205,7 +205,7 @@ static void
 }
 
 static void busy_timer_notify_snapshot_created(const BusyTimer* instance) {
-    const BusyTimerSnapshot* snapshot = &instance->user_snapshot;
+    const BusyTimerSnapshot* snapshot = &instance->last_snapshot;
 
     FURI_LOG_D(TAG, "Snapshot created with timestamp: %llu", snapshot->timestamp_ms);
 
@@ -490,10 +490,10 @@ static void busy_timer_make_snapshot(BusyTimer* instance, BusyTimerSnapshot* sna
     snapshot->app_config = instance->app_config;
 }
 
-static void busy_timer_publish_snapshot(const BusyTimer* instance) {
+static void busy_timer_publish_last_snapshot(const BusyTimer* instance) {
     busy_timer_notify_snapshot_created(instance);
 
-    const BusyTimerSnapshot* snapshot = &instance->user_snapshot;
+    const BusyTimerSnapshot* snapshot = &instance->last_snapshot;
     char* snapshot_str = busy_timer_snapshot_serialize(snapshot);
     furi_check(snapshot_str);
 
@@ -524,11 +524,9 @@ static void busy_timer_publish_profile(BusyTimer* instance, BusyTimerProfileId p
     free(profile_str);
 }
 
-static void busy_timer_schedule_publish_snapshot(BusyTimer* instance) {
-    busy_timer_make_snapshot(instance, &instance->user_snapshot);
-
+static void busy_timer_schedule_publish_last_snapshot(BusyTimer* instance) {
     if(instance->snapshot_update_count == 0) {
-        busy_timer_publish_snapshot(instance);
+        busy_timer_publish_last_snapshot(instance);
     }
 
     ++instance->snapshot_update_count;
@@ -548,7 +546,7 @@ static void
 static void busy_timer_apply_snapshot(BusyTimer* instance, const BusyTimerSnapshot* snapshot) {
     const time_t snapshot_timestamp_ms = snapshot->timestamp_ms;
 
-    if(snapshot_timestamp_ms <= instance->user_snapshot.timestamp_ms) {
+    if(snapshot_timestamp_ms <= instance->last_snapshot.timestamp_ms) {
         // Ignore snapshots that are older than the last known one
         FURI_LOG_D(TAG, "Ignoring stale/own snapshot with timestamp %llu", snapshot_timestamp_ms);
         return;
@@ -602,6 +600,8 @@ static void busy_timer_apply_snapshot(BusyTimer* instance, const BusyTimerSnapsh
         furi_crash("Invalid BusyTimerSnapshotType value");
     }
 
+    instance->last_snapshot = *snapshot;
+
     instance->timer_config.mode = new_mode;
     instance->state = new_state;
 
@@ -621,7 +621,7 @@ static void busy_timer_apply_snapshot(BusyTimer* instance, const BusyTimerSnapsh
     busy_timer_notify_tick(instance);
     busy_timer_notify_paused(instance);
 
-    busy_timer_schedule_publish_snapshot(instance);
+    busy_timer_schedule_publish_last_snapshot(instance);
 }
 
 static BusyTimerSetProfileResult busy_timer_set_profile_internal(
@@ -680,7 +680,7 @@ static void busy_timer_snapshot_timer_callback(void* context) {
     BusyTimer* instance = context;
 
     if(instance->snapshot_update_count > 1) {
-        busy_timer_publish_snapshot(instance);
+        busy_timer_publish_last_snapshot(instance);
     }
 
     instance->snapshot_update_count = 0;
@@ -799,7 +799,8 @@ static void
         FURI_LOG_I(TAG, "Resumed");
     }
 
-    busy_timer_schedule_publish_snapshot(instance);
+    busy_timer_make_snapshot(instance, &instance->last_snapshot);
+    busy_timer_schedule_publish_last_snapshot(instance);
 }
 
 static void
@@ -812,7 +813,8 @@ static void
 
         FURI_LOG_I(TAG, "Stopped");
 
-        busy_timer_schedule_publish_snapshot(instance);
+        busy_timer_make_snapshot(instance, &instance->last_snapshot);
+        busy_timer_schedule_publish_last_snapshot(instance);
     }
 }
 
@@ -868,7 +870,9 @@ static void
 
     busy_timer_start_timer(instance);
     busy_timer_notify_tick(instance);
-    busy_timer_schedule_publish_snapshot(instance);
+
+    busy_timer_make_snapshot(instance, &instance->last_snapshot);
+    busy_timer_schedule_publish_last_snapshot(instance);
 
     FURI_LOG_I(TAG, "Interval override");
 }
@@ -887,7 +891,9 @@ static void
     }
 
     busy_timer_notify_paused(instance);
-    busy_timer_schedule_publish_snapshot(instance);
+
+    busy_timer_make_snapshot(instance, &instance->last_snapshot);
+    busy_timer_schedule_publish_last_snapshot(instance);
 }
 
 static void
@@ -896,7 +902,9 @@ static void
 
     if(busy_timer_is_running(instance)) {
         busy_timer_next_state(instance, true);
-        busy_timer_schedule_publish_snapshot(instance);
+
+        busy_timer_make_snapshot(instance, &instance->last_snapshot);
+        busy_timer_schedule_publish_last_snapshot(instance);
 
         FURI_LOG_I(TAG, "Skipped");
     }
@@ -907,7 +915,9 @@ static void
     UNUSED(data);
 
     if(instance->state == BusyTimerStateIdle) {
-        busy_timer_schedule_publish_snapshot(instance);
+        busy_timer_make_snapshot(instance, &instance->last_snapshot);
+        busy_timer_schedule_publish_last_snapshot(instance);
+
         FURI_LOG_I(TAG, "Finalized");
     }
 }

--- a/applications/services/busy_timer/busy_timer.c
+++ b/applications/services/busy_timer/busy_timer.c
@@ -205,7 +205,7 @@ static void
 }
 
 static void busy_timer_notify_snapshot_created(const BusyTimer* instance) {
-    const BusyTimerSnapshot* snapshot = &instance->last_snapshot;
+    const BusyTimerSnapshot* snapshot = &instance->captured_snapshot;
 
     FURI_LOG_D(TAG, "Snapshot created with timestamp: %llu", snapshot->timestamp_ms);
 
@@ -446,7 +446,9 @@ static void busy_timer_fill_snapshot_common(BusyTimer* instance, BusyTimerSnapsh
     common->is_paused = !busy_timer_is_running(instance);
 }
 
-static void busy_timer_make_snapshot(BusyTimer* instance, BusyTimerSnapshot* snapshot) {
+static void busy_timer_capture_snapshot(BusyTimer* instance) {
+    BusyTimerSnapshot* snapshot = &instance->captured_snapshot;
+
     snapshot->timestamp_ms = furi_hal_rtc_get_timestamp_ms();
 
     if(instance->state != BusyTimerStateIdle) {
@@ -490,10 +492,10 @@ static void busy_timer_make_snapshot(BusyTimer* instance, BusyTimerSnapshot* sna
     snapshot->app_config = instance->app_config;
 }
 
-static void busy_timer_publish_last_snapshot(const BusyTimer* instance) {
+static void busy_timer_publish_captured_snapshot(const BusyTimer* instance) {
     busy_timer_notify_snapshot_created(instance);
 
-    const BusyTimerSnapshot* snapshot = &instance->last_snapshot;
+    const BusyTimerSnapshot* snapshot = &instance->captured_snapshot;
     char* snapshot_str = busy_timer_snapshot_serialize(snapshot);
     furi_check(snapshot_str);
 
@@ -524,9 +526,9 @@ static void busy_timer_publish_profile(BusyTimer* instance, BusyTimerProfileId p
     free(profile_str);
 }
 
-static void busy_timer_schedule_publish_last_snapshot(BusyTimer* instance) {
+static void busy_timer_schedule_publish_captured_snapshot(BusyTimer* instance) {
     if(instance->snapshot_update_count == 0) {
-        busy_timer_publish_last_snapshot(instance);
+        busy_timer_publish_captured_snapshot(instance);
     }
 
     ++instance->snapshot_update_count;
@@ -546,7 +548,7 @@ static void
 static void busy_timer_apply_snapshot(BusyTimer* instance, const BusyTimerSnapshot* snapshot) {
     const time_t snapshot_timestamp_ms = snapshot->timestamp_ms;
 
-    if(snapshot_timestamp_ms <= instance->last_snapshot.timestamp_ms) {
+    if(snapshot_timestamp_ms <= instance->captured_snapshot.timestamp_ms) {
         // Ignore snapshots that are older than the last known one
         FURI_LOG_D(TAG, "Ignoring stale/own snapshot with timestamp %llu", snapshot_timestamp_ms);
         return;
@@ -600,7 +602,7 @@ static void busy_timer_apply_snapshot(BusyTimer* instance, const BusyTimerSnapsh
         furi_crash("Invalid BusyTimerSnapshotType value");
     }
 
-    instance->last_snapshot = *snapshot;
+    instance->captured_snapshot = *snapshot;
 
     instance->timer_config.mode = new_mode;
     instance->state = new_state;
@@ -621,7 +623,7 @@ static void busy_timer_apply_snapshot(BusyTimer* instance, const BusyTimerSnapsh
     busy_timer_notify_tick(instance);
     busy_timer_notify_paused(instance);
 
-    busy_timer_schedule_publish_last_snapshot(instance);
+    busy_timer_schedule_publish_captured_snapshot(instance);
 }
 
 static BusyTimerSetProfileResult busy_timer_set_profile_internal(
@@ -680,7 +682,7 @@ static void busy_timer_snapshot_timer_callback(void* context) {
     BusyTimer* instance = context;
 
     if(instance->snapshot_update_count > 1) {
-        busy_timer_publish_last_snapshot(instance);
+        busy_timer_publish_captured_snapshot(instance);
     }
 
     instance->snapshot_update_count = 0;
@@ -799,8 +801,8 @@ static void
         FURI_LOG_I(TAG, "Resumed");
     }
 
-    busy_timer_make_snapshot(instance, &instance->last_snapshot);
-    busy_timer_schedule_publish_last_snapshot(instance);
+    busy_timer_capture_snapshot(instance);
+    busy_timer_schedule_publish_captured_snapshot(instance);
 }
 
 static void
@@ -813,8 +815,8 @@ static void
 
         FURI_LOG_I(TAG, "Stopped");
 
-        busy_timer_make_snapshot(instance, &instance->last_snapshot);
-        busy_timer_schedule_publish_last_snapshot(instance);
+        busy_timer_capture_snapshot(instance);
+        busy_timer_schedule_publish_captured_snapshot(instance);
     }
 }
 
@@ -871,8 +873,8 @@ static void
     busy_timer_start_timer(instance);
     busy_timer_notify_tick(instance);
 
-    busy_timer_make_snapshot(instance, &instance->last_snapshot);
-    busy_timer_schedule_publish_last_snapshot(instance);
+    busy_timer_capture_snapshot(instance);
+    busy_timer_schedule_publish_captured_snapshot(instance);
 
     FURI_LOG_I(TAG, "Interval override");
 }
@@ -892,8 +894,8 @@ static void
 
     busy_timer_notify_paused(instance);
 
-    busy_timer_make_snapshot(instance, &instance->last_snapshot);
-    busy_timer_schedule_publish_last_snapshot(instance);
+    busy_timer_capture_snapshot(instance);
+    busy_timer_schedule_publish_captured_snapshot(instance);
 }
 
 static void
@@ -903,8 +905,8 @@ static void
     if(busy_timer_is_running(instance)) {
         busy_timer_next_state(instance, true);
 
-        busy_timer_make_snapshot(instance, &instance->last_snapshot);
-        busy_timer_schedule_publish_last_snapshot(instance);
+        busy_timer_capture_snapshot(instance);
+        busy_timer_schedule_publish_captured_snapshot(instance);
 
         FURI_LOG_I(TAG, "Skipped");
     }
@@ -915,8 +917,8 @@ static void
     UNUSED(data);
 
     if(instance->state == BusyTimerStateIdle) {
-        busy_timer_make_snapshot(instance, &instance->last_snapshot);
-        busy_timer_schedule_publish_last_snapshot(instance);
+        busy_timer_capture_snapshot(instance);
+        busy_timer_schedule_publish_captured_snapshot(instance);
 
         FURI_LOG_I(TAG, "Finalized");
     }
@@ -935,7 +937,7 @@ static void busy_timer_get_snapshot_api_message_handler(
     BusyTimer* instance,
     BusyTimerApiMessageData* data) {
     const BusyTimerApiMessageGetSnapshot* get_snapshot = &data->get_snapshot;
-    busy_timer_make_snapshot(instance, get_snapshot->snapshot);
+    *get_snapshot->snapshot = instance->captured_snapshot;
 }
 
 static void busy_timer_set_snapshot_api_message_handler(

--- a/applications/services/busy_timer/busy_timer.c
+++ b/applications/services/busy_timer/busy_timer.c
@@ -205,7 +205,7 @@ static void
 }
 
 static void busy_timer_notify_snapshot_created(const BusyTimer* instance) {
-    const BusyTimerSnapshot* snapshot = &instance->captured_snapshot;
+    const BusyTimerSnapshot* snapshot = &instance->last_known_snapshot;
 
     FURI_LOG_D(TAG, "Snapshot created with timestamp: %llu", snapshot->timestamp_ms);
 
@@ -447,7 +447,7 @@ static void busy_timer_fill_snapshot_common(BusyTimer* instance, BusyTimerSnapsh
 }
 
 static void busy_timer_capture_snapshot(BusyTimer* instance) {
-    BusyTimerSnapshot* snapshot = &instance->captured_snapshot;
+    BusyTimerSnapshot* snapshot = &instance->last_known_snapshot;
 
     snapshot->timestamp_ms = furi_hal_rtc_get_timestamp_ms();
 
@@ -492,10 +492,10 @@ static void busy_timer_capture_snapshot(BusyTimer* instance) {
     snapshot->app_config = instance->app_config;
 }
 
-static void busy_timer_publish_captured_snapshot(const BusyTimer* instance) {
+static void busy_timer_publish_last_known_snapshot(const BusyTimer* instance) {
     busy_timer_notify_snapshot_created(instance);
 
-    const BusyTimerSnapshot* snapshot = &instance->captured_snapshot;
+    const BusyTimerSnapshot* snapshot = &instance->last_known_snapshot;
     char* snapshot_str = busy_timer_snapshot_serialize(snapshot);
     furi_check(snapshot_str);
 
@@ -526,9 +526,9 @@ static void busy_timer_publish_profile(BusyTimer* instance, BusyTimerProfileId p
     free(profile_str);
 }
 
-static void busy_timer_schedule_publish_captured_snapshot(BusyTimer* instance) {
+static void busy_timer_schedule_publish_last_known_snapshot(BusyTimer* instance) {
     if(instance->snapshot_update_count == 0) {
-        busy_timer_publish_captured_snapshot(instance);
+        busy_timer_publish_last_known_snapshot(instance);
     }
 
     ++instance->snapshot_update_count;
@@ -548,7 +548,7 @@ static void
 static void busy_timer_apply_snapshot(BusyTimer* instance, const BusyTimerSnapshot* snapshot) {
     const time_t snapshot_timestamp_ms = snapshot->timestamp_ms;
 
-    if(snapshot_timestamp_ms <= instance->captured_snapshot.timestamp_ms) {
+    if(snapshot_timestamp_ms <= instance->last_known_snapshot.timestamp_ms) {
         // Ignore snapshots that are older than the last known one
         FURI_LOG_D(TAG, "Ignoring stale/own snapshot with timestamp %llu", snapshot_timestamp_ms);
         return;
@@ -602,7 +602,7 @@ static void busy_timer_apply_snapshot(BusyTimer* instance, const BusyTimerSnapsh
         furi_crash("Invalid BusyTimerSnapshotType value");
     }
 
-    instance->captured_snapshot = *snapshot;
+    instance->last_known_snapshot = *snapshot;
 
     instance->timer_config.mode = new_mode;
     instance->state = new_state;
@@ -623,7 +623,7 @@ static void busy_timer_apply_snapshot(BusyTimer* instance, const BusyTimerSnapsh
     busy_timer_notify_tick(instance);
     busy_timer_notify_paused(instance);
 
-    busy_timer_schedule_publish_captured_snapshot(instance);
+    busy_timer_schedule_publish_last_known_snapshot(instance);
 }
 
 static BusyTimerSetProfileResult busy_timer_set_profile_internal(
@@ -682,7 +682,7 @@ static void busy_timer_snapshot_timer_callback(void* context) {
     BusyTimer* instance = context;
 
     if(instance->snapshot_update_count > 1) {
-        busy_timer_publish_captured_snapshot(instance);
+        busy_timer_publish_last_known_snapshot(instance);
     }
 
     instance->snapshot_update_count = 0;
@@ -802,7 +802,7 @@ static void
     }
 
     busy_timer_capture_snapshot(instance);
-    busy_timer_schedule_publish_captured_snapshot(instance);
+    busy_timer_schedule_publish_last_known_snapshot(instance);
 }
 
 static void
@@ -816,7 +816,7 @@ static void
         FURI_LOG_I(TAG, "Stopped");
 
         busy_timer_capture_snapshot(instance);
-        busy_timer_schedule_publish_captured_snapshot(instance);
+        busy_timer_schedule_publish_last_known_snapshot(instance);
     }
 }
 
@@ -874,7 +874,7 @@ static void
     busy_timer_notify_tick(instance);
 
     busy_timer_capture_snapshot(instance);
-    busy_timer_schedule_publish_captured_snapshot(instance);
+    busy_timer_schedule_publish_last_known_snapshot(instance);
 
     FURI_LOG_I(TAG, "Interval override");
 }
@@ -895,7 +895,7 @@ static void
     busy_timer_notify_paused(instance);
 
     busy_timer_capture_snapshot(instance);
-    busy_timer_schedule_publish_captured_snapshot(instance);
+    busy_timer_schedule_publish_last_known_snapshot(instance);
 }
 
 static void
@@ -906,7 +906,7 @@ static void
         busy_timer_next_state(instance, true);
 
         busy_timer_capture_snapshot(instance);
-        busy_timer_schedule_publish_captured_snapshot(instance);
+        busy_timer_schedule_publish_last_known_snapshot(instance);
 
         FURI_LOG_I(TAG, "Skipped");
     }
@@ -918,7 +918,7 @@ static void
 
     if(instance->state == BusyTimerStateIdle) {
         busy_timer_capture_snapshot(instance);
-        busy_timer_schedule_publish_captured_snapshot(instance);
+        busy_timer_schedule_publish_last_known_snapshot(instance);
 
         FURI_LOG_I(TAG, "Finalized");
     }
@@ -937,7 +937,7 @@ static void busy_timer_get_snapshot_api_message_handler(
     BusyTimer* instance,
     BusyTimerApiMessageData* data) {
     const BusyTimerApiMessageGetSnapshot* get_snapshot = &data->get_snapshot;
-    *get_snapshot->snapshot = instance->captured_snapshot;
+    *get_snapshot->snapshot = instance->last_known_snapshot;
 }
 
 static void busy_timer_set_snapshot_api_message_handler(

--- a/applications/services/busy_timer/busy_timer_i.h
+++ b/applications/services/busy_timer/busy_timer_i.h
@@ -108,7 +108,7 @@ struct BusyTimer {
     FuriMessageQueue* api_queue;
     FuriPubSub* event_pubsub;
     Mqtt* mqtt;
-    BusyTimerSnapshot last_snapshot;
+    BusyTimerSnapshot captured_snapshot;
     BusyTimerSettings settings[BusyTimerProfileIdMax];
     // TODO FW-635: Refactor & simplify internals ---->
     BusyTimerState state;

--- a/applications/services/busy_timer/busy_timer_i.h
+++ b/applications/services/busy_timer/busy_timer_i.h
@@ -108,7 +108,7 @@ struct BusyTimer {
     FuriMessageQueue* api_queue;
     FuriPubSub* event_pubsub;
     Mqtt* mqtt;
-    BusyTimerSnapshot user_snapshot;
+    BusyTimerSnapshot last_snapshot;
     BusyTimerSettings settings[BusyTimerProfileIdMax];
     // TODO FW-635: Refactor & simplify internals ---->
     BusyTimerState state;

--- a/applications/services/busy_timer/busy_timer_i.h
+++ b/applications/services/busy_timer/busy_timer_i.h
@@ -108,7 +108,7 @@ struct BusyTimer {
     FuriMessageQueue* api_queue;
     FuriPubSub* event_pubsub;
     Mqtt* mqtt;
-    BusyTimerSnapshot captured_snapshot;
+    BusyTimerSnapshot last_known_snapshot;
     BusyTimerSettings settings[BusyTimerProfileIdMax];
     // TODO FW-635: Refactor & simplify internals ---->
     BusyTimerState state;


### PR DESCRIPTION
# What's new

- When a snapshot is applied via `busy_timer_set_snapshot()`, it is retransmitted as-is
- The `busy_timer_get_snapshot()` function (as well as respective GET HTTP method) returns the last snapshot instead of capturing a new one

# Verification 

1. Install the firmware bundle
2. Start the BUSY timer
3. Ensure that snapshots set via MQTT or HTTP API are retransmitted as-is
4. Ensture that the GET `busy/snapshot` method returns the last captured snapshot and does not create a new one

> [!NOTE]
> After reset, getting the snapshot will return a default-initialised value instead of   the actual one (this will be fixed later by saving the snapshot to the storage)

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
