### PR TITLE
[FW-811] Throttle websocket stream when overburdened

### DIFF
--- a/applications/services/state_publisher/rate_limiter.c
+++ b/applications/services/state_publisher/rate_limiter.c
@@ -5,11 +5,18 @@ RateLimiter rate_limiter_init(RateLimiterLimit limit) {
         .limit = limit,
         .last_tick_ms = 0,
         .sent_since_last_tick = 0,
+        .paused = false,
     };
 }
 
 void rate_limiter_set_limit(RateLimiter* instance, RateLimiterLimit limit) {
     instance->limit = limit;
+}
+
+bool rate_limiter_set_paused(RateLimiter* instance, bool paused) {
+    bool was_paused = instance->paused;
+    instance->paused = paused;
+    return was_paused;
 }
 
 uint32_t rate_limiter_send_if_allowed(
@@ -18,6 +25,10 @@ uint32_t rate_limiter_send_if_allowed(
     RateLimiterSendCallback cb,
     void* cb_context,
     bool heartbeat) {
+    if(instance->paused) {
+        return UINT32_MAX;
+    }
+
     bool send = false;
     if(now - instance->last_tick_ms >= instance->limit.period_ms) {
         send = true;

--- a/applications/services/state_publisher/rate_limiter.h
+++ b/applications/services/state_publisher/rate_limiter.h
@@ -17,6 +17,7 @@ typedef struct RateLimiter {
     RateLimiterLimit limit;
     time_t last_tick_ms;
     uint32_t sent_since_last_tick;
+    bool paused;
 } RateLimiter;
 
 typedef bool (*RateLimiterSendCallback)(void* context, bool heartbeat);
@@ -24,6 +25,13 @@ typedef bool (*RateLimiterSendCallback)(void* context, bool heartbeat);
 RateLimiter rate_limiter_init(RateLimiterLimit limit);
 
 void rate_limiter_set_limit(RateLimiter* instance, RateLimiterLimit limit);
+
+/**
+ * Pause or resume.
+ *
+ * @return previous paused state
+ */
+bool rate_limiter_set_paused(RateLimiter* instance, bool paused);
 
 uint32_t rate_limiter_send_if_allowed(
     RateLimiter* instance,

--- a/applications/services/state_publisher/state_publisher.c
+++ b/applications/services/state_publisher/state_publisher.c
@@ -79,7 +79,7 @@ static StatePublisher* state_publisher_alloc(void) {
     instance->screen_streamer_front = screen_streamer_alloc(
         GuiDisplayIdFront, instance->gui, screen_streamer_callback, instance);
 
-    instance->transports_mutex = furi_mutex_alloc(FuriMutexTypeNormal);
+    instance->transports_mutex = furi_mutex_alloc(FuriMutexTypeRecursive);
     for(uint32_t i = 0; i != COUNT_OF(instance->transports); ++i) {
         Transport* t = instance->transports + i;
         t->valid = false;
@@ -162,6 +162,22 @@ void state_publisher_set_rate_limit(
     furi_mutex_acquire(instance->transports_mutex, FuriWaitForever);
     rate_limiter_set_limit(&instance->transports[transport].limiter, rate_limit);
     furi_mutex_release(instance->transports_mutex);
+}
+
+void state_publisher_set_paused(
+    StatePublisher* instance,
+    StatePublisherTransportHandle transport,
+    bool paused) {
+    furi_mutex_acquire(instance->transports_mutex, FuriWaitForever);
+    bool was_paused = rate_limiter_set_paused(&instance->transports[transport].limiter, paused);
+    furi_mutex_release(instance->transports_mutex);
+
+    if(!paused && was_paused) {
+        Message msg = {
+            .type = MessageTypeTransportResumed,
+        };
+        state_publisher_send_message(instance, &msg);
+    }
 }
 
 int32_t state_publisher_srv(void* p) {
@@ -325,6 +341,10 @@ static bool handle_publish_update(StatePublisher* instance, const Message* messa
             for(size_t i = 0; i != MAX_TRANSPORTS; ++i) {
                 Transport* t = instance->transports + i;
                 if(t->valid && (t->flags & flags)) {
+                    if(StateUpdateArray_size(t->seq_updates) >= MAX_SEQ_UPDATES) {
+                        FURI_LOG_W(TAG, "Sequential updates full, dropping");
+                        StateUpdateArray_reset(t->seq_updates);
+                    }
                     StateUpdateArray_push_back(t->seq_updates, shared_update);
                 }
             }
@@ -362,6 +382,13 @@ static void rate_limiter_timer_callback(void* context) {
     uint32_t sleep_time_ms = send_out(instance, StreamFlagAll, false);
 
     furi_event_loop_timer_start(instance->rate_limiter_timer, ms_to_ticks(sleep_time_ms));
+}
+
+static bool handle_transport_resumed(StatePublisher* instance, const Message* message) {
+    furi_assert(message->type == MessageTypeTransportResumed);
+
+    send_out(instance, StreamFlagAll, false);
+    return true;
 }
 
 static bool handle_power_event(StatePublisher* instance, const Message* message) {
@@ -408,6 +435,7 @@ static bool handle_ble(StatePublisher* instance, const Message* message) {
 
 static const MessageHandler message_handlers[] = {
     [MessageTypePublishUpdate] = handle_publish_update,
+    [MessageTypeTransportResumed] = handle_transport_resumed,
     [MessageTypePowerEvent] = handle_power_event,
     [MessageTypeAudioEvent] = handle_audio_event,
     [MessageTypeMatterEvent] = handle_matter_event,

--- a/applications/services/state_publisher/state_publisher.h
+++ b/applications/services/state_publisher/state_publisher.h
@@ -71,6 +71,11 @@ void state_publisher_set_rate_limit(
     StatePublisherTransportHandle transport,
     RateLimiterLimit rate_limit);
 
+void state_publisher_set_paused(
+    StatePublisher* instance,
+    StatePublisherTransportHandle transport,
+    bool paused);
+
 /**
  * Produce serialized BSB_State.State message with set error field
  *

--- a/applications/services/state_publisher/state_publisher_i.h
+++ b/applications/services/state_publisher/state_publisher_i.h
@@ -35,6 +35,8 @@ void state_publisher_free_state_update(BSB_State_StateUpdate* update);
 SHARED_PTR_DEF(SharedStateUpdate, BSB_State_StateUpdate, STATE_UPDATE_OPLIST);
 ARRAY_DEF(StateUpdateArray, SharedStateUpdate_t, SHARED_PTR_OPLIST(SharedStateUpdate));
 
+#define MAX_SEQ_UPDATES 128
+
 typedef struct Transport {
     bool valid;
 
@@ -76,6 +78,7 @@ struct StatePublisher {
 
 typedef enum {
     MessageTypePublishUpdate,
+    MessageTypeTransportResumed,
     MessageTypePowerEvent,
     MessageTypeAudioEvent,
     MessageTypeMatterEvent,

--- a/applications/services/web_server/http_api/api_status_streaming.c
+++ b/applications/services/web_server/http_api/api_status_streaming.c
@@ -12,8 +12,10 @@
 #define STREAM_LOG_W(...)
 #endif
 
-#define MAX_CLIENTS_COUNT          (4)
-#define MAX_PUBLISH_MESSAGES_COUNT (8)
+#define MAX_CLIENTS_COUNT                 (4)
+#define MAX_PUBLISH_MESSAGES_COUNT        (8)
+#define PUBLISH_MESSAGES_PAUSE_THRESHOLD  (6)
+#define PUBLISH_MESSAGES_RESUME_THRESHOLD (2)
 
 #define FRAME_QUEUE_TIMEOUT          (10)
 #define FRAME_INTERVAL_MS            (100)
@@ -87,7 +89,6 @@ static void client_heartbeat_timer_callback(void* ctx) {
     case ClientStateInvalid:
     case ClientStateHandshake:
         // should never happen
-        furi_assert(false);
         break;
     }
 }
@@ -100,6 +101,12 @@ static void client_publish_callback(const SharedByteArray_t data, void* context)
     DataMessage msg;
     SharedByteArray_init_set(msg.data, data);
     FuriStatus error = furi_message_queue_put(client->active.queue, &msg, FRAME_QUEUE_TIMEOUT);
+    size_t count = furi_message_queue_get_count(client->active.queue);
+    if(count >= PUBLISH_MESSAGES_PAUSE_THRESHOLD) {
+        STREAM_LOG_W("Queue full, throttling");
+        state_publisher_set_paused(
+            client->parent->state_publisher, client->active.transport_handle, true);
+    }
     if(error != FuriStatusOk) {
         FURI_LOG_E(TAG, "Queue overflow, update skipped (%u)", error);
         SharedByteArray_clear(msg.data);
@@ -207,6 +214,11 @@ static void client_send_frame(struct mg_connection* conn, void* data, size_t len
                 conn, ByteArray_cget(*array, 0), ByteArray_size(*array), WEBSOCKET_OP_BINARY);
             SharedByteArray_clear(msg.data);
         }
+        if(furi_message_queue_get_count(client->active.queue) <=
+           PUBLISH_MESSAGES_RESUME_THRESHOLD) {
+            state_publisher_set_paused(
+                client->parent->state_publisher, client->active.transport_handle, false);
+        }
     } else if(client->state == ClientStateRequestingPing) {
         STREAM_LOG_D("Requesting ping");
         client_set_state(client, ClientStateWaitingPong);
@@ -255,6 +267,8 @@ static void client_on_message(struct mg_connection* conn, struct mg_ws_message* 
         STREAM_LOG_D("PONG");
         client_set_state(client, ClientStateActive);
         client->active.heartbeat_timer->expire = mg_now() + CLIENT_HEARTBEAT_INTERVAL_MS;
+        // Make sure to wake up and send collected messages
+        mg_wakeup(web_srv_get_mgr(), client->conn->id, NULL, 0);
     } else if(WEBSOCKET_TEXT(ws_msg->flags)) {
         STREAM_LOG_D("MSG");
 

--- a/applications/services/web_server/http_api/api_status_streaming.c
+++ b/applications/services/web_server/http_api/api_status_streaming.c
@@ -214,8 +214,9 @@ static void client_send_frame(struct mg_connection* conn, void* data, size_t len
                 conn, ByteArray_cget(*array, 0), ByteArray_size(*array), WEBSOCKET_OP_BINARY);
             SharedByteArray_clear(msg.data);
         }
-        if(furi_message_queue_get_count(client->active.queue) <=
-           PUBLISH_MESSAGES_RESUME_THRESHOLD) {
+        if(client->active.transport_handle != STATE_PUBLISHER_TRANSPORT_HANDLE_INVALID &&
+           furi_message_queue_get_count(client->active.queue) <=
+               PUBLISH_MESSAGES_RESUME_THRESHOLD) {
             state_publisher_set_paused(
                 client->parent->state_publisher, client->active.transport_handle, false);
         }
@@ -245,6 +246,7 @@ static void client_set_enabled(Client* client, bool enabled) {
     } else if(was_enabled && !enabled) {
         state_publisher_del_transport(
             client->parent->state_publisher, client->active.transport_handle);
+        client->active.transport_handle = STATE_PUBLISHER_TRANSPORT_HANDLE_INVALID;
     }
 }
 


### PR DESCRIPTION
# What's new

- Add state publisher throttle: suspend packets production
- Limit sequential updates to prevent memory leak if throttled forever
- If websocket can't manage to send data, throttle

# Verification 

- Test if the original intercom-related crash doesn't happen anymore

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
