### PR TITLE
[FW-783] Close websocket with a message if no available slots

### DIFF
--- a/applications/services/state_publisher/state_publisher.c
+++ b/applications/services/state_publisher/state_publisher.c
@@ -249,6 +249,7 @@ static bool send_out_for_transport(void* context, bool heartbeat) {
             .timestamp = time_get_timestamp_ms(),
             .updates_count = count,
             .updates = raw_updates,
+            .has_error = false,
         };
 
         SharedByteArray_t data;
@@ -271,6 +272,27 @@ static bool send_out_for_transport(void* context, bool heartbeat) {
     }
     StateUpdateArray_clear(updates);
     return sent;
+}
+
+void state_publisher_serialize_error_message(
+    ByteArray_t* buf,
+    BSB_Error_Severity severity,
+    BSB_Error_Cause cause) {
+    BSB_State_State state = {
+        .timestamp = time_get_timestamp_ms(),
+        .updates_count = 0,
+        .updates = NULL,
+        .has_error = true,
+        .error = {
+            .cause = cause,
+            .severity = severity,
+        }};
+    pb_ostream_t stream = ostream_with_buffer(buf);
+    bool result = pb_encode(&stream, BSB_State_State_fields, &state);
+    if(!result) {
+        FURI_LOG_E(TAG, "cannot encode");
+        ByteArray_reset(*buf);
+    }
 }
 
 static uint32_t send_out(StatePublisher* instance, StreamFlag flags, bool heartbeat) {

--- a/applications/services/state_publisher/state_publisher.c
+++ b/applications/services/state_publisher/state_publisher.c
@@ -274,7 +274,7 @@ static bool send_out_for_transport(void* context, bool heartbeat) {
     return sent;
 }
 
-void state_publisher_serialize_error_message(
+bool state_publisher_serialize_error_message(
     ByteArray_t* buf,
     BSB_Error_Severity severity,
     BSB_Error_Cause cause) {
@@ -293,6 +293,7 @@ void state_publisher_serialize_error_message(
         FURI_LOG_E(TAG, "cannot encode");
         ByteArray_reset(*buf);
     }
+    return result;
 }
 
 static uint32_t send_out(StatePublisher* instance, StreamFlag flags, bool heartbeat) {

--- a/applications/services/state_publisher/state_publisher.h
+++ b/applications/services/state_publisher/state_publisher.h
@@ -73,8 +73,10 @@ void state_publisher_set_rate_limit(
 
 /**
  * Produce serialized BSB_State.State message with set error field
+ *
+ * @return true on success
  */
-void state_publisher_serialize_error_message(
+bool state_publisher_serialize_error_message(
     ByteArray_t* buf,
     BSB_Error_Severity severity,
     BSB_Error_Cause cause);

--- a/applications/services/state_publisher/state_publisher.h
+++ b/applications/services/state_publisher/state_publisher.h
@@ -11,6 +11,7 @@
 #include <matter/matter.h>
 #include <mlib/m-array.h>
 #include <mlib/m-shared.h>
+#include <error.pb.h>
 
 #include "rate_limiter.h"
 
@@ -69,6 +70,14 @@ void state_publisher_set_rate_limit(
     StatePublisher* instance,
     StatePublisherTransportHandle transport,
     RateLimiterLimit rate_limit);
+
+/**
+ * Produce serialized BSB_State.State message with set error field
+ */
+void state_publisher_serialize_error_message(
+    ByteArray_t* buf,
+    BSB_Error_Severity severity,
+    BSB_Error_Cause cause);
 
 #ifdef __cplusplus
 }

--- a/applications/services/web_server/http_api/api_status_streaming.c
+++ b/applications/services/web_server/http_api/api_status_streaming.c
@@ -265,14 +265,15 @@ static void client_on_message(struct mg_connection* conn, struct mg_ws_message* 
     }
 }
 
-static void client_connection_on_born_dead(struct mg_connection* conn) {
+static void client_connection_on_open_rejected(struct mg_connection* conn) {
     ByteArray_t buf;
     ByteArray_init(buf);
-    state_publisher_serialize_error_message(
-        &buf, BSB_Error_Severity_FATAL, BSB_Error_Cause_RESOURCE_LIMIT);
-    const void* data = ByteArray_cget(buf, 0);
-    size_t len = ByteArray_size(buf);
-    mg_ws_send(conn, data, len, WEBSOCKET_OP_BINARY);
+    if(state_publisher_serialize_error_message(
+           &buf, BSB_Error_Severity_FATAL, BSB_Error_Cause_RESOURCE_LIMIT)) {
+        const void* data = ByteArray_cget(buf, 0);
+        size_t len = ByteArray_size(buf);
+        mg_ws_send(conn, data, len, WEBSOCKET_OP_BINARY);
+    }
     ByteArray_clear(buf);
     conn->is_draining = 1;
 }
@@ -295,7 +296,7 @@ bool http_api_status_ws_callback(
     if(!client) {
         FURI_LOG_W(TAG, "No available websockets");
         ConnectionContext* conn_ctx = (void*)conn->data;
-        conn_ctx->ws.on_open = client_connection_on_born_dead;
+        conn_ctx->ws.on_open = client_connection_on_open_rejected;
     } else {
         ConnectionContext* conn_ctx = (void*)conn->data;
         conn_ctx->ws.on_open = client_connection_open;

--- a/applications/services/web_server/http_api/api_status_streaming.c
+++ b/applications/services/web_server/http_api/api_status_streaming.c
@@ -210,7 +210,7 @@ static void client_send_frame(struct mg_connection* conn, void* data, size_t len
         client_set_state(client, ClientStateWaitingPong);
         mg_ws_send(conn, data, len, WEBSOCKET_OP_PING);
     } else if(client->state == ClientStateInvalid) {
-        mg_close_conn(conn);
+        conn->is_draining = 1;
     }
 }
 
@@ -265,6 +265,18 @@ static void client_on_message(struct mg_connection* conn, struct mg_ws_message* 
     }
 }
 
+static void client_connection_on_born_dead(struct mg_connection* conn) {
+    ByteArray_t buf;
+    ByteArray_init(buf);
+    state_publisher_serialize_error_message(
+        &buf, BSB_Error_Severity_FATAL, BSB_Error_Cause_RESOURCE_LIMIT);
+    const void* data = ByteArray_cget(buf, 0);
+    size_t len = ByteArray_size(buf);
+    mg_ws_send(conn, data, len, WEBSOCKET_OP_BINARY);
+    ByteArray_clear(buf);
+    conn->is_draining = 1;
+}
+
 bool http_api_status_ws_callback(
     FuriString* path,
     HttpMethod method,
@@ -281,16 +293,17 @@ bool http_api_status_ws_callback(
     Client* client = client_alloc(instance, conn);
 
     if(!client) {
-        MG_REPLY_ERROR(conn, 400, "Exceeded max clients count");
-        return true;
+        FURI_LOG_W(TAG, "No available websockets");
+        ConnectionContext* conn_ctx = (void*)conn->data;
+        conn_ctx->ws.on_open = client_connection_on_born_dead;
+    } else {
+        ConnectionContext* conn_ctx = (void*)conn->data;
+        conn_ctx->ws.on_open = client_connection_open;
+        conn_ctx->on_close = client_connection_close;
+        conn_ctx->ws.on_message = client_on_message;
+        conn_ctx->on_wakeup = client_send_frame;
+        conn_ctx->context = client;
     }
-
-    ConnectionContext* conn_ctx = (void*)conn->data;
-    conn_ctx->ws.on_open = client_connection_open;
-    conn_ctx->on_close = client_connection_close;
-    conn_ctx->ws.on_message = client_on_message;
-    conn_ctx->on_wakeup = client_send_frame;
-    conn_ctx->context = client;
 
     mg_ws_upgrade(conn, msg, NULL);
 

--- a/applications/services/web_server/http_api/api_streaming.c
+++ b/applications/services/web_server/http_api/api_streaming.c
@@ -292,7 +292,7 @@ static void api_streaming_client_send_frame(struct mg_connection* conn, void* da
         api_streaming_client_set_state(client, StreamClientStateWaitingPong);
         mg_ws_send(conn, data, len, WEBSOCKET_OP_PING);
     } else if(client->state == StreamClientStateInvalid) {
-        mg_close_conn(conn);
+        conn->is_draining = 1;
     }
 }
 


### PR DESCRIPTION
# What's new

- `/api/status/ws` websocket sends a State message with `error` field set if no websockets available

# Verification 

- Open 4 websockets
- Open 5th websocket, observe the output

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
