### PR TITLE
[FW-884] Allow to publish to mqtt device topic with active session

### DIFF
--- a/applications/services/mqtt/mqtt_subscription.c
+++ b/applications/services/mqtt/mqtt_subscription.c
@@ -19,8 +19,10 @@ static void mqtt_subscription_free(MqttSubscription* subscription) {
 static bool mqtt_is_valid_scope_for_current_status(Mqtt* instance, MqttScope scope) {
     bool is_valid = false;
 
-    if(instance->status == MqttStatusConnectedLinked && scope == MqttScopeSession) {
-        is_valid = true;
+    if(scope == MqttScopeSession) {
+        if(instance->status == MqttStatusConnectedLinked) {
+            is_valid = true;
+        }
     } else if(scope == MqttScopeDevice) {
         if(instance->status == MqttStatusConnectedLinked ||
            instance->status == MqttStatusConnectedNotLinked) {

--- a/applications/services/mqtt/mqtt_subscription.c
+++ b/applications/services/mqtt/mqtt_subscription.c
@@ -21,8 +21,11 @@ static bool mqtt_is_valid_scope_for_current_status(Mqtt* instance, MqttScope sco
 
     if(instance->status == MqttStatusConnectedLinked && scope == MqttScopeSession) {
         is_valid = true;
-    } else if(instance->status == MqttStatusConnectedNotLinked && scope == MqttScopeDevice) {
-        is_valid = true;
+    } else if(scope == MqttScopeDevice) {
+        if(instance->status == MqttStatusConnectedLinked ||
+           instance->status == MqttStatusConnectedNotLinked) {
+            is_valid = true;
+        }
     }
 
     return is_valid;


### PR DESCRIPTION
# What's new

- If mqtt session exists, busybar can still publish messages to device topic

# Verification 

- Device with active session publishes data to `/device/<serial_number>/up/v1/presence` topic

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
