### PR TITLE
[FW-827] More ways to reset hello screen

### DIFF
--- a/applications/main/power_on/power_on.c
+++ b/applications/main/power_on/power_on.c
@@ -49,9 +49,20 @@ static bool power_on_input_callback(const InputEvent* event, void* context) {
 
     bool consumed = false;
     if(event->type == InputTypeShort) {
-        if(event->key == InputKeyStart)
+        switch(event->key) {
+        case InputKeyStart:
+        case InputKeyOk:
+        case InputKeyBusy:
+        case InputKeyCustom:
+        case InputKeyOff:
+        case InputKeyApps:
+        case InputKeySettings:
             furi_thread_flags_set(instance->thread, PowerOnAppThreadFlagExitToMenu);
-        consumed = true;
+            consumed = true;
+            break;
+        default:
+            break;
+        }
     } else if(event->type == InputTypeLong) {
         if(event->key == InputKeyBack)
             furi_thread_flags_set(instance->thread, PowerOnAppThreadFlagExitToTransportMode);


### PR DESCRIPTION
# What's new
[FW-827]
- Reset hello screen with switch and OK button

# Verification 

- see task description

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-827]: https://flipper.atlassian.net/browse/FW-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ