### PR TITLE
Fix common bugs in WiFi, USB network, crypto HAL, and related components

### DIFF
--- a/applications/services/usb_network/usb_network.c
+++ b/applications/services/usb_network/usb_network.c
@@ -110,9 +110,10 @@ bool tud_network_recv_cb(const uint8_t* src, uint16_t size) {
         for(struct pbuf* q = p; q != NULL && size > 0; q = q->next) {
             /* Read enough bytes to fill this pbuf in the chain. 
              * The available data in the pbuf is given by the q->len variable. */
-            memcpy(q->payload, src, size < q->len ? size : q->len);
-            src += q->len;
-            size -= q->len;
+            const uint16_t chunk = size < q->len ? size : q->len;
+            memcpy(q->payload, src, chunk);
+            src += chunk;
+            size -= chunk;
         }
 
 #if(ETH_PAD_SIZE != 0)

--- a/applications/services/web_server/http_api/api_wifi.c
+++ b/applications/services/web_server/http_api/api_wifi.c
@@ -305,10 +305,11 @@ static bool api_wifi_connect_parse_config(
     FuriString* buf = furi_string_alloc();
     do {
         if(!api_wifi_mg_json_get_str_key(body, WIFI_JSON_KEY_SSID, buf, error_msg)) break;
-        strncpy(credentials->ssid, furi_string_get_cstr(buf), SSID_MAX_LEN);
+        strlcpy(credentials->ssid, furi_string_get_cstr(buf), sizeof(credentials->ssid));
 
         if(!api_wifi_mg_json_get_str_key(body, WIFI_JSON_KEY_PASSWORD, buf, error_msg)) break;
-        strncpy(credentials->passphrase, furi_string_get_cstr(buf), PASSPHRASE_MAX_LEN);
+        strlcpy(
+            credentials->passphrase, furi_string_get_cstr(buf), sizeof(credentials->passphrase));
 
         if(!api_wifi_mg_json_get_str_key(body, WIFI_JSON_KEY_SECURITY, buf, error_msg)) break;
         if(!api_wifi_get_security_mode_by_name(buf, &credentials->security_mode)) {

--- a/applications/services/wifi/wifi_api.c
+++ b/applications/services/wifi/wifi_api.c
@@ -21,7 +21,10 @@ static void wifi_api_nonblocking_request(Wifi* instance, const WifiMessage* mess
         instance->api_message = *message;
         furi_event_loop_set_custom_event(instance->event_loop, WifiEventRequest);
     } else {
-        FURI_LOG_W(TAG, "Dropping nonblocking request type %d, another request in progress", message->request_type);
+        FURI_LOG_W(
+            TAG,
+            "Dropping nonblocking request type %d, another request in progress",
+            message->request_type);
     }
 }
 

--- a/applications/services/wifi/wifi_api.c
+++ b/applications/services/wifi/wifi_api.c
@@ -20,6 +20,8 @@ static void wifi_api_nonblocking_request(Wifi* instance, const WifiMessage* mess
     if(furi_semaphore_acquire(instance->api_semaphore, 0) == FuriStatusOk) {
         instance->api_message = *message;
         furi_event_loop_set_custom_event(instance->event_loop, WifiEventRequest);
+    } else {
+        FURI_LOG_W(TAG, "Dropping nonblocking request type %d, another request in progress", message->request_type);
     }
 }
 

--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -217,7 +217,7 @@ static sl_status_t wifi_connect_request_handler(
                 break;
             }
 
-            if(i < NUM_CONNECTION_ATTEMPTS) {
+            if(i < NUM_CONNECTION_ATTEMPTS - 1) {
                 furi_delay_ms(250);
             }
         }
@@ -342,7 +342,7 @@ static void wifi_scan_finished_event_handler(Wifi* instance, const WifiScanFinis
                 const sl_wifi_extended_scan_result_t* result_in = &scan_results[i];
                 WifiScanResult* result_out = &response.scan_results.data[i];
 
-                strncpy(result_out->ssid, (const char*)result_in->ssid, SSID_MAX_LEN);
+                strlcpy(result_out->ssid, (const char*)result_in->ssid, SSID_MAX_LEN);
                 result_out->security_mode = wifi_decode_security_mode(result_in->security_mode);
                 result_out->rssi = result_in->rssi;
             }
@@ -489,7 +489,7 @@ static sl_status_t
 
     } else if(event == SL_WIFI_STATS_MODULE_STATE_EVENT) {
         furi_assert(data);
-        furi_assert(data_length = sizeof(sl_wifi_module_state_stats_response_t));
+        furi_assert(data_length == sizeof(sl_wifi_module_state_stats_response_t));
 
         const sl_wifi_module_state_stats_response_t* response = data;
 

--- a/applications/services/wifi/wifi_backend_net.c
+++ b/applications/services/wifi/wifi_backend_net.c
@@ -290,7 +290,7 @@ sl_status_t
     const sl_wifi_system_packet_t* pkt = sl_si91x_host_get_buffer_data(buffer, 0, NULL);
 
     const uint8_t* data = pkt->data;
-    const uint16_t data_len = MAX(pkt->length, LWIP_FRAME_ALIGNMENT);
+    const uint16_t data_len = MIN(pkt->length, MAX_TRANSFER_UNIT);
 
     const uint16_t ethertype = *((const uint16_t*)&data[12]);
 

--- a/applications/services/wifi/wifi_backend_util.c
+++ b/applications/services/wifi/wifi_backend_util.c
@@ -67,11 +67,8 @@ sl_wifi_security_t wifi_encode_security_mode(WifiSecurityMode security_mode) {
 }
 
 void wifi_encode_ssid(sl_wifi_ssid_t* sl_ssid, const char* ssid) {
-    char* sl_ssid_str = (char*)sl_ssid->value;
-    const size_t sl_ssid_capacity = sizeof(sl_ssid->value);
-
-    strncpy(sl_ssid_str, ssid, sl_ssid_capacity);
-    sl_ssid->length = strlen(sl_ssid_str);
+    const size_t len = strlcpy((char*)sl_ssid->value, ssid, sizeof(sl_ssid->value));
+    sl_ssid->length = MIN(len, sizeof(sl_ssid->value) - 1);
 }
 
 WifiSecurityMode wifi_decode_security_mode(sl_wifi_security_t sl_security) {

--- a/applications/services/wifi/wifi_net.c
+++ b/applications/services/wifi/wifi_net.c
@@ -79,14 +79,15 @@ static void wifi_net_intercom_rx_callback(const void* data, size_t data_size, vo
     pbuf_header(p, -ETH_PAD_SIZE); /* drop the padding word */
 #endif
 
-    const void* src = data;
+    const uint8_t* src = data;
 
     for(struct pbuf* q = p; q != NULL && size > 0; q = q->next) {
         /* Read enough bytes to fill this pbuf in the chain.
          * The available data in the pbuf is given by the q->len variable. */
-        memcpy(q->payload, src, size < q->len ? size : q->len);
-        src += q->len;
-        size -= q->len;
+        const size_t chunk = MIN(size, q->len);
+        memcpy(q->payload, src, chunk);
+        src += chunk;
+        size -= chunk;
     }
 
 #if(ETH_PAD_SIZE != 0)
@@ -158,6 +159,14 @@ bool wifi_net_up(Wifi* instance, const WifiIpConfig* ip_config) {
 
         if(furi_semaphore_acquire(instance->dhcp_semaphore, DHCP_WAIT_MS) != FuriStatusOk) {
             FURI_LOG_E(TAG, "Failed to receive IP configuration");
+
+            LOCK_TCPIP_CORE();
+            netif_set_status_callback(netif, NULL);
+            dhcp_release_and_stop(netif);
+            netif_set_down(netif);
+            netif_set_link_down(netif);
+            UNLOCK_TCPIP_CORE();
+
             success = false;
         }
     }

--- a/applications/services/wifi/wifi_state.c
+++ b/applications/services/wifi/wifi_state.c
@@ -23,7 +23,7 @@ void wifi_state_transition(Wifi* instance, WifiState new_state, ...) {
             if(new_state == WifiStateConnecting) {
                 const WifiCredentials* credentials = va_arg(args, const WifiCredentials*);
 
-                strncpy(info->ssid, credentials->ssid, SSID_MAX_LEN);
+                strlcpy(info->ssid, credentials->ssid, SSID_MAX_LEN);
                 info->security_mode = credentials->security_mode;
             } else {
                 furi_crash("Invalid transition from WifiStateDisconnected");

--- a/applications/settings/account_settings/account_settings.c
+++ b/applications/settings/account_settings/account_settings.c
@@ -102,7 +102,7 @@ static void account_settings_account_event_callback(
     case AccountModelEventPinGot:
         evt.event = AppEventAccountLinkPin;
         furi_assert(pin);
-        strncpy(evt.link.pin, pin, ACCOUNT_MODEL_LINK_PIN_LEN);
+        strlcpy(evt.link.pin, pin, sizeof(evt.link.pin));
         evt.link.valid_untill = pin_valid_untill;
         break;
     case AccountModelEventPinTimeout:

--- a/applications/system/crypto_test/helpers/crypto_sha.c
+++ b/applications/system/crypto_test/helpers/crypto_sha.c
@@ -27,7 +27,7 @@ static const uint8_t digest_out_sha512[FURI_HAL_CRYPTO_SHA512_DIGEST_SIZE] = {
     0xae, 0xad, 0xb6, 0x88, 0x90, 0x18, 0x50, 0x1d, 0x28, 0x9e, 0x49, 0x00, 0xf7,
     0xe4, 0x33, 0x1b, 0x99, 0xde, 0xc4, 0xb5, 0x43, 0x3a, 0xc7, 0xd3, 0x29, 0xee,
     0xb6, 0xdd, 0x26, 0x54, 0x5e, 0x96, 0xe5, 0x5b, 0x87, 0x4b, 0xe9, 0x09};
-static const uint8_t digest_out_sha244[FURI_HAL_CRYPTO_SHA224_DIGEST_SIZE] = {
+static const uint8_t digest_out_sha224[FURI_HAL_CRYPTO_SHA224_DIGEST_SIZE] = {
     0xC9, 0x7C, 0xA9, 0xA5, 0x59, 0x85, 0x0C, 0xE9, 0x7A, 0x04, 0xA9, 0x6D, 0xEF, 0x6D,
     0x99, 0xA9, 0xE0, 0xE0, 0xE2, 0xAB, 0x14, 0xE6, 0xB8, 0xDF, 0x26, 0x5F, 0xC0, 0xB3};
 
@@ -63,7 +63,7 @@ void crypto_sha_test_custom_sha_mode(FuriHalCryptoShaMode sha_mode) {
     case FuriHalCryptoShaModeSha512:
         digest_length = FURI_HAL_CRYPTO_SHA512_DIGEST_SIZE;
         break;
-    case FuriHalCryptoShaModeSha244:
+    case FuriHalCryptoShaModeSha224:
         digest_length = FURI_HAL_CRYPTO_SHA224_DIGEST_SIZE;
         break;
 
@@ -86,8 +86,8 @@ void crypto_sha_test_custom_sha_mode(FuriHalCryptoShaMode sha_mode) {
     case FuriHalCryptoShaModeSha512:
         crypto_sha_check("SHA512", digest, digest_out_sha512, FURI_HAL_CRYPTO_SHA512_DIGEST_SIZE);
         break;
-    case FuriHalCryptoShaModeSha244:
-        crypto_sha_check("SHA224", digest, digest_out_sha244, FURI_HAL_CRYPTO_SHA224_DIGEST_SIZE);
+    case FuriHalCryptoShaModeSha224:
+        crypto_sha_check("SHA224", digest, digest_out_sha224, FURI_HAL_CRYPTO_SHA224_DIGEST_SIZE);
         break;
 
     default:
@@ -104,6 +104,6 @@ void crypto_sha_command(PipeSide* pipe, FuriString* args, void* context) {
     crypto_sha_test_custom_sha_mode(FuriHalCryptoShaModeSha256);
     crypto_sha_test_custom_sha_mode(FuriHalCryptoShaModeSha384);
     crypto_sha_test_custom_sha_mode(FuriHalCryptoShaModeSha512);
-    crypto_sha_test_custom_sha_mode(FuriHalCryptoShaModeSha244);
+    crypto_sha_test_custom_sha_mode(FuriHalCryptoShaModeSha224);
     printf("Crypto SHA done\r\n");
 }

--- a/applications/system/updater/updater.c
+++ b/applications/system/updater/updater.c
@@ -366,7 +366,7 @@ static void download_state_callback(const FuriString* state, void* context) {
 
     UpdaterUpdateState* update_state = furi_state_acquire(instance->update_state);
     update_state->event = UpdaterUpdateEventDetailChange;
-    strncpy(update_state->detail, furi_string_get_cstr(state), sizeof(update_state->detail));
+    strlcpy(update_state->detail, furi_string_get_cstr(state), sizeof(update_state->detail));
     furi_state_release(instance->update_state);
 }
 

--- a/targets/f64/furi_hal/furi_hal_crypto.c
+++ b/targets/f64/furi_hal/furi_hal_crypto.c
@@ -9,7 +9,7 @@
 
 #define TAG "Crypto"
 
-uint8_t wrap_iv[] =
+static const uint8_t wrap_iv[] =
     {0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46};
 
 //#################### AES ####################
@@ -27,6 +27,7 @@ FuriHalCryptoAes* furi_hal_crypto_aes_init(
     uint8_t* key,
     size_t key_size,
     FuriHalCryptoWrappingMode wrapping_mode) {
+    furi_check(mode < COUNT_OF(furi_hal_crypto_aes_mode));
     FuriHalCryptoAes* handle = malloc(sizeof(FuriHalCryptoAes));
     furi_check(handle != NULL, "Failed to allocate memory for AES handle");
 
@@ -52,13 +53,12 @@ FuriHalCryptoAes* furi_hal_crypto_aes_init(
     }
     handle->config.key_config.b0.key_slot = 0;
     handle->config.key_config.b0.wrap_iv_mode = SL_SI91X_WRAP_IV_CBC_MODE;
-    if(handle->config.key_config.b0.wrap_iv_mode == SL_SI91X_WRAP_IV_CBC_MODE) {
-        memcpy(handle->config.key_config.b0.wrap_iv, wrap_iv, SL_SI91X_IV_SIZE);
-    }
-    memcpy(handle->config.key_config.b0.key_buffer, key, handle->config.key_config.b0.key_size);
+    memcpy(handle->config.key_config.b0.wrap_iv, wrap_iv, SL_SI91X_IV_SIZE);
 
     if(wrapping_mode == FuriHalCryptoWrappingModeOff) {
         handle->config.key_config.b0.key_type = SL_SI91X_TRANSPARENT_KEY;
+        memcpy(
+            handle->config.key_config.b0.key_buffer, key, handle->config.key_config.b0.key_size);
     } else {
         handle->config.key_config.b0.key_type = SL_SI91X_WRAPPED_KEY;
         //for 128 bits key, wrap key size is 128 bits,
@@ -78,6 +78,8 @@ FuriHalCryptoAes* furi_hal_crypto_aes_init(
 }
 
 void furi_hal_crypto_aes_deinit(FuriHalCryptoAes* handle) {
+    furi_check(handle);
+    memset(handle, 0, sizeof(*handle));
     free(handle);
 }
 
@@ -153,6 +155,7 @@ FuriHalCryptoEcdsa* furi_hal_crypto_ecdsa_sign_init(
     uint8_t* key,
     uint32_t key_mode,
     FuriHalCryptoWrappingMode wrapping_mode) {
+    furi_check(mode < COUNT_OF(furi_hal_crypto_ecdsa_sha_mode));
     FuriHalCryptoEcdsa* handle = malloc(sizeof(FuriHalCryptoEcdsa));
     furi_check(handle != NULL, "Failed to allocate memory for ECDSA handle");
 
@@ -179,9 +182,7 @@ FuriHalCryptoEcdsa* furi_hal_crypto_ecdsa_sign_init(
         handle->config.private_key_length =
             SL_SI91X_ECDSA_PRIV_KEY_SIZE_256; // wrapped key is of fixed output size 32;
         handle->config.key_config.b0.wrap_iv_mode = SL_SI91X_WRAP_IV_CBC_MODE;
-        if(handle->config.key_config.b0.wrap_iv_mode == SL_SI91X_WRAP_IV_CBC_MODE) {
-            memcpy(handle->config.key_config.b0.wrap_iv, wrap_iv, SL_SI91X_IV_SIZE);
-        }
+        memcpy(handle->config.key_config.b0.wrap_iv, wrap_iv, SL_SI91X_IV_SIZE);
     }
     handle->config.key_config.b0.key_size = 0;
     handle->config.key_config.b0.key_slot = 0;
@@ -194,6 +195,7 @@ FuriHalCryptoEcdsa* furi_hal_crypto_ecdsa_verify_init(
     FuriHalCryptoEcdsaMode mode,
     uint8_t* key,
     uint32_t key_mode) {
+    furi_check(mode < COUNT_OF(furi_hal_crypto_ecdsa_sha_mode));
     FuriHalCryptoEcdsa* handle = malloc(sizeof(FuriHalCryptoEcdsa));
     furi_check(handle != NULL, "Failed to allocate memory for ECDSA handle");
 
@@ -223,6 +225,7 @@ FuriHalCryptoEcdsa* furi_hal_crypto_ecdsa_verify_init(
 
 void furi_hal_crypto_ecdsa_deinit(FuriHalCryptoEcdsa* handle) {
     furi_check(handle);
+    memset(handle, 0, sizeof(*handle));
     free(handle);
 }
 
@@ -254,16 +257,16 @@ bool furi_hal_crypto_ecdsa_verify(
     uint16_t signature_length) {
     furi_check(handle && input && signature);
     furi_check(handle->config.public_key && handle->config.public_key_length);
-    uint8_t* verify = NULL;
+    uint8_t verify_result = 0;
     handle->config.msg = input;
     handle->config.msg_length = input_length;
     handle->config.signature = signature;
     handle->config.signature_length = signature_length;
-    sl_status_t status = sl_si91x_ecdsa(&handle->config, verify);
+    sl_status_t status = sl_si91x_ecdsa(&handle->config, &verify_result);
     if(status != SL_STATUS_OK) {
         FURI_LOG_E(TAG, "Failed to verify data, Error Code : 0x%08lX", status);
         return false;
-    } else if(*verify != 1) {
+    } else if(verify_result != 1) {
         FURI_LOG_D(TAG, "Failed to verify data");
         return false;
     }
@@ -287,6 +290,7 @@ FuriHalCryptoHmac* furi_hal_crypto_hmac_init(
     uint8_t* key,
     size_t key_size,
     FuriHalCryptoWrappingMode wrapping_mode) {
+    furi_check(mode < COUNT_OF(furi_hal_crypto_hmac_sha_mode));
     FuriHalCryptoHmac* handle = malloc(sizeof(FuriHalCryptoHmac));
     furi_check(handle != NULL, "Failed to allocate memory for HMAC handle");
 
@@ -298,9 +302,7 @@ FuriHalCryptoHmac* furi_hal_crypto_hmac_init(
     } else {
         handle->config.key_config.B0.key_type = SL_SI91X_WRAPPED_KEY;
         handle->config.key_config.B0.wrap_iv_mode = SL_SI91X_WRAP_IV_CBC_MODE;
-        if(handle->config.key_config.B0.wrap_iv_mode == SL_SI91X_WRAP_IV_CBC_MODE) {
-            memcpy(handle->config.key_config.B0.wrap_iv, wrap_iv, SL_SI91X_IV_SIZE);
-        }
+        memcpy(handle->config.key_config.B0.wrap_iv, wrap_iv, SL_SI91X_IV_SIZE);
     }
     handle->config.key_config.B0.key_size = key_size;
     handle->config.key_config.B0.key = key;
@@ -310,6 +312,7 @@ FuriHalCryptoHmac* furi_hal_crypto_hmac_init(
 
 void furi_hal_crypto_hmac_deinit(FuriHalCryptoHmac* handle) {
     furi_check(handle);
+    memset(handle, 0, sizeof(*handle));
     free(handle);
 }
 
@@ -358,10 +361,7 @@ void furi_hal_crypto_hmac_wrap_key(
     wrap_config->padding = (1 << 0); //SL_SI91X_HMAC_PADDING;
     wrap_config->hmac_sha_mode = furi_hal_crypto_hmac_sha_mode[hmac_sha_mode];
 
-    if(wrap_config->wrap_iv_mode == SL_SI91X_WRAP_IV_CBC_MODE) {
-        memcpy(wrap_config->wrap_iv, wrap_iv, SL_SI91X_IV_SIZE);
-    }
-    //memset(wrapped_key, 0, *wrapped_key_size);
+    memcpy(wrap_config->wrap_iv, wrap_iv, SL_SI91X_IV_SIZE);
     memcpy(wrap_config->key_buffer, key, wrap_config->key_size);
 
     sl_status_t status = sl_si91x_wrap(wrap_config, wrapped_key);
@@ -380,7 +380,7 @@ static const sl_si91x_crypto_sha_mode_t furi_hal_crypto_sha_mode[] = {
     [FuriHalCryptoShaModeSha256] = SL_SI91X_SHA_256,
     [FuriHalCryptoShaModeSha384] = SL_SI91X_SHA_384,
     [FuriHalCryptoShaModeSha512] = SL_SI91X_SHA_512,
-    [FuriHalCryptoShaModeSha244] = SL_SI91X_SHA_224,
+    [FuriHalCryptoShaModeSha224] = SL_SI91X_SHA_224,
 };
 
 bool furi_hal_crypto_sha(
@@ -400,7 +400,7 @@ bool furi_hal_crypto_sha(
          digest_length == FURI_HAL_CRYPTO_SHA384_DIGEST_SIZE) ||
         (sha_mode == FuriHalCryptoShaModeSha512 &&
          digest_length == FURI_HAL_CRYPTO_SHA512_DIGEST_SIZE) ||
-        (sha_mode == FuriHalCryptoShaModeSha244 &&
+        (sha_mode == FuriHalCryptoShaModeSha224 &&
          digest_length == FURI_HAL_CRYPTO_SHA224_DIGEST_SIZE));
     sl_status_t status = sl_si91x_sha(furi_hal_crypto_sha_mode[sha_mode], msg, msg_length, digest);
     if(status != SL_STATUS_OK) {
@@ -423,12 +423,9 @@ void furi_hal_crypto_wrap_key(uint32_t key_size, uint8_t* key, uint8_t* wrapped_
     wrap_config->padding = 0;
 
     memcpy(wrap_config->key_buffer, key, wrap_config->key_size);
-    if(wrap_config->wrap_iv_mode == SL_SI91X_WRAP_IV_CBC_MODE) {
-        memcpy(wrap_config->wrap_iv, wrap_iv, SL_SI91X_IV_SIZE);
-    }
+    memcpy(wrap_config->wrap_iv, wrap_iv, SL_SI91X_IV_SIZE);
 
     sl_status_t status = sl_si91x_wrap(wrap_config, wrapped_key);
-    furi_check(key_size == wrap_config->key_size, "Invalid key size");
     free(wrap_config);
 
     if(status != SL_STATUS_OK) {

--- a/targets/f64/furi_hal/furi_hal_crypto.h
+++ b/targets/f64/furi_hal/furi_hal_crypto.h
@@ -66,7 +66,7 @@ typedef enum {
     FuriHalCryptoShaModeSha256,
     FuriHalCryptoShaModeSha384,
     FuriHalCryptoShaModeSha512,
-    FuriHalCryptoShaModeSha244,
+    FuriHalCryptoShaModeSha224,
     FuriHalCryptoShaModeMAX,
 } FuriHalCryptoShaMode;
 
@@ -298,7 +298,7 @@ void furi_hal_crypto_hmac_wrap_key(
  *   FuriHalCryptoShaModeSha256 – For SHA256 
  *   FuriHalCryptoShaModeSha384 – For SHA384 
  *   FuriHalCryptoShaModeSha512 – For SHA512 
- *   FuriHalCryptoShaModeSha244 – For SHA224 
+ *   FuriHalCryptoShaModeSha224 – For SHA224 
  * @param[in] msg Pointer to the message buffer
  * @param[in] msg_length Length of the message buffer
  * @param[out] digest Pointer to the digest buffer


### PR DESCRIPTION
# What's new

## Crypto HAL (`targets/f64/furi_hal/`)

### `furi_hal_crypto.c`

- **ECDSA verify NULL dereference** — `sl_si91x_ecdsa()` was called with `verify = NULL`, then `*verify` was dereferenced. Replaced with a stack variable `uint8_t verify_result = 0` and passed `&verify_result`.
- **AES-192 key buffer over-read** — `memcpy` always copied `key_size` bytes from the key into `key_buffer`, but for wrapped keys the buffer is filled by the wrapping operation itself. Moved the transparent-key `memcpy` into the `FuriHalCryptoWrappingModeOff` branch only.
- **Bounds checks on mode enums** — Added `furi_check(mode < COUNT_OF(...))` at the top of `furi_hal_crypto_aes_init`, `ecdsa_sign_init`, `ecdsa_verify_init`, and `hmac_init` to catch invalid enum values before they index into lookup tables.
- **Key material wiping** — Added `memset(handle, 0, sizeof(*handle))` before `free(handle)` in `furi_hal_crypto_aes_deinit`, `ecdsa_deinit`, and `hmac_deinit`.
- **Missing null check** — Added `furi_check(handle)` in `furi_hal_crypto_aes_deinit`.
- **Dead code removal** — Removed always-true `if(wrap_iv_mode == CBC)` conditionals that immediately followed the assignment of `wrap_iv_mode = CBC`.
- **Removed misleading post-hoc assertion** — `furi_check(key_size == wrap_config->key_size)` in `wrap_key` was placed after the operation, not before.
- **`wrap_iv` linkage** — Changed from `uint8_t wrap_iv[]` to `static const uint8_t wrap_iv[]`.

### `furi_hal_crypto.h`

- **Typo** — Renamed `FuriHalCryptoShaModeSha244` → `FuriHalCryptoShaModeSha224` (SHA-224, not SHA-244).

### `crypto_test/helpers/crypto_sha.c`

- Updated all references from `Sha244` → `Sha224` to match the header rename.

---

## WiFi service (`applications/services/wifi/`)

### `wifi_backend.c`

- **Assignment-in-assert** — `furi_assert(data_length = sizeof(...))` used `=` (assignment) instead of `==` (comparison). In release builds where asserts are stripped, `data_length` would be silently overwritten.
- **Retry delay off-by-one** — `if(i < NUM_CONNECTION_ATTEMPTS)` was always true inside the loop `for(i = 0; i < NUM_CONNECTION_ATTEMPTS; ++i)`, causing an unnecessary 250ms delay after the final failed attempt. Changed to `i < NUM_CONNECTION_ATTEMPTS - 1`.
- **`strncpy` → `strlcpy`** in scan result SSID copy.

### `wifi_backend_net.c`

- **Buffer over-read** — `data_len = MAX(pkt->length, LWIP_FRAME_ALIGNMENT)` would read past `pkt->data` when `pkt->length` was smaller than `LWIP_FRAME_ALIGNMENT`. Changed to `MIN(pkt->length, MAX_TRANSFER_UNIT)` to clamp to actual packet size.

### `wifi_backend_util.c`

- **OOB `strlen` after `strncpy`** — `wifi_encode_ssid` used `strncpy` to fill `sl_ssid->value[32]`, then called `strlen()` on it. If the SSID was ≥32 bytes, `strncpy` would not null-terminate, causing `strlen` to read out of bounds. Replaced with `strlcpy` and set length from its return value.

### `wifi_net.c`

- **pbuf copy buffer over-read / unsigned underflow** — In the pbuf receive loop, `src` and `size` were advanced by `q->len` (pbuf chunk capacity) instead of the actual bytes copied. When `size < q->len` on the last chunk, `size -= q->len` would underflow the unsigned counter, and `src` would advance past the valid source data. Fixed by computing `chunk = MIN(size, q->len)` and using it for all three operations.
- **`void*` pointer arithmetic** — Changed `const void* src` to `const uint8_t* src` to avoid undefined behavior with pointer arithmetic on `void*`.
- **DHCP timeout resource leak** — When DHCP timed out in `wifi_net_up`, the function returned `false` without cleaning up: the status callback remained registered, DHCP state was not released, and the netif stayed up. Added cleanup: clear status callback, `dhcp_release_and_stop`, `netif_set_down`, `netif_set_link_down`.

### `wifi_api.c`

- **Silent request drops** — When `wifi_api_nonblocking_request` failed to acquire the semaphore, the request was silently discarded. Added `FURI_LOG_W` to log the dropped request type.

### `wifi_state.c`

- **`strncpy` → `strlcpy`** in state transition SSID copy.

---

## USB network (`applications/services/usb_network/`)

### `usb_network.c`

- **pbuf copy buffer over-read / unsigned underflow** — Same bug as WiFi `wifi_net.c`: `src` and `size` were advanced by `q->len` instead of actual bytes copied. Fixed identically.

---

## `strncpy` → `strlcpy` migration

All `strncpy` calls in application code replaced with `strlcpy`, fixing missing null-termination bugs when the source string fills the destination buffer:

| File | Field | Bug |
|------|-------|-----|
| `web_server/http_api/api_wifi.c` | `credentials->ssid` | No null-term if SSID ≥ 34 chars |
| `web_server/http_api/api_wifi.c` | `credentials->passphrase` | No null-term if passphrase ≥ 64 chars |
| `account_settings/account_settings.c` | `evt.link.pin` | No null-term if PIN is exactly 4 chars |
| `updater/updater.c` | `update_state->detail` | No null-term if detail ≥ 128 chars |

---

## Affected components

- `furi_hal_crypto` (f64 target HAL)
- `crypto_test` (system app)
- `wifi` (service — backend, frontend, networking, state, utilities)
- `usb_network` (service)
- `web_server` (service — WiFi API handler)
- `account_settings` (settings app)
- `updater` (system app)

# Verification 

- [ Describe how to verify changes ]

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
