### PR TITLE
[FW-705] Change debug settings name

### DIFF
--- a/applications/settings/system_settings/scenes/system_settings_scene_debug.c
+++ b/applications/settings/system_settings/scenes/system_settings_scene_debug.c
@@ -45,7 +45,7 @@ static void system_settings_scene_debug_fill_var_item_list(
 
     VarItem* debug_item = var_item_list_add_selector(
         list,
-        "Debug apps",
+        "Dev mode",
         NULL,
         debug_apps_names,
         COUNT_OF(debug_apps_names),


### PR DESCRIPTION
# What's new

- Change debug settings name from "Debug apps" to "Dev mode"

# Verification 

- Debug settings name is "Dev mode"

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
