### PR TITLE
[FW-813] Fix Trigger smart home option

### DIFF
--- a/applications/services/busy_timer/busy_timer_smart_home.c
+++ b/applications/services/busy_timer/busy_timer_smart_home.c
@@ -64,8 +64,7 @@ static void busy_timer_smart_home_start_app(BusyTimer* instance) {
         busy_timer_apply_profile_settings(instance, TIMER_SMART_HOME_PROFILE_ID);
     }
 
-    BusyTimerSettings* settings = &instance->settings[TIMER_SMART_HOME_PROFILE_ID];
-    BusyAppConfig* app_config = &settings->profile.app_config;
+    BusyAppConfig* app_config = &instance->app_config;
     // NOTE: "Trigger smart home" setting is forced ON only for the current session.
     //       The main profile setting will remain unchanged.
     app_config->is_smart_home_enabled = true;


### PR DESCRIPTION
# What's new

- Fix exiting from the timer when `Trigger smart home` was initially `OFF`

# Verification 

1. Flash the firmware bundle
2. Go to `BUSY -> Setup -> Smart home` and set `Trigger smart home` to `OFF`
3. Set the Matter switch ON (either via a smart home app or `matter -> switch on` in telnet CLI
4. Set the Matter switch OFF (using the same methods as in 3.)
5. The BUSY app should exit by itself (or show the start screen, depending on how the app was started)

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
