### PR TITLE
[FW-823] Fix status lights not going off

### DIFF
--- a/applications/services/busy_timer/busy_timer.c
+++ b/applications/services/busy_timer/busy_timer.c
@@ -555,18 +555,16 @@ static void busy_timer_apply_snapshot(BusyTimer* instance, const BusyTimerSnapsh
 
     busy_timer_stop_timer(instance);
 
-    const BusyTimerSnapshotType type = snapshot->type;
-
-    if(type == BusyTimerSnapshotTypeNotStarted) {
-        instance->state = BusyTimerStateIdle;
-        busy_timer_exit_app();
-        return;
-    }
-
     BusyTimerMode new_mode;
     BusyTimerState new_state;
 
-    if(type == BusyTimerSnapshotTypeInfinite) {
+    const BusyTimerSnapshotType type = snapshot->type;
+
+    if(type == BusyTimerSnapshotTypeNotStarted) {
+        new_mode = BusyTimerModeMax;
+        new_state = BusyTimerStateIdle;
+
+    } else if(type == BusyTimerSnapshotTypeInfinite) {
         new_mode = BusyTimerModeInfinite;
         new_state = BusyTimerStateWork;
 
@@ -604,15 +602,20 @@ static void busy_timer_apply_snapshot(BusyTimer* instance, const BusyTimerSnapsh
     strcpy(instance->card_id, snapshot->common.card_id);
     instance->app_config = snapshot->app_config;
 
-    if(!snapshot->common.is_paused) {
-        busy_timer_start_timer(instance);
+    if(new_state != BusyTimerStateIdle) {
+        if(!snapshot->common.is_paused) {
+            busy_timer_start_timer(instance);
+        }
+        // Override prev_tick_timestamp_ms value set by busy_timer_start_timer() call above
+        instance->prev_tick_timestamp_ms = snapshot_timestamp_ms;
+
+        busy_timer_start_app(&snapshot->app_config);
+        busy_timer_notify_initial_state(instance);
+
+    } else {
+        busy_timer_notify_state_changed(instance);
+        busy_timer_exit_app();
     }
-
-    instance->prev_tick_timestamp_ms = snapshot_timestamp_ms;
-
-    busy_timer_start_app(&snapshot->app_config);
-
-    busy_timer_notify_initial_state(instance);
 
     busy_timer_schedule_publish_last_known_snapshot(instance);
 }

--- a/applications/services/busy_timer/busy_timer_smart_home.c
+++ b/applications/services/busy_timer/busy_timer_smart_home.c
@@ -18,7 +18,9 @@ static void
                                                              MatterSwitchStateOff;
     } else if(event_type == BusyTimerEventTypePaused) {
         const bool is_paused = event->paused.is_paused;
-        switch_state = is_paused ? MatterSwitchStateOff : MatterSwitchStateOn;
+        if(instance->state == BusyTimerStateWork) {
+            switch_state = is_paused ? MatterSwitchStateOff : MatterSwitchStateOn;
+        }
 
     } else if(event_type == BusyTimerEventTypeIntervalEnded) {
         switch_state = MatterSwitchStateOff;


### PR DESCRIPTION
# What's new

- Fix Status Lights not going off when exiting from a timer via a snapshot
- Fix Matter switch erroneously becoming on when skipping intervals via a snapshot

# Verification 

1. Flash the firmware bundle
2. Start monitoring the Matter switch state via an app or by running `matter` in the telnet CLI
3. Start a BUSY timer session via an app in Interval mode
4. In the app, press Pause, then press Skip to rest. The Matter switch should become OFF.
5. Exit from the session via the app. The status lights should go off.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
