### PR TITLE
[FW-657] Replaced debug asserts with warning logs

### DIFF
--- a/applications/services/web_server/http_api/api_streaming.c
+++ b/applications/services/web_server/http_api/api_streaming.c
@@ -126,9 +126,13 @@ static inline void
     else if(display_id == GuiDisplayIdBack)
         instance->back_clients_count++;
 
-    furi_assert(
-        (size_t)(instance->front_clients_count + instance->back_clients_count +
-                 instance->idle_clients_count) == StreamClientsList_size(instance->clients));
+    size_t total_clients = instance->front_clients_count + instance->back_clients_count +
+                           instance->idle_clients_count;
+    size_t list_size = StreamClientsList_size(instance->clients);
+    if(total_clients != list_size) {
+        FURI_LOG_W(
+            TAG, "Increment mismatch total_clients = %d, list_size = %d", total_clients, list_size);
+    }
     furi_mutex_release(instance->clients_lock);
 }
 
@@ -139,9 +143,13 @@ static inline void
     else if(display_id == GuiDisplayIdBack)
         instance->back_clients_count--;
 
-    furi_assert(
-        (size_t)(instance->front_clients_count + instance->back_clients_count +
-                 instance->idle_clients_count) == StreamClientsList_size(instance->clients));
+    size_t total_clients = instance->front_clients_count + instance->back_clients_count +
+                           instance->idle_clients_count;
+    size_t list_size = StreamClientsList_size(instance->clients);
+    if(total_clients != list_size) {
+        FURI_LOG_W(
+            TAG, "Decrement mismatch total_clients = %d, list_size = %d", total_clients, list_size);
+    }
 }
 
 static inline void


### PR DESCRIPTION
# What's new

[FW-657] 

- This issue happened when ws connection was established, but remote side didn't send screen type and closed connection instead

# Verification 

- [ Describe how to verify changes ]

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-657]: https://flipper.atlassian.net/browse/FW-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ