### PR TITLE
[FW-679] Updater Fails If "/ext/update" Directory Is Missing

### DIFF
--- a/applications/system/updater/updater.c
+++ b/applications/system/updater/updater.c
@@ -508,7 +508,8 @@ static UpdaterStatus do_unpack(Updater* instance, UpdaterMessage* message) {
     do {
         FURI_LOG_D(TAG, "Creating staging directory...");
 
-        if(storage_common_mkdir(instance->storage, staging_path) != FSE_OK) {
+        if(path_recursive_create_dir(instance->storage, message->as_unpack.staging_path) !=
+           FSE_OK) {
             FURI_LOG_E(TAG, "Failed to create staging directory %s", staging_path);
             update_status = UpdaterStatusUnpackCreateStagingDirectoryFailure;
             break;


### PR DESCRIPTION
> [!NOTE]
> Jira: [FW-679](https://flipper.atlassian.net/browse/FW-679)

# What's new

- replace updater's mkdir with recursive one

# Verification 

- update starts regardless of mentioned directory status (existing/missing)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-679]: https://flipper.atlassian.net/browse/FW-679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ