### PR TITLE
[FW-658] MQTT: drop packets when buffer is full

### DIFF
--- a/applications/services/mqtt/mqtt_subscription.c
+++ b/applications/services/mqtt/mqtt_subscription.c
@@ -1,5 +1,7 @@
 #include "mqtt_i.h"
 
+#define MQTT_MAX_UNSENT_DATA_SIZE_BYTES (50 * 1024)
+
 static MqttSubscription* mqtt_subscription_alloc(void) {
     MqttSubscription* subscription = malloc(sizeof(MqttSubscription));
 
@@ -116,6 +118,12 @@ bool mqtt_publish_internal(
     uint32_t props_count) {
     if(!mqtt_is_valid_scope_for_current_status(instance, scope)) {
         FURI_LOG_E(TAG, "Unable to publish: scope: %d, status: %d", scope, instance->status);
+        return false;
+    }
+
+    // Drop messages if we have huge backlog of unsent messages
+    if(instance->conn->send.size >= MQTT_MAX_UNSENT_DATA_SIZE_BYTES) {
+        FURI_LOG_W(TAG, "Dropping %u bytes from topic '%s'", data_size, topic);
         return false;
     }
 


### PR DESCRIPTION
# What's new
[FW-658]
- Drop packets when buffer is full

# Verification 

- Launch screen streaming through MQTT
- Move busybar away from WiFi AP
- Verify graceful packets drop in logs

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-658]: https://flipper.atlassian.net/browse/FW-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ