### PR TITLE
Busy: Fix "No screen found" on exit

### DIFF
--- a/applications/main/busy/widgets/transition_overlay.c
+++ b/applications/main/busy/widgets/transition_overlay.c
@@ -83,15 +83,6 @@ static void transition_overlay_lvgl_constructor(const lv_obj_class_t* class_p, l
     widget_set_visible((Widget*)instance, false);
 }
 
-static void transition_overlay_lvgl_destructor(const lv_obj_class_t* class_p, lv_obj_t* obj) {
-    UNUSED(class_p);
-
-    TransitionOverlay* instance = (TransitionOverlay*)obj;
-    snap_image_free(instance->snap);
-    lv_obj_del(obj);
-    anim_player_free(instance->mask);
-}
-
 // Implementation
 
 static void transition_overlay_animate_color(TransitionOverlay* instance) {
@@ -274,7 +265,6 @@ void transition_overlay_start(TransitionOverlay* instance) {
 const lv_obj_class_t transition_overlay_lvgl_class = {
     .base_class = &widget_lvgl_class,
     .constructor_cb = transition_overlay_lvgl_constructor,
-    .destructor_cb = transition_overlay_lvgl_destructor,
     .name = "widget-transition-overlay",
     .width_def = LV_PCT(100),
     .height_def = LV_PCT(100),


### PR DESCRIPTION
# What's new

- Fix "No screen found" warning during exit from the BUSY app

> [!NOTE]
> You don't have to explicitly delete child `lv_obj` subclass objects in the parent object's destructor.

# Verification 

1. Install the firmware bundle.
2. Exit from the BUSY/Custom app via the switch (flick it several times back and forth)
3. Ensure there is NO following output in U5 logs:
```
14279 [W][Gui] [Warn] lv_obj_get_display: No screen found
14282 [W][Gui] [Warn] lv_obj_get_display: No screen found
14285 [W][Gui] [Warn] lv_obj_get_display: No screen found
14288 [W][Gui] [Warn] lv_obj_get_display: No screen found
```

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
