### PR TITLE
[FW-761] api: matter: use resolution in seconds, not milliseconds

### DIFF
--- a/applications/services/web_server/http_api/api_smart_home.c
+++ b/applications/services/web_server/http_api/api_smart_home.c
@@ -32,11 +32,8 @@ static void
     };
     cJSON_AddStringToObject(status_upd, "value", status_string[fabrics.last_status]);
 
-    // representing a millisecond timestamp as a number will have precision issues
     if(fabrics.last_status_at) {
-        char timestamp[32];
-        snprintf(timestamp, sizeof(timestamp), "%" PRIu64, fabrics.last_status_at);
-        cJSON_AddStringToObject(status_upd, "timestamp", timestamp);
+        cJSON_AddNumberToObject(status_upd, "timestamp", fabrics.last_status_at / 1000);
     }
 
     char* serialized = cJSON_PrintUnformatted(object);

--- a/applications/services/web_server/http_api/http_api.h
+++ b/applications/services/web_server/http_api/http_api.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "../web_server_i.h"
 
-#define API_VERSION {16, 0, 0}
+#define API_VERSION {17, 0, 0}
 
 // Root API handlers
 void* http_api_root_alloc(void);

--- a/applications/services/web_server/resources/apps_assets/web_server/www/openapi.yaml
+++ b/applications/services/web_server/resources/apps_assets/web_server/www/openapi.yaml
@@ -2817,9 +2817,9 @@ components:
               description: 'Latest state of smart home pairing (Matter "commissioning") process. Note: "never_started" only refers to the current power cycle of the device; this status is not recorded across reboots.'
               example: "completed_successfully"
             timestamp:
-              type: string
-              description: "UTC Unix millisecond timestamp of latest state update. Only present when a status update has occurred. Note: it's a number in a string."
-              example: "1769436711000"
+              type: integer
+              description: "UTC Unix second timestamp of latest state update. Only present when a status update has occurred."
+              example: 1769436711
     SmartHomePairingPayload:
       type: object
       description: Set of information for pairing with a Matter smart home

--- a/applications/services/web_server/resources/apps_assets/web_server/www/openapi.yaml
+++ b/applications/services/web_server/resources/apps_assets/web_server/www/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: BUSY Bar HTTP API
   description: HTTP API for BUSY Bar web server
-  version: 16.0.0
+  version: 17.0.0
   contact:
     name: tbd
 

--- a/tests/clients/api/matter.py
+++ b/tests/clients/api/matter.py
@@ -25,7 +25,7 @@ class PairingStatus(BaseModel):
     """Pairing status details."""
 
     value: Literal["never_started", "started", "completed_successfully", "failed"]
-    timestamp: str | None = None
+    timestamp: int | None = None
 
 
 class SmartHomePairingResponse(BaseModel):

--- a/tests/integration/frontend/matter/test_api_matter.py
+++ b/tests/integration/frontend/matter/test_api_matter.py
@@ -24,6 +24,8 @@ class TestSmartHomePairingAPI:
             "completed_successfully",
             "failed",
         ]
+        if response.latest_pairing_status.timestamp is not None:
+            assert isinstance(response.latest_pairing_status.timestamp, int)
 
     @allure.title("POST /api/smart_home/pairing (start)")
     @pytest.mark.api


### PR DESCRIPTION
# What's new

[FW-761] 
- api: matter: use resolution in seconds, not milliseconds

# Verification 

- check that `/api/smart_home/pairing` endpoint data now contains ints, not strings

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-761]: https://flipper.atlassian.net/browse/FW-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ