### PR TITLE
[FW-455] Github: trigger reindex on release

### DIFF
--- a/.github/workflows/reindex.yml
+++ b/.github/workflows/reindex.yml
@@ -1,0 +1,15 @@
+name: "Post-release hooks"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  reindex:
+    name: "Post-release hooks"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Trigger reindex"
+        run: |
+          curl --fail -L -H "Token: ${{ secrets.INDEXER_TOKEN }}" \
+              "${{ secrets.INDEXER_URL }}"/firmware/reindex;


### PR DESCRIPTION
# What's new
[FW-455] 
- Upon release, trigger reindex to update https://update.flipperzero.one/busybar-firmware/directory.json

# Verification 

- Read the changes
- Wait for the next RC

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-455]: https://flipper.atlassian.net/browse/FW-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ