### PR TITLE
[FW-929] Fix connection to passwordless networks

### DIFF
--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -196,7 +196,7 @@ static sl_status_t wifi_connect_request_handler(
             break;
         }
 
-        if(credentials->security_mode != WifiSecurityModeOpen) {
+        if(security_mode != WifiSecurityModeOpen) {
             status = sl_net_set_credential(
                 wifi_get_credential_id(security_mode),
                 // TODO: Other passphrase types than PSK?

--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -174,13 +174,14 @@ static sl_status_t wifi_connect_request_handler(
 
     do {
         const WifiCredentials* credentials = &request->connect_request.credentials;
+        const WifiSecurityMode security_mode = credentials->security_mode;
 
         // Initialise client profile
         sl_net_wifi_client_profile_t profile = {
             .config =
                 {
-                    .security = wifi_encode_security_mode(credentials->security_mode),
-                    .credential_id = SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID,
+                    .security = wifi_encode_security_mode(security_mode),
+                    .credential_id = wifi_get_credential_id(security_mode),
                 },
         };
 
@@ -197,7 +198,7 @@ static sl_status_t wifi_connect_request_handler(
 
         if(credentials->security_mode != WifiSecurityModeOpen) {
             status = sl_net_set_credential(
-                SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID,
+                wifi_get_credential_id(security_mode),
                 // TODO: Other passphrase types than PSK?
                 SL_NET_WIFI_PSK,
                 credentials->passphrase,

--- a/applications/services/wifi/wifi_backend_util.c
+++ b/applications/services/wifi/wifi_backend_util.c
@@ -107,3 +107,8 @@ void wifi_decode_ssid(char* ssid, const sl_wifi_ssid_t* sl_ssid) {
     strncpy(ssid, (char*)sl_ssid->value, sl_ssid->length);
     ssid[sl_ssid->length] = '\0';
 }
+
+sl_net_credential_id_t wifi_get_credential_id(WifiSecurityMode security_mode) {
+    return (security_mode == WifiSecurityModeOpen) ? SL_NET_NO_CREDENTIAL_ID :
+                                                     SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID;
+}

--- a/applications/services/wifi/wifi_backend_util.h
+++ b/applications/services/wifi/wifi_backend_util.h
@@ -15,3 +15,5 @@ WifiStatus wifi_decode_sl_status(sl_status_t sl_status);
 WifiSecurityMode wifi_decode_security_mode(sl_wifi_security_t sl_security);
 
 void wifi_decode_ssid(char* ssid, const sl_wifi_ssid_t* sl_ssid);
+
+sl_net_credential_id_t wifi_get_credential_id(WifiSecurityMode security_mode);


### PR DESCRIPTION
# What's new

[FW-929]

- Fix connection to passwordless networks

# Verification 

1. Flash the firmware bundle.
2. Ensure that connecting to paswordless (open) wi-fi network works.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-929]: https://flipper.atlassian.net/browse/FW-929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ