### PR TITLE
[FW-671] Missing Switch Transition Animations

### DIFF
--- a/applications/services/gui/modules/anim_player.c
+++ b/applications/services/gui/modules/anim_player.c
@@ -21,6 +21,8 @@ static void anim_player_timer_cb(lv_timer_t* timer) {
     AnimFileFrameInfo info = anim_file_frame(instance->file);
     lv_obj_invalidate(instance->canvas);
 
+    if(info.flags & AnimFileFrameFlagFinished) lv_timer_pause(instance->timer);
+
     if(instance->frame_cb) instance->frame_cb(instance, &info, instance->frame_cb_context);
 }
 

--- a/lib/anim_file/components/anim_file_seq.c
+++ b/lib/anim_file/components/anim_file_seq.c
@@ -29,7 +29,14 @@ AnimFileFrameFlag anim_file_seq_load_current_frame(AnimFile* anim) {
         if(!seq->remaining_duration) return AnimFileFrameFlagNoChange;
 
         if(seq->disp_frame_idx == seq->last_disp_frame) {
-            if(!anim_file_start_last_frame(anim)) return AnimFileFrameFlagNoChange;
+            if(!anim_file_start_last_frame(anim)) {
+                AnimFileFrameFlag flags = seq->flags;
+
+                seq->flags = AnimFileFrameFlagNone;
+                seq->remaining_duration = 0;
+
+                return flags;
+            }
         }
 
         seq->disp_frame_idx++;


### PR DESCRIPTION
> [!NOTE]
> Jira [FW-671](https://flipper.atlassian.net/browse/FW-671)

# What's new

- anim player final state processing fix (for non-looping animations)

# Verification 

- animations are working correctly
- [this ](https://www.figma.com/design/CGfSagPcxKchQOTwaV1Uga/-BUSY-Bar--Interfaces?node-id=10849-39008&m=dev) animations are displayed on all transitions (previously they were displayed on some of them only)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-671]: https://flipper.atlassian.net/browse/FW-671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ