### PR TITLE
[FW-733] Config tuning to avoid hitting LWIP bug with connection teardown

### DIFF
--- a/targets/f21/lwip/lwipopts.h
+++ b/targets/f21/lwip/lwipopts.h
@@ -8,7 +8,13 @@
 #define DEFAULT_RAW_RECVMBOX_SIZE 32
 #define DEFAULT_UDP_RECVMBOX_SIZE 32
 #define DEFAULT_TCP_RECVMBOX_SIZE 32
-#define DEFAULT_ACCEPTMBOX_SIZE   32
+/* Must be >= TCP_DEFAULT_LISTEN_BACKLOG to avoid triggering a bug in lwIP's
+ * accept_function() (api_msg.c ~line 594): when LWIP_NETCONN_FULLDUPLEX=1 and
+ * sys_mbox_trypost fails (mbox full), netconn_free() calls netconn_drain() on a
+ * freshly allocated netconn without NETCONN_FLAG_MBOXINVALID set, hitting
+ * LWIP_ASSERT("netconn marked closed"). Fix: set newconn->flags |=
+ * NETCONN_FLAG_MBOXINVALID before netconn_free() in the cleanup path. */
+#define DEFAULT_ACCEPTMBOX_SIZE   64
 
 #define LWIP_MDNS_RESPONDER 1
 
@@ -38,7 +44,7 @@
 #define MEMP_NUM_UDP_PCB                       32
 #define MEMP_NUM_TCP_PCB                       64
 #define MEMP_NUM_TCP_PCB_LISTEN                16
-#define MEMP_NUM_TCP_SEG                       128
+#define MEMP_NUM_TCP_SEG                       256
 #define MEMP_NUM_ALTCP_PCB                     MEMP_NUM_TCP_PCB
 #define MEMP_NUM_REASSDATA                     32
 #define MEMP_NUM_FRAG_PBUF                     32
@@ -160,7 +166,7 @@
 #define LWIP_HAVE_LOOPIF                   (LWIP_NETIF_LOOPBACK && !LWIP_SINGLE_NETIF)
 #define LWIP_LOOPIF_MULTICAST              0
 #define LWIP_NETIF_LOOPBACK                1
-#define LWIP_LOOPBACK_MAX_PBUFS            0
+#define LWIP_LOOPBACK_MAX_PBUFS            32
 #define LWIP_NETIF_LOOPBACK_MULTITHREADING (!NO_SYS)
 #define TCPIP_THREAD_NAME                  "LwipWorker"
 #define LWIP_NETCONN                       1


### PR DESCRIPTION
# What's new

[FW-733]
- lwip: config tuning to avoid hitting bug with connection teardown

# Verification 

- put device under network stress like unit tests 
- observe no crashes with stack trace from [FW-733]

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-733]: https://flipper.atlassian.net/browse/FW-733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FW-733]: https://flipper.atlassian.net/browse/FW-733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ