### PR TITLE
[FW-519] Proper MPU Configuration For BKPSRAM Region

### DIFF
--- a/targets/f21/furi_hal/furi_hal.c
+++ b/targets/f21/furi_hal/furi_hal.c
@@ -6,6 +6,7 @@
 
 void furi_hal_init_early(void) {
     furi_hal_cortex_init_early();
+    furi_hal_mpu_init_early();
     furi_hal_clock_init_early();
     furi_hal_bus_init_early();
     furi_hal_dma_init_early();
@@ -28,7 +29,6 @@ void furi_hal_deinit_early(void) {
 }
 
 void furi_hal_init(void) {
-    furi_hal_mpu_init();
     furi_hal_clock_init();
     furi_hal_serial_control_init();
     furi_hal_nvm_init();

--- a/targets/f21/furi_hal/furi_hal_mpu.c
+++ b/targets/f21/furi_hal/furi_hal_mpu.c
@@ -1,6 +1,8 @@
-#include <core/check.h>
-#include <core/log.h>
-#include <furi_hal_mpu.h>
+#include "furi_hal_mpu.h"
+
+#include <furi.h>
+
+#include <stm32u5_linker.h>
 #include <stm32u5xx_ll_cortex.h>
 
 #define TAG "MPU"
@@ -14,6 +16,9 @@
 #define FURI_HAL_MPU_NULL_REGION_ADDRESS (0x00000000)
 #define FURI_HAL_MPU_NULL_REGION_SIZE    (1024 * 1024)
 
+#define FURI_HAL_MPU_BKPSRAM_REGION_ADDRESS ((uintptr_t) & __bkp_start__)
+#define FURI_HAL_MPU_BKPSRAM_REGION_SIZE    ((uintptr_t) & __bkp_size__)
+
 static_assert(FURI_HAL_MPU_IS_VALID_ADDRESS(FURI_HAL_MPU_NULL_REGION_ADDRESS));
 static_assert(FURI_HAL_MPU_IS_VALID_SIZE(FURI_HAL_MPU_NULL_REGION_SIZE));
 
@@ -23,15 +28,21 @@ typedef enum {
 
     /* stack overflow protection */
     FuriHalMpuRegionStack = LL_MPU_REGION_NUMBER1,
+
+    /* bkpsram, allows unaligned access */
+    FuriHalMpuRegionBkpSram = LL_MPU_REGION_NUMBER2,
 } FuriHalMpuRegion;
 
 typedef enum {
     /* null pointer dereference protection */
-    FuriHalMpuAttributesIndexNull = LL_MPU_ATTRIBUTES_NUMBER0,
+    FuriHalMpuAttributesIdxNull = LL_MPU_ATTRIBUTES_NUMBER0,
 
     /* stack overflow protection */
-    FuriHalMpuAttributesIndexStack = LL_MPU_ATTRIBUTES_NUMBER1,
-} FuriHalMpuAtt;
+    FuriHalMpuAttributesIdxStack = LL_MPU_ATTRIBUTES_NUMBER1,
+
+    /* bkpsram, allows unaligned access */
+    FuriHalMpuAttributesIdxBkpSram = LL_MPU_ATTRIBUTES_NUMBER2,
+} FuriHalMpuAttributesIdx;
 
 static void furi_hal_mpu_enable(void) {
     LL_MPU_Enable(LL_MPU_CTRL_PRIVILEGED_DEFAULT);
@@ -55,7 +66,7 @@ static void
     LL_MPU_ConfigRegion(
         region,
         mpu_attributes,
-        FuriHalMpuAttributesIndexNull << MPU_RLAR_AttrIndx_Pos,
+        FuriHalMpuAttributesIdxNull << MPU_RLAR_AttrIndx_Pos,
         address,
         address + size - 1);
     furi_hal_mpu_enable();
@@ -75,7 +86,27 @@ static void
     LL_MPU_ConfigRegion(
         region,
         mpu_attributes,
-        FuriHalMpuAttributesIndexStack << MPU_RLAR_AttrIndx_Pos,
+        FuriHalMpuAttributesIdxStack << MPU_RLAR_AttrIndx_Pos,
+        address,
+        address + size - 1);
+    furi_hal_mpu_enable();
+}
+
+static void
+    furi_hal_mpu_configure_bkpsram(FuriHalMpuRegion region, uint32_t address, uint32_t size) {
+    /* any other bits won't be used by the MPU */
+    furi_assert(FURI_HAL_MPU_IS_VALID_ADDRESS(address));
+    furi_assert(FURI_HAL_MPU_IS_VALID_SIZE(size));
+
+    uint32_t mpu_attributes = LL_MPU_INSTRUCTION_ACCESS_DISABLE | LL_MPU_ACCESS_NOT_SHAREABLE |
+                              LL_MPU_REGION_ALL_RW;
+
+    furi_hal_mpu_disable();
+    /* MPU's actual limit address is postfixed with 0x1F */
+    LL_MPU_ConfigRegion(
+        region,
+        mpu_attributes,
+        FuriHalMpuAttributesIdxBkpSram << MPU_RLAR_AttrIndx_Pos,
         address,
         address + size - 1);
     furi_hal_mpu_enable();
@@ -87,15 +118,16 @@ static void furi_hal_mpu_protect_disable(FuriHalMpuRegion region) {
     furi_hal_mpu_enable();
 }
 
-void furi_hal_mpu_set_stack_protection(uint32_t* stack) {
-    uint32_t _stack = (uint32_t)stack;
+void furi_hal_mpu_set_stack_protection(uint32_t* stack_pointer) {
+    uint32_t stack_address = (uint32_t)stack_pointer;
 
-    if(!FURI_HAL_MPU_IS_VALID_ADDRESS(_stack)) {
+    if(!FURI_HAL_MPU_IS_VALID_ADDRESS(stack_address)) {
         /* align _stack upwards by MPU's granularity value */
-        _stack = (_stack + (1 << MPU_RBAR_BASE_Pos)) & MPU_RBAR_BASE_Msk;
+        stack_address = (stack_address + (1 << MPU_RBAR_BASE_Pos)) & MPU_RBAR_BASE_Msk;
     }
 
-    furi_hal_mpu_protect_read_only(FuriHalMpuRegionStack, _stack, FURI_HAL_MPU_STACK_REGION_SIZE);
+    furi_hal_mpu_protect_read_only(
+        FuriHalMpuRegionStack, stack_address, FURI_HAL_MPU_STACK_REGION_SIZE);
 }
 
 void furi_hal_mpu_reset_stack_protection(void) {
@@ -103,11 +135,20 @@ void furi_hal_mpu_reset_stack_protection(void) {
 }
 
 void furi_hal_mpu_init(void) {
-    LL_MPU_ConfigAttributes(FuriHalMpuAttributesIndexNull, LL_MPU_NO_ALLOCATE);
-    LL_MPU_ConfigAttributes(FuriHalMpuAttributesIndexStack, LL_MPU_R_ALLOCATE);
+    LL_MPU_ConfigAttributes(FuriHalMpuAttributesIdxNull, LL_MPU_DEVICE_NGNRNE);
+    LL_MPU_ConfigAttributes(FuriHalMpuAttributesIdxStack, LL_MPU_DEVICE_NGNRNE);
+
+    /* any normal (not-device) type memory has to have [7:4] bits (i.e. outer) non-zero */
+    LL_MPU_ConfigAttributes(
+        FuriHalMpuAttributesIdxBkpSram, (LL_MPU_NOT_CACHEABLE << 4) | LL_MPU_NOT_CACHEABLE);
 
     furi_hal_mpu_protect_no_access(
         FuriHalMpuRegionNull, FURI_HAL_MPU_NULL_REGION_ADDRESS, FURI_HAL_MPU_NULL_REGION_SIZE);
+
+    furi_hal_mpu_configure_bkpsram(
+        FuriHalMpuRegionBkpSram,
+        FURI_HAL_MPU_BKPSRAM_REGION_ADDRESS,
+        FURI_HAL_MPU_BKPSRAM_REGION_SIZE);
 
     FURI_LOG_I(TAG, "Initialization successful");
 }

--- a/targets/f21/furi_hal/furi_hal_mpu.c
+++ b/targets/f21/furi_hal/furi_hal_mpu.c
@@ -134,7 +134,7 @@ void furi_hal_mpu_reset_stack_protection(void) {
     furi_hal_mpu_protect_disable(FuriHalMpuRegionStack);
 }
 
-void furi_hal_mpu_init(void) {
+void furi_hal_mpu_init_early(void) {
     LL_MPU_ConfigAttributes(FuriHalMpuAttributesIdxNull, LL_MPU_DEVICE_NGNRNE);
     LL_MPU_ConfigAttributes(FuriHalMpuAttributesIdxStack, LL_MPU_DEVICE_NGNRNE);
 

--- a/targets/f21/furi_hal/furi_hal_mpu.c
+++ b/targets/f21/furi_hal/furi_hal_mpu.c
@@ -53,7 +53,11 @@ static void
     furi_hal_mpu_disable();
     /* MPU's actual limit address is postfixed with 0x1F */
     LL_MPU_ConfigRegion(
-        region, mpu_attributes, FuriHalMpuAttributesIndexNull, address, address + size - 1);
+        region,
+        mpu_attributes,
+        FuriHalMpuAttributesIndexNull << MPU_RLAR_AttrIndx_Pos,
+        address,
+        address + size - 1);
     furi_hal_mpu_enable();
 }
 
@@ -69,7 +73,11 @@ static void
     furi_hal_mpu_disable();
     /* MPU's actual limit address is postfixed with 0x1F */
     LL_MPU_ConfigRegion(
-        region, mpu_attributes, FuriHalMpuAttributesIndexStack, address, address + size - 1);
+        region,
+        mpu_attributes,
+        FuriHalMpuAttributesIndexStack << MPU_RLAR_AttrIndx_Pos,
+        address,
+        address + size - 1);
     furi_hal_mpu_enable();
 }
 

--- a/targets/f21/furi_hal/furi_hal_mpu.h
+++ b/targets/f21/furi_hal/furi_hal_mpu.h
@@ -15,7 +15,7 @@ extern "C" {
 /**
  * @brief Initialize memory protection unit
  */
-void furi_hal_mpu_init(void);
+void furi_hal_mpu_init_early(void);
 
 #ifdef __cplusplus
 }

--- a/targets/f21/furi_hal/furi_hal_nvm.c
+++ b/targets/f21/furi_hal/furi_hal_nvm.c
@@ -36,8 +36,6 @@ static bool furi_hal_nvm_is_valid(void) {
     return (header->magic == NVM_MAGIC) && (header->version == NVM_VERSION);
 }
 
-#pragma GCC push_options
-#pragma GCC optimize("O0")
 void furi_hal_nvm_reset(void) {
     memset((void*)nvm_storage, 0, sizeof(NvmData));
 
@@ -51,7 +49,6 @@ void furi_hal_nvm_reset(void) {
 
     nvm_was_reset = true;
 }
-#pragma GCC pop_options
 
 void furi_hal_nvm_set_flag(FuriHalNvmFlag flag) {
     nvm_storage->flags |= (1 << flag);

--- a/targets/f21/src/boot_update.c
+++ b/targets/f21/src/boot_update.c
@@ -28,7 +28,8 @@ typedef struct {
 static MountPoint* mount_point[_VOLUMES];
 
 static void platform_boot_update_sys_init(void) {
-    furi_hal_mpu_init();
+    furi_hal_mpu_init_early();
+
     furi_hal_clock_init();
     furi_hal_interrupt_init();
     furi_hal_sdmmc_init(false);


### PR DESCRIPTION
> [!NOTE]
> * [**FW-519**](https://flipper.atlassian.net/browse/FW-519)

# What's new

- fix few MPU setup issues
- make BKPSRAM region accessible in unaligned manner using MPU

# Verification 

- trigger NVM reset on an optimized firmware, there should be no HardFault

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
