### PR TITLE
Revert submenu/var_item scroll

### DIFF
--- a/applications/main/busy/scenes/busy_scene_setup_smart_home.c
+++ b/applications/main/busy/scenes/busy_scene_setup_smart_home.c
@@ -2,7 +2,7 @@
 
 #include <gui/modules/var_item_list.h>
 
-#define ITEM_LABEL_ENABLE "Trigger smart home"
+#define ITEM_LABEL_ENABLE "Trigger smart\nhome"
 
 typedef struct {
     VarItemList* front_list;

--- a/applications/services/gui/modules/submenu.c
+++ b/applications/services/gui/modules/submenu.c
@@ -137,10 +137,8 @@ static void submenu_item_lvgl_event(const lv_obj_class_t* class_p, lv_event_t* e
 
     if(code == LV_EVENT_FOCUSED) {
         lv_obj_add_state(instance->cursor, LV_STATE_FOCUSED);
-        // lv_label_set_long_mode(instance->label, LV_LABEL_LONG_SCROLL);
     } else if(code == LV_EVENT_DEFOCUSED) {
         lv_obj_remove_state(instance->cursor, LV_STATE_FOCUSED);
-        // lv_label_set_long_mode(instance->label, LV_LABEL_LONG_CLIP);
     }
 }
 

--- a/applications/services/gui/modules/submenu.c
+++ b/applications/services/gui/modules/submenu.c
@@ -137,10 +137,10 @@ static void submenu_item_lvgl_event(const lv_obj_class_t* class_p, lv_event_t* e
 
     if(code == LV_EVENT_FOCUSED) {
         lv_obj_add_state(instance->cursor, LV_STATE_FOCUSED);
-        lv_label_set_long_mode(instance->label, LV_LABEL_LONG_SCROLL);
+        // lv_label_set_long_mode(instance->label, LV_LABEL_LONG_SCROLL);
     } else if(code == LV_EVENT_DEFOCUSED) {
         lv_obj_remove_state(instance->cursor, LV_STATE_FOCUSED);
-        lv_label_set_long_mode(instance->label, LV_LABEL_LONG_CLIP);
+        // lv_label_set_long_mode(instance->label, LV_LABEL_LONG_CLIP);
     }
 }
 

--- a/applications/services/gui/modules/var_item_list.c
+++ b/applications/services/gui/modules/var_item_list.c
@@ -147,10 +147,8 @@ static void var_item_lvgl_event(const lv_obj_class_t* class_p, lv_event_t* event
 
     if(code == LV_EVENT_FOCUSED) {
         lv_obj_add_state(instance->cursor, LV_STATE_FOCUSED);
-        // lv_label_set_long_mode(instance->label, LV_LABEL_LONG_SCROLL);
     } else if(code == LV_EVENT_DEFOCUSED) {
         lv_obj_remove_state(instance->cursor, LV_STATE_FOCUSED);
-        // lv_label_set_long_mode(instance->label, LV_LABEL_LONG_CLIP);
     }
 }
 

--- a/applications/services/gui/modules/var_item_list.c
+++ b/applications/services/gui/modules/var_item_list.c
@@ -147,10 +147,10 @@ static void var_item_lvgl_event(const lv_obj_class_t* class_p, lv_event_t* event
 
     if(code == LV_EVENT_FOCUSED) {
         lv_obj_add_state(instance->cursor, LV_STATE_FOCUSED);
-        lv_label_set_long_mode(instance->label, LV_LABEL_LONG_SCROLL);
+        // lv_label_set_long_mode(instance->label, LV_LABEL_LONG_SCROLL);
     } else if(code == LV_EVENT_DEFOCUSED) {
         lv_obj_remove_state(instance->cursor, LV_STATE_FOCUSED);
-        lv_label_set_long_mode(instance->label, LV_LABEL_LONG_CLIP);
+        // lv_label_set_long_mode(instance->label, LV_LABEL_LONG_CLIP);
     }
 }
 


### PR DESCRIPTION
# What's new

- Revert long text scroll in var_item_list and submenu

# Verification 

- Check busy -> setup -> Smart home and settings -> time -> time zone

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
