### PR TITLE
[FW-742] WiFi DHCP Client hostname

### DIFF
--- a/applications/services/device_name/device_name.h
+++ b/applications/services/device_name/device_name.h
@@ -14,6 +14,8 @@
 
 #include <furi.h>
 
+#include "device_name_common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/applications/services/device_name/device_name_common.h
+++ b/applications/services/device_name/device_name_common.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define DEVICE_NAME_DEFAULT    "BUSY Bar"
+#define DEVICE_NAME_MAX_LENGTH (20U)
+#define DEVICE_NAME_MAX_SIZE   (DEVICE_NAME_MAX_LENGTH + 1U)

--- a/applications/services/device_name/settings/device_name_settings_interface_v1.h
+++ b/applications/services/device_name/settings/device_name_settings_interface_v1.h
@@ -1,10 +1,7 @@
 #pragma once
 
 #include <setting_provider.h>
-
-#define DEVICE_NAME_DEFAULT    "BUSY Bar"
-#define DEVICE_NAME_MAX_LENGTH (20U)
-#define DEVICE_NAME_MAX_SIZE   (DEVICE_NAME_MAX_LENGTH + 1U)
+#include "../device_name_common.h"
 
 typedef enum {
     DeviceNameSettingsV1IdxName,

--- a/applications/services/wifi/wifi.c
+++ b/applications/services/wifi/wifi.c
@@ -4,6 +4,9 @@
 
 #include "wifi_state.h"
 
+#include <device_name/device_name.h>
+#include <device_name/settings/device_name_settings_interface_v1.h>
+
 static void wifi_intercom_rx_callback(const void* data, size_t data_size, void* context) {
     furi_assert(data_size == sizeof(WifiResponse));
     furi_assert(context);
@@ -242,6 +245,22 @@ static void wifi_custom_event_callback(uint32_t events, void* context) {
     }
 }
 
+static void wifi_generate_dhcp_hostname(Wifi* instance) {
+    DeviceName* device_name = furi_record_open(RECORD_DEVICE_NAME);
+    FuriString* device_name_str = furi_string_alloc();
+
+    device_name_get(device_name, device_name_str);
+    instance->dhcp_hostname = furi_string_alloc_set_str(DEVICE_NAME_DEFAULT);
+
+    if(!furi_string_equal_str(device_name_str, DEVICE_NAME_DEFAULT)) {
+        furi_string_cat_printf(
+            instance->dhcp_hostname, " %s", furi_string_get_cstr(device_name_str));
+    }
+
+    furi_string_free(device_name_str);
+    furi_record_close(RECORD_DEVICE_NAME);
+}
+
 static Wifi* wifi_alloc(void) {
     Wifi* instance = malloc(sizeof(Wifi));
 
@@ -251,6 +270,7 @@ static Wifi* wifi_alloc(void) {
     instance->dhcp_semaphore = furi_semaphore_alloc(1, 0);
     instance->state = furi_state_alloc(sizeof(WifiInfo));
     instance->intercom = furi_record_open(RECORD_INTERCOM);
+    wifi_generate_dhcp_hostname(instance);
 
     furi_record_open(RECORD_NETWORK);
 

--- a/applications/services/wifi/wifi.c
+++ b/applications/services/wifi/wifi.c
@@ -5,7 +5,6 @@
 #include "wifi_state.h"
 
 #include <device_name/device_name.h>
-#include <device_name/settings/device_name_settings_interface_v1.h>
 
 static void wifi_intercom_rx_callback(const void* data, size_t data_size, void* context) {
     furi_assert(data_size == sizeof(WifiResponse));

--- a/applications/services/wifi/wifi_i.h
+++ b/applications/services/wifi/wifi_i.h
@@ -52,6 +52,7 @@ struct Wifi {
     Intercom* intercom;
     IntercomChannel* intercom_ch_control;
     IntercomChannel* intercom_ch_data;
+    FuriString* dhcp_hostname;
     struct netif netif;
     WifiMessage api_message;
     WifiRequest request;

--- a/applications/services/wifi/wifi_net.c
+++ b/applications/services/wifi/wifi_net.c
@@ -119,6 +119,8 @@ void wifi_net_init(Wifi* instance, const uint8_t* hw_addr) {
     netif->hwaddr_len = ETH_HWADDR_LEN;
     memcpy(netif->hwaddr, hw_addr, ETH_HWADDR_LEN);
 
+    netif->hostname = furi_string_get_cstr(instance->dhcp_hostname);
+
     UNLOCK_TCPIP_CORE();
 
     instance->intercom_ch_data = intercom_channel_open(

--- a/targets/f21/lwip/lwipopts.h
+++ b/targets/f21/lwip/lwipopts.h
@@ -154,7 +154,7 @@
     LWIP_MEM_ALIGN_SIZE(TCP_MSS + 40 + PBUF_LINK_ENCAPSULATION_HLEN + PBUF_LINK_HLEN)
 #define LWIP_PBUF_REF_T                    u8_t
 #define LWIP_SINGLE_NETIF                  0
-#define LWIP_NETIF_HOSTNAME                0
+#define LWIP_NETIF_HOSTNAME                1
 #define LWIP_NETIF_API                     0 // TODO: enable?
 #define LWIP_NETIF_STATUS_CALLBACK         1
 #define LWIP_NETIF_EXT_STATUS_CALLBACK     0


### PR DESCRIPTION
# What's new

- Generate correct hostname for WiFi DHCP client

# Verification 

- Set custom name. Connect to WiFi. The hostname must be "BUSY Bar <custom_name>"
- Delete settings in device name service. Reboot device and connect to WiFi. The hostname must be "BUSY Bar"

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
