### PR TITLE
[FW-867] Fix crash when scanning for Wifi networks

### DIFF
--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -324,12 +324,12 @@ static void wifi_scan_finished_event_handler(Wifi* instance, const WifiScanFinis
     if(response.status == WifiStatusOk) {
         uint16_t results_count = 0;
 
-        const size_t results_size = sizeof(sl_wifi_extended_scan_result_t) * SCAN_MAX_RESULTS;
-        sl_wifi_extended_scan_result_t* scan_results = malloc(results_size);
+        sl_wifi_extended_scan_result_t* scan_results =
+            malloc(sizeof(sl_wifi_extended_scan_result_t) * SCAN_MAX_RESULTS);
 
         sl_wifi_extended_scan_result_parameters_t params = {
             .scan_results = scan_results,
-            .array_length = results_size,
+            .array_length = SCAN_MAX_RESULTS,
             .result_count = &results_count,
         };
 


### PR DESCRIPTION
# What's new

[FW-867]

- Fix crash when scanning for Wifi networks

# Verification 

1. Flash the firmware bundle
2. Open the web interface
3. Disconnect from a network (if applicable)
4. Press "Select network"
5. Wait several minutes while staying in the network selection screen

The device should not crash.

Additionally, monitor heap state using `top` in `sl_cli`. The "max block" value should always stay lower or equal to max available heap.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix

[FW-867]: https://flipper.atlassian.net/browse/FW-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ