### PR TITLE
[FW-918] Fix updater crash at 0%

### DIFF
--- a/applications/system/updater/updater_normal.c
+++ b/applications/system/updater/updater_normal.c
@@ -288,15 +288,15 @@ UpdaterStatus updater_internal_do_verify_bundle_sha(Updater* instance, UpdaterMe
             UpdaterStatusOk :
             UpdaterStatusShaMismatch;
 
-    furi_string_free(sha256_calc);
-    furi_string_free(message->as_verify_bundle_sha.tar_path);
-    furi_string_free(message->as_verify_bundle_sha.sha);
-
     if(update_status == UpdaterStatusOk) {
         FURI_LOG_D(TAG, "SHA256 checksum verified successfully");
     } else {
         FURI_LOG_E(TAG, "SHA256 checksum verification failed for %s", tar_path);
     }
+
+    furi_string_free(sha256_calc);
+    furi_string_free(message->as_verify_bundle_sha.tar_path);
+    furi_string_free(message->as_verify_bundle_sha.sha);
 
     return update_status;
 }


### PR DESCRIPTION
# What's new

[FW-918]

- Fix a use-after-free situation that resulted in a crash at 0% progress in the cases where the SHA check was failing

# Verification 

1. Flash the firmware bundle
2. Somehow try updating from a bundle with invalid SHA sum?
3. Ensure that the updater does not crash.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix

[FW-918]: https://flipper.atlassian.net/browse/FW-918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ