### PR TITLE
[FW-919] Fix pairing with Alexa

### DIFF
--- a/lib/matter_glue/platform/bsb/BSBDeviceAttestationCredsProvider.cpp
+++ b/lib/matter_glue/platform/bsb/BSBDeviceAttestationCredsProvider.cpp
@@ -18,25 +18,24 @@ enum {
 
 using namespace DeviceLayer::BSB;
 
-void BSBDACProvider::SetCertificationDeclaration(const void* buffer, size_t size) {
+void BSBDACProvider::SetCertificationDeclaration(const uint8_t* buffer, size_t size) {
     furi_check(buffer);
-    furi_check(!m_cd_buffer);
-    furi_check(!m_cd_size);
+    furi_check(m_cd_buffer == nullptr);
+    furi_check(m_cd_size == 0);
 
-    if(!size) return;
-
-    m_cd_buffer = malloc(size);
-    m_cd_size = size;
-    memcpy(m_cd_buffer, buffer, size);
+    if(size) {
+        m_cd_buffer = static_cast<uint8_t*>(malloc(size));
+        memcpy(m_cd_buffer, buffer, size);
+        m_cd_size = size;
+    }
 }
 
 CHIP_ERROR BSBDACProvider::GetCertificationDeclaration(MutableByteSpan& out_cd_buffer) {
-    if(!m_cd_buffer) return CHIP_ERROR_CERT_NOT_FOUND;
+    if(m_cd_buffer)  {
+        return CopySpanToMutableSpan(ByteSpan{m_cd_buffer, m_cd_size}, out_cd_buffer);
+    }
 
-    size_t to_copy = MIN(m_cd_size, out_cd_buffer.size());
-    memcpy(out_cd_buffer.begin(), m_cd_buffer, to_copy);
-
-    return CHIP_NO_ERROR;
+    return CHIP_ERROR_CERT_NOT_FOUND;
 }
 
 CHIP_ERROR BSBDACProvider::GetFirmwareInformation(MutableByteSpan& out_firmware_info_buffer) {

--- a/lib/matter_glue/platform/bsb/BSBDeviceAttestationCredsProvider.cpp
+++ b/lib/matter_glue/platform/bsb/BSBDeviceAttestationCredsProvider.cpp
@@ -31,7 +31,7 @@ void BSBDACProvider::SetCertificationDeclaration(const uint8_t* buffer, size_t s
 }
 
 CHIP_ERROR BSBDACProvider::GetCertificationDeclaration(MutableByteSpan& out_cd_buffer) {
-    if(m_cd_buffer)  {
+    if(m_cd_buffer) {
         return CopySpanToMutableSpan(ByteSpan{m_cd_buffer, m_cd_size}, out_cd_buffer);
     }
 

--- a/lib/matter_glue/platform/bsb/BSBDeviceAttestationCredsProvider.hpp
+++ b/lib/matter_glue/platform/bsb/BSBDeviceAttestationCredsProvider.hpp
@@ -8,11 +8,11 @@ namespace BSB {
 
 class BSBDACProvider : public DeviceAttestationCredentialsProvider {
 private:
-    void* m_cd_buffer = NULL;
+    uint8_t* m_cd_buffer = nullptr;
     size_t m_cd_size = 0;
 
 public:
-    void SetCertificationDeclaration(const void* buffer, size_t size);
+    void SetCertificationDeclaration(const uint8_t* buffer, size_t size);
     CHIP_ERROR GetCertificationDeclaration(MutableByteSpan& out_cd_buffer) override;
     CHIP_ERROR GetFirmwareInformation(MutableByteSpan& out_firmware_info_buffer) override;
     CHIP_ERROR GetDeviceAttestationCert(MutableByteSpan& out_dac_buffer) override;


### PR DESCRIPTION
# What's new

[FW-919]

- Fix incorrect buffer size calculation that could cause failure pairing with Amazon Echo devices

# Verification 

1. Install the firmware bundle.
2. Ensure that the device pairs to an Amazon hub via Matter

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-919]: https://flipper.atlassian.net/browse/FW-919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ