### PR TITLE
[FW-808, FW-826] Status Lights Improvements

### DIFF
--- a/applications/services/status_lights/status_lights_backend.c
+++ b/applications/services/status_lights/status_lights_backend.c
@@ -51,7 +51,7 @@ static uint16_t status_lights_scale_component(uint8_t component, float brightnes
     return (uint16_t)CLAMP(scaled + 0.5f, (float)UINT16_MAX, 0.0f);
 }
 
-static void status_lights_update_output(Color color, float brightness) {
+static void status_lights_set_output(Color color, float brightness) {
     uint16_t r = status_lights_scale_component(color.r, brightness);
     uint16_t g = status_lights_scale_component(color.g, brightness);
     uint16_t b = status_lights_scale_component(color.b, brightness);
@@ -71,7 +71,7 @@ static void status_lights_run_pattern(void* context) {
     instance->preset_api->run(instance->preset_instance, &base_color);
     instance->active_color = base_color;
 
-    status_lights_update_output(base_color, instance->brightness);
+    status_lights_set_output(base_color, instance->brightness);
 }
 
 static void status_lights_message_queue_callback(FuriEventLoopObject* object, void* context) {
@@ -229,7 +229,7 @@ static void
     instance->brightness = status_lights_normalize_brightness(brightness);
 
     if(instance->preset_api) {
-        status_lights_update_output(instance->active_color, instance->brightness);
+        status_lights_set_output(instance->active_color, instance->brightness);
     }
 }
 

--- a/applications/services/status_lights/status_lights_backend.c
+++ b/applications/services/status_lights/status_lights_backend.c
@@ -11,6 +11,7 @@
 
 typedef enum {
     StatusLightsEventSyncDone = 1UL << 0,
+    StatusLightsEventIntercomError = 1UL << 1,
 } StatusLightsEvent;
 
 typedef void (*CommandHandler)(StatusLights* instance, const StatusLightsCommand* command);
@@ -100,11 +101,25 @@ static void status_lights_intercom_state_callback(const void* message, void* con
 
     StatusLights* instance = context;
 
-    const IntercomStatus intercom_status = *(IntercomStatus*)message;
+    StatusLightsEvent event;
+    switch(*(const IntercomStatus*)message) {
+    case IntercomStatusOk:
+        event = StatusLightsEventSyncDone;
+        break;
 
-    if(intercom_status == IntercomStatusOk) {
-        furi_event_loop_set_custom_event(instance->event_loop, StatusLightsEventSyncDone);
+    case IntercomStatusErrorSync:
+    /* fall-through */
+    case IntercomStatusErrorFraming:
+    /* fall-through */
+    case IntercomStatusErrorTimeout:
+        event = StatusLightsEventIntercomError;
+        break;
+
+    default:
+        return;
     }
+
+    furi_event_loop_set_custom_event(instance->event_loop, event);
 }
 
 static void status_lights_event_callback(uint32_t events, void* context) {
@@ -119,6 +134,20 @@ static void status_lights_event_callback(uint32_t events, void* context) {
             instance);
         // Not sending anything to the channel
         UNUSED(intercom_ch);
+    }
+
+    if(events & StatusLightsEventIntercomError) {
+        if(instance->preset_instance) {
+            furi_assert(instance->preset_api);
+
+            instance->preset_api->free(instance->preset_instance);
+            instance->preset_instance = NULL;
+            instance->preset_api = NULL;
+
+            furi_event_loop_timer_stop(instance->timer);
+        }
+
+        furi_hal_pwm_stop();
     }
 }
 

--- a/applications/services/status_lights/status_lights_backend.c
+++ b/applications/services/status_lights/status_lights_backend.c
@@ -34,7 +34,7 @@ static float status_lights_normalize_brightness(uint8_t brightness) {
     return ((1.f / 100.f) * (float)(brightness));
 }
 
-static uint8_t status_lights_scale_component(uint8_t component, float brightness) {
+static uint16_t status_lights_scale_component(uint8_t component, float brightness) {
     if(component == 0) {
         return 0;
     }
@@ -43,19 +43,19 @@ static uint8_t status_lights_scale_component(uint8_t component, float brightness
 
     /* gamma tuned so 5% brightness becomes the first visible step */
     const float gamma = 2.08f;
-    const float pwm_scale = powf(constrained, gamma);
+    const float pwm_scale = powf(constrained, gamma) * (UINT16_MAX / UINT8_MAX);
 
     const float scaled = (float)component * pwm_scale;
 
-    return (uint8_t)CLAMP(scaled + 0.5f, 255.0f, 0.0f);
+    return (uint16_t)CLAMP(scaled + 0.5f, (float)UINT16_MAX, 0.0f);
 }
 
-static void status_lights_apply_brightness(Color* color, float brightness) {
-    furi_assert(color);
+static void status_lights_update_output(Color color, float brightness) {
+    uint16_t r = status_lights_scale_component(color.r, brightness);
+    uint16_t g = status_lights_scale_component(color.g, brightness);
+    uint16_t b = status_lights_scale_component(color.b, brightness);
 
-    color->r = status_lights_scale_component(color->r, brightness);
-    color->g = status_lights_scale_component(color->g, brightness);
-    color->b = status_lights_scale_component(color->b, brightness);
+    furi_hal_pwm_set_rgb(r, g, b);
 }
 
 static void status_lights_run_pattern(void* context) {
@@ -70,10 +70,7 @@ static void status_lights_run_pattern(void* context) {
     instance->preset_api->run(instance->preset_instance, &base_color);
     instance->active_color = base_color;
 
-    Color scaled_color = base_color;
-    status_lights_apply_brightness(&scaled_color, instance->brightness);
-
-    furi_hal_pwm_set_rgb(scaled_color.r, scaled_color.g, scaled_color.b);
+    status_lights_update_output(base_color, instance->brightness);
 }
 
 static void status_lights_message_queue_callback(FuriEventLoopObject* object, void* context) {
@@ -203,10 +200,7 @@ static void
     instance->brightness = status_lights_normalize_brightness(brightness);
 
     if(instance->preset_api) {
-        Color scaled_color = instance->active_color;
-        status_lights_apply_brightness(&scaled_color, instance->brightness);
-
-        furi_hal_pwm_set_rgb(scaled_color.r, scaled_color.g, scaled_color.b);
+        status_lights_update_output(instance->active_color, instance->brightness);
     }
 }
 

--- a/applications/services/status_lights/status_lights_backend.c
+++ b/applications/services/status_lights/status_lights_backend.c
@@ -42,11 +42,13 @@ static uint16_t status_lights_scale_component(uint8_t component, float brightnes
 
     const float constrained = CLAMP(brightness, 1.0f, 0.0f);
 
-    /* gamma tuned so 5% brightness becomes the first visible step */
-    const float gamma = 2.08f;
+    /* tuned to provide minimal dynamic range for low-value components at 5% brightness */
+    const float gamma = 1.85f;
     const float pwm_scale = powf(constrained, gamma) * (UINT16_MAX / UINT8_MAX);
 
-    const float scaled = (float)component * pwm_scale;
+    /* tuned to make LEDs light up at 1-value components */
+    const float offset = 4.f;
+    const float scaled = (float)component * pwm_scale + offset;
 
     return (uint16_t)CLAMP(scaled + 0.5f, (float)UINT16_MAX, 0.0f);
 }

--- a/targets/f64/furi_hal/furi_hal_pwm.c
+++ b/targets/f64/furi_hal/furi_hal_pwm.c
@@ -221,21 +221,21 @@ void furi_hal_pwm_stop(void) {
     mcpwm_counter_reset(MCPWM, FURI_HAL_PWM_CHANNEL_BLUE);
 }
 
-void furi_hal_pwm_set_rgb(uint8_t red, uint8_t green, uint8_t blue) {
+void furi_hal_pwm_set_rgb(uint16_t red, uint16_t green, uint16_t blue) {
     uint32_t ticks = 0;
 
     // Set the duty cycle for the red channel
-    ticks = (uint32_t)((FURI_HAL_PWM_RATE * red) >> 8);
+    ticks = (uint32_t)((FURI_HAL_PWM_RATE * red) >> 16);
     MCPWM->PWM_DUTYCYCLE_REG_WR_VALUE_b[FURI_HAL_PWM_CHANNEL_RED].PWM_DUTYCYCLE_REG_WR_VALUE_CH =
         ticks;
 
     // Set the duty cycle for the green channel
-    ticks = (uint32_t)((FURI_HAL_PWM_RATE * green) >> 8);
+    ticks = (uint32_t)((FURI_HAL_PWM_RATE * green) >> 16);
     MCPWM->PWM_DUTYCYCLE_REG_WR_VALUE_b[FURI_HAL_PWM_CHANNEL_GREEN].PWM_DUTYCYCLE_REG_WR_VALUE_CH =
         ticks;
 
     // Set the duty cycle for the blue channel
-    ticks = (uint32_t)((FURI_HAL_PWM_RATE * blue) >> 8);
+    ticks = (uint32_t)((FURI_HAL_PWM_RATE * blue) >> 16);
     MCPWM->PWM_DUTYCYCLE_REG_WR_VALUE_b[FURI_HAL_PWM_CHANNEL_BLUE].PWM_DUTYCYCLE_REG_WR_VALUE_CH =
         ticks;
 }

--- a/targets/f64/furi_hal/furi_hal_pwm.h
+++ b/targets/f64/furi_hal/furi_hal_pwm.h
@@ -32,7 +32,7 @@ void furi_hal_pwm_stop(void);
  * @param green Green color
  * @param blue  Blue color
  */
-void furi_hal_pwm_set_rgb(uint8_t red, uint8_t green, uint8_t blue);
+void furi_hal_pwm_set_rgb(uint16_t red, uint16_t green, uint16_t blue);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
> [!NOTE]
> * [**FW-808**](https://flipper.atlassian.net/browse/FW-808) - Status Lights Cancel Current Indication On Intercom Error
> * [**FW-826**](https://flipper.atlassian.net/browse/FW-826) - Status Lights Turning Off Under Low Light Conditions

# What's new

- status lights stop on intercom error
- status lights have wider range of brightness/color change

# Verification 

- run status lights using (e.g. using `status_lights` cli), cause intercom error => status lights turn off

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
