### PR TITLE
[FW-712] Intercom: Fix deadlock condition upon receiving an invalid frame

### DIFF
--- a/applications/services/intercom/intercom_rx.c
+++ b/applications/services/intercom/intercom_rx.c
@@ -6,7 +6,11 @@
 
 typedef enum {
     IntercomRxThreadFlagFrameReceived = 1UL << 0,
+    IntercomRxThreadFlagErrorOccurred = 1UL << 1,
 } IntercomRxThreadFlag;
+
+#define INTERCOM_RX_THREAD_FLAGS_ALL \
+    (IntercomRxThreadFlagFrameReceived | IntercomRxThreadFlagErrorOccurred)
 
 #ifdef SRV_INTERCOM_WATCHDOG
 
@@ -72,7 +76,7 @@ static void intercom_rx_state_callback(const void* item, void* context) {
     const IntercomStatus status = *(IntercomStatus*)item;
 
     if(status != IntercomStatusOk) {
-        furi_thread_suspend(rx_thread);
+        furi_thread_flags_set(rx_thread, IntercomRxThreadFlagErrorOccurred);
     }
 }
 
@@ -100,9 +104,14 @@ static void intercom_rx_wait_for_data(Intercom* instance) {
     furi_hal_serial_dma_rx_start(
         instance->serial, (void*)&instance->rx_frame, sizeof(IntercomFrame));
 
-    const uint32_t flags = furi_thread_flags_wait(
-        IntercomRxThreadFlagFrameReceived, FuriFlagWaitAny, FuriWaitForever);
-    furi_check(flags == IntercomRxThreadFlagFrameReceived);
+    const uint32_t flags =
+        furi_thread_flags_wait(INTERCOM_RX_THREAD_FLAGS_ALL, FuriFlagWaitAny, FuriWaitForever);
+
+    furi_check((flags & FuriFlagError) == 0);
+
+    if(flags & IntercomRxThreadFlagErrorOccurred) {
+        furi_thread_suspend(furi_thread_get_current_id());
+    }
 }
 
 static int32_t intercom_rx_thread(void* arg) {


### PR DESCRIPTION
# What's new

- Fix deadlock condition upon receiving an invalid frame

# Verification 

1. Flash the firmware bundle
2. After the system boots up, press `917_RST` to reset the Si917 and cause a framing error
3. The main (U5) processor should remain responsive
4. Execute `power reboot` from the CLI. The system should reboot and resume normal function.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix