### PR TITLE
[FW-828] Change `/api/update/changelog` Error Mesage On Unavailability

### DIFF
--- a/applications/services/web_server/http_api/api_update.c
+++ b/applications/services/web_server/http_api/api_update.c
@@ -461,7 +461,7 @@ static bool api_update_changelog_callback(
         FuriString* check_version = furi_string_alloc();
         do {
             if(check_state.result != UpdaterCheckResultAvailable) {
-                error_text = "Update not available";
+                error_text = "Changelog not available";
                 break;
             }
 


### PR DESCRIPTION
> [!NOTE]
> * [**FW-828**](https://flipper.atlassian.net/browse/FW-828)

# What's new

- `/api/update/changelog` now returns `Changelog not available` instead of `Update not available` on unavailability

# Verification 

*see pervious section*

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
