### PR TITLE
[FW-714] BusyTimer: Accept profiles with missing/null busy_bar_settings field

### DIFF
--- a/applications/services/busy_timer/busy_timer.c
+++ b/applications/services/busy_timer/busy_timer.c
@@ -747,7 +747,7 @@ static void busy_timer_mqtt_profile_busy_callback(const MqttMessage* message, vo
     if(busy_timer_profile_deserialize(&profile, json_text, json_text_len)) {
         busy_timer_set_profile(instance, BusyTimerProfileIdBusy, &profile);
     } else {
-        FURI_LOG_W(TAG, "Invalid profile data");
+        FURI_LOG_W(TAG, "Invalid busy profile data");
     }
 }
 
@@ -763,7 +763,7 @@ static void busy_timer_mqtt_profile_custom_callback(const MqttMessage* message, 
     if(busy_timer_profile_deserialize(&profile, json_text, json_text_len)) {
         busy_timer_set_profile(instance, BusyTimerProfileIdCustom, &profile);
     } else {
-        FURI_LOG_W(TAG, "Invalid profile data");
+        FURI_LOG_W(TAG, "Invalid custom profile data");
     }
 }
 

--- a/applications/services/busy_timer/busy_timer_profile.c
+++ b/applications/services/busy_timer/busy_timer_profile.c
@@ -104,6 +104,18 @@ static bool busy_timer_profile_deserialize_timer_settings(
     return success;
 }
 
+static bool
+    busy_timer_profile_handle_missing_app_config(const cJSON* json, BusyAppConfig* app_config) {
+    bool success = false;
+
+    if(json == NULL || cJSON_IsNull(json)) {
+        memset(app_config, 0, sizeof(BusyAppConfig));
+        success = true;
+    }
+
+    return success;
+}
+
 // Public functions
 
 char* busy_timer_profile_serialize(const BusyTimerProfile* profile) {
@@ -148,7 +160,8 @@ bool busy_timer_profile_deserialize(
         }
 
         item = cJSON_GetObjectItem(json, KEY_COMMON_BUSY_BAR_SETTINGS);
-        if(!busy_timer_common_deserialize_app_config(item, &profile->app_config)) {
+        if(!busy_timer_common_deserialize_app_config(item, &profile->app_config) &&
+           !busy_timer_profile_handle_missing_app_config(item, &profile->app_config)) {
             break;
         }
 


### PR DESCRIPTION
# What's new

- Accept profiles with missing/null `busy_bar_settings` field

# Verification 

1. Flash the firmware bundle
2. Using MQTTX, post a profile with missing/nulled `busy_bar_settings` field
3. Ensure that the profile is not rejected and gets default values

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
