### PR TITLE
[FW-695] WIFI setting parent app name

### DIFF
--- a/applications/main/settings_menu/settings.c
+++ b/applications/main/settings_menu/settings.c
@@ -162,8 +162,6 @@ static void settings_free(SettingsApp* instance) {
 }
 
 int32_t settings_app(void* arg) {
-    UNUSED(arg);
-
     SettingsApp* instance = settings_alloc(arg);
     furi_event_loop_run(instance->event_loop);
     settings_free(instance);

--- a/applications/settings/about/about.c
+++ b/applications/settings/about/about.c
@@ -151,7 +151,7 @@ static void about_free(About* instance) {
 }
 
 int32_t about_entry(void* arg) {
-    if(arg) {
+    if(settings_app_descriptor_is_valid(arg)) {
         SettingsAppDescriptor* descriptor = arg;
         furi_string_set_str(descriptor->front_title, "About");
         furi_string_set_str(descriptor->back_title, "About");

--- a/applications/settings/account_settings/account_settings.c
+++ b/applications/settings/account_settings/account_settings.c
@@ -195,7 +195,7 @@ static AccountSettings* account_settings_alloc() {
         scene_manager_next_scene(instance->scene_manager, SceneIdLinkedInfo);
     } else {
         if(wifi_info.state == WifiStateDisconnected) {
-            desktop_replace_current_app(instance->desktop, WIFI_SETTINGS_APP, NULL);
+            account_settings_open_wifi_settings(instance);
         } else {
             AccountModelState state = account_model_get_state(instance->model);
             if(state == AccountModelStateConnectedNotLinked) {
@@ -240,7 +240,7 @@ static void account_settings_free(AccountSettings* instance) {
 }
 
 int32_t account_settings_entry(void* arg) {
-    if(arg) {
+    if(settings_app_descriptor_is_valid(arg)) {
         AccountModel* model = account_model_alloc();
         bool is_linked = account_model_is_linked(model);
 
@@ -291,4 +291,9 @@ void account_settings_send_custom_event(AccountSettings* instance, uint32_t even
 
     furi_check(
         furi_message_queue_put(instance->event_queue, &evt, FuriWaitForever) == FuriStatusOk);
+}
+
+void account_settings_open_wifi_settings(AccountSettings* instance) {
+    furi_assert(instance);
+    desktop_replace_current_app(instance->desktop, WIFI_SETTINGS_APP, THIS_SETTINGS_APP);
 }

--- a/applications/settings/account_settings/account_settings_i.h
+++ b/applications/settings/account_settings/account_settings_i.h
@@ -73,6 +73,8 @@ void account_settings_send_custom_event(AccountSettings* instance, uint32_t even
 
 void account_settings_get_short_email(AccountSettings* instance, FuriString* mail_str);
 
+void account_settings_open_wifi_settings(AccountSettings* instance);
+
 #ifdef __cplusplus
 }
 #endif

--- a/applications/settings/account_settings/scenes/scene_connecting.c
+++ b/applications/settings/account_settings/scenes/scene_connecting.c
@@ -56,7 +56,7 @@ static bool account_scene_connecting_on_event(const SceneManagerEvent* event, vo
             consumed = true;
             break;
         case AppEventWifiDisconnected:
-            desktop_replace_current_app(instance->desktop, WIFI_SETTINGS_APP, NULL);
+            account_settings_open_wifi_settings(instance);
             consumed = true;
             break;
         default:

--- a/applications/settings/account_settings/scenes/scene_error.c
+++ b/applications/settings/account_settings/scenes/scene_error.c
@@ -86,7 +86,7 @@ static bool account_scene_error_on_event(const SceneManagerEvent* event, void* c
     if(event->type == SceneManagerEventTypeCustom) {
         switch(event->event) {
         case SceneEventOpenWifiSettings:
-            desktop_replace_current_app(instance->desktop, WIFI_SETTINGS_APP, NULL);
+            account_settings_open_wifi_settings(instance);
             consumed = true;
             break;
 

--- a/applications/settings/account_settings/scenes/scene_link_pin.c
+++ b/applications/settings/account_settings/scenes/scene_link_pin.c
@@ -119,7 +119,7 @@ static bool account_scene_link_pin_on_event(const SceneManagerEvent* event, void
             consumed = true;
             break;
         case AppEventWifiDisconnected:
-            desktop_replace_current_app(instance->desktop, WIFI_SETTINGS_APP, NULL);
+            account_settings_open_wifi_settings(instance);
             consumed = true;
             break;
 

--- a/applications/settings/account_settings/scenes/scene_not_linked_menu.c
+++ b/applications/settings/account_settings/scenes/scene_not_linked_menu.c
@@ -75,7 +75,7 @@ static bool account_scene_not_linked_menu_on_event(const SceneManagerEvent* even
             consumed = true;
             break;
         case AppEventWifiDisconnected:
-            desktop_replace_current_app(instance->desktop, WIFI_SETTINGS_APP, NULL);
+            account_settings_open_wifi_settings(instance);
             consumed = true;
             break;
         default:

--- a/applications/settings/ble_settings/ble_settings.c
+++ b/applications/settings/ble_settings/ble_settings.c
@@ -171,7 +171,7 @@ static void ble_settings_set_icon_by_status(
 }
 
 int32_t ble_settings_entry(void* arg) {
-    if(arg) {
+    if(settings_app_descriptor_is_valid(arg)) {
         SettingsAppDescriptor* descriptor = arg;
         furi_string_set_str(descriptor->front_title, "Bluetooth");
         furi_string_set_str(descriptor->back_title, "Bluetooth");

--- a/applications/settings/brightness_settings/brightness_settings.c
+++ b/applications/settings/brightness_settings/brightness_settings.c
@@ -160,7 +160,7 @@ static void brightness_settings_free(BrightnessSettings* instance) {
 }
 
 int32_t brightness_settings_entry(void* arg) {
-    if(arg) {
+    if(settings_app_descriptor_is_valid(arg)) {
         BrightnessModel* model = brightness_model_alloc();
         SettingsAppDescriptor* descriptor = arg;
 

--- a/applications/settings/debug_app_list/debug_app_list.c
+++ b/applications/settings/debug_app_list/debug_app_list.c
@@ -153,7 +153,7 @@ static void debug_app_list_free(DebugAppList* instance) {
 }
 
 int32_t debug_app_list_entry(void* arg) {
-    if(arg) {
+    if(settings_app_descriptor_is_valid(arg)) {
         SettingsAppDescriptor* descriptor = arg;
 
         furi_string_set_str(descriptor->front_title, "Debug apps");

--- a/applications/settings/firmware/firmware.c
+++ b/applications/settings/firmware/firmware.c
@@ -191,7 +191,7 @@ static void this_setup_app_descriptor(SettingsAppDescriptor* descriptor) {
 }
 
 int32_t settings_firmware_app_entry(void* argument) {
-    if(argument) {
+    if(settings_app_descriptor_is_valid(argument)) {
         this_setup_app_descriptor(argument);
     } else {
         ThisInstance* instance = this_alloc();

--- a/applications/settings/matter_settings/matter_settings.c
+++ b/applications/settings/matter_settings/matter_settings.c
@@ -39,6 +39,11 @@ static void matter_settings_input_queue_callback(FuriEventLoopObject* object, vo
     }
 }
 
+static void matter_settings_open_wifi_settings(MatterSettings* instance) {
+    furi_assert(instance);
+    desktop_replace_current_app(instance->desktop, WIFI_SETTINGS_APP, THIS_SETTINGS_APP);
+}
+
 static void matter_settings_event_queue_callback(FuriEventLoopObject* object, void* context) {
     UNUSED(object);
 
@@ -57,7 +62,7 @@ static void matter_settings_event_queue_callback(FuriEventLoopObject* object, vo
             scene_manager_replace_current_scene(instance->scene_manager, event_to_scene[event]);
 
         } else if(event == AppEventRequiredWifiNotAvailable) {
-            desktop_replace_current_app(instance->desktop, WIFI_SETTINGS_APP, NULL);
+            matter_settings_open_wifi_settings(instance);
 
         } else {
             scene_manager_handle_custom_event(instance->scene_manager, event);
@@ -201,7 +206,7 @@ static void matter_settings_free(MatterSettings* instance) {
 }
 
 int32_t matter_settings_entry(void* arg) {
-    if(arg) {
+    if(settings_app_descriptor_is_valid(arg)) {
         SettingsAppDescriptor* descriptor = arg;
 
         furi_string_set_str(descriptor->front_title, "Smart home");

--- a/applications/settings/sound_settings/sound_settings.c
+++ b/applications/settings/sound_settings/sound_settings.c
@@ -160,7 +160,7 @@ static void sound_settings_free(SoundSettings* instance) {
 }
 
 int32_t sound_settings_entry(void* arg) {
-    if(arg) {
+    if(settings_app_descriptor_is_valid(arg)) {
         VolumeModel* model = volume_model_alloc();
         SettingsAppDescriptor* descriptor = arg;
 

--- a/applications/settings/system_settings/system_settings.c
+++ b/applications/settings/system_settings/system_settings.c
@@ -156,7 +156,7 @@ static void system_settings_free(SystemSettings* instance) {
 }
 
 int32_t system_settings_entry(void* arg) {
-    if(arg) {
+    if(settings_app_descriptor_is_valid(arg)) {
         SettingsAppDescriptor* descriptor = arg;
         furi_string_set_str(descriptor->front_title, "System");
         furi_string_set_str(descriptor->back_title, "System");

--- a/applications/settings/time_settings/time_settings.c
+++ b/applications/settings/time_settings/time_settings.c
@@ -137,7 +137,7 @@ static void time_settings_free(TimeSettings* instance) {
 }
 
 int32_t time_settings_entry(void* arg) {
-    if(arg) {
+    if(settings_app_descriptor_is_valid(arg)) {
         SettingsAppDescriptor* descriptor = arg;
 
         furi_string_set_str(descriptor->front_title, "Time");

--- a/applications/settings/wifi_settings/scenes/scene_wifi_forget.c
+++ b/applications/settings/wifi_settings/scenes/scene_wifi_forget.c
@@ -70,7 +70,8 @@ static bool wifi_scene_forget_on_event(const SceneManagerEvent* event, void* con
         switch(event->event) {
         case SceneEventConfirm:
             wifi_model_forget(instance->model);
-            desktop_replace_current_app(instance->desktop, MAIN_SETTINGS_APP, THIS_SETTINGS_APP);
+            desktop_replace_current_app(
+                instance->desktop, MAIN_SETTINGS_APP, instance->parent_app_id);
             consumed = true;
             break;
         case SceneEventCancel:

--- a/applications/settings/wifi_settings/scenes/scene_wifi_not_connected.c
+++ b/applications/settings/wifi_settings/scenes/scene_wifi_not_connected.c
@@ -63,7 +63,7 @@ static bool wifi_scene_not_connected_on_event(const SceneManagerEvent* event, vo
         }
 
     } else if(event->type == SceneManagerEventTypeBack) {
-        desktop_replace_current_app(instance->desktop, MAIN_SETTINGS_APP, THIS_SETTINGS_APP);
+        desktop_replace_current_app(instance->desktop, MAIN_SETTINGS_APP, instance->parent_app_id);
         consumed = true;
     }
 

--- a/applications/settings/wifi_settings/scenes/scene_wifi_state.c
+++ b/applications/settings/wifi_settings/scenes/scene_wifi_state.c
@@ -115,7 +115,7 @@ static bool wifi_scene_state_on_event(const SceneManagerEvent* event, void* cont
         }
 
     } else if(event->type == SceneManagerEventTypeBack) {
-        desktop_replace_current_app(instance->desktop, MAIN_SETTINGS_APP, THIS_SETTINGS_APP);
+        desktop_replace_current_app(instance->desktop, MAIN_SETTINGS_APP, instance->parent_app_id);
         consumed = true;
     }
 

--- a/applications/settings/wifi_settings/wifi_settings.c
+++ b/applications/settings/wifi_settings/wifi_settings.c
@@ -78,8 +78,9 @@ static void wifi_settings_wifi_state_callback(void* context) {
     wifi_settings_send_custom_event(instance, AppEventWifiStateChange);
 }
 
-static WifiSettings* wifi_settings_alloc() {
+static WifiSettings* wifi_settings_alloc(const char* parent_app_id) {
     WifiSettings* instance = malloc(sizeof(WifiSettings));
+    instance->parent_app_id = parent_app_id;
     instance->event_loop = furi_event_loop_alloc();
     instance->input_queue = furi_message_queue_alloc(4, sizeof(InputEvent));
     instance->event_queue = furi_message_queue_alloc(4, sizeof(uint32_t));
@@ -167,11 +168,12 @@ static void wifi_settings_free(WifiSettings* instance) {
 }
 
 int32_t wifi_settings_entry(void* arg) {
-    if(arg) {
+    if(settings_app_descriptor_is_valid(arg)) {
+        SettingsAppDescriptor* descriptor = arg;
+
         WifiModel* wifi_model = wifi_model_alloc();
         WifiModelState wifi_state = wifi_model_get_state(wifi_model);
 
-        SettingsAppDescriptor* descriptor = arg;
         furi_string_set_str(descriptor->front_title, "Wi-Fi");
         furi_string_set_str(descriptor->back_title, "Wi-Fi");
         if(wifi_state == WifiModelStateDisconnected) {
@@ -189,7 +191,14 @@ int32_t wifi_settings_entry(void* arg) {
         return 0;
     }
 
-    WifiSettings* instance = wifi_settings_alloc();
+    const char* parent_app_id = THIS_SETTINGS_APP;
+    if(arg) {
+        if(((char*)arg)[0] != '\0') {
+            parent_app_id = arg;
+        }
+    }
+
+    WifiSettings* instance = wifi_settings_alloc(parent_app_id);
     FuriThread* thread = furi_thread_get_current();
     furi_thread_set_signal_callback(thread, wifi_settings_thread_signal_callback, instance);
     furi_event_loop_run(instance->event_loop);

--- a/applications/settings/wifi_settings/wifi_settings_i.h
+++ b/applications/settings/wifi_settings/wifi_settings_i.h
@@ -55,6 +55,8 @@ typedef struct {
     NavBar* back_nav_bar;
 
     WifiModel* model;
+
+    const char* parent_app_id;
 } WifiSettings;
 
 void wifi_settings_send_custom_event(WifiSettings* instance, uint32_t event);

--- a/lib/settings_helpers/app_desc.c
+++ b/lib/settings_helpers/app_desc.c
@@ -2,6 +2,8 @@
 
 SettingsAppDescriptor* settings_app_descriptor_alloc(void) {
     SettingsAppDescriptor* desc = malloc(sizeof(SettingsAppDescriptor));
+    desc->magic = SETTINGS_APP_DESCRIPTOR_MAGIC;
+
     desc->front_title = furi_string_alloc();
     desc->back_title = furi_string_alloc();
     desc->menu_extra = furi_string_alloc();
@@ -27,5 +29,11 @@ void settings_app_descriptor_reset(SettingsAppDescriptor* desc) {
     furi_string_reset(desc->menu_extra);
     furi_string_reset(desc->front_icon);
     furi_string_reset(desc->back_icon);
+    desc->magic = SETTINGS_APP_DESCRIPTOR_MAGIC;
     desc->display_in_menu = true;
+}
+
+bool settings_app_descriptor_is_valid(void* arg) {
+    if(!arg) return false;
+    return ((SettingsAppDescriptor*)arg)->magic == SETTINGS_APP_DESCRIPTOR_MAGIC;
 }

--- a/lib/settings_helpers/app_desc.h
+++ b/lib/settings_helpers/app_desc.h
@@ -13,14 +13,20 @@ extern "C" {
 
 #include <furi.h>
 
+#define SETTINGS_APP_DESCRIPTOR_MAGIC 0x00AA5500
+
 /**
  * @brief Dynamic information about a settings submenu.
- * 
- * If you're a `SETTINGS` app and you're given a non-NULL argument, it's a
- * pointer to this structure. You must fill it with data as quickly as possible
- * and exit immediately. This data will be shown in the main settings menu.
+ *
+ * If you're a `SETTINGS` app, you're given a non-NULL argument and first 4 bytes equal to
+ * SETTINGS_APP_DESCRIPTOR_MAGIC, it's a pointer to this structure.
+ * You must fill it with data as quickly as possible and exit immediately.
+ * This data will be shown in the main settings menu.
  */
 typedef struct {
+    uint32_t
+        magic; //<! Magic value to identify descriptor is not a string, set to SETTINGS_APP_DESCRIPTOR_MAGIC
+
     FuriString* front_title; //<! Title on front display
     FuriString* back_title; //<! Title on back display
     FuriString* menu_extra; //<! Sub-label for menus on both displays
@@ -35,6 +41,8 @@ SettingsAppDescriptor* settings_app_descriptor_alloc(void);
 void settings_app_descriptor_free(SettingsAppDescriptor* desc);
 
 void settings_app_descriptor_reset(SettingsAppDescriptor* desc);
+
+bool settings_app_descriptor_is_valid(void* arg);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
# What's new
[FW-695]
- Support for passing string arguments to setting apps
- WIFI settings: passing parent app name to settings menu

# Verification 

- Disconnect wifi, open account/smart home settings
- Press back, the cursor should be on a last selected app

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-695]: https://flipper.atlassian.net/browse/FW-695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ