### PR TITLE
[FW-927] Update Checker Crash

### DIFF
--- a/applications/services/state_publisher/state_publisher.c
+++ b/applications/services/state_publisher/state_publisher.c
@@ -43,8 +43,8 @@ void state_publisher_send_message(StatePublisher* instance, const Message* messa
         return;
     }
 
-    FuriStatus queue_status =
-        furi_message_queue_put(instance->message_queue, message, MESSAGE_QUEUE_TIMEOUT_MS);
+    FuriStatus queue_status = furi_message_queue_put(
+        instance->message_queue, message, furi_ms_to_ticks(MESSAGE_QUEUE_TIMEOUT_MS));
 
     if(queue_status != FuriStatusOk) {
         FURI_LOG_E(TAG, "Failed to put an item into message queue.");

--- a/applications/services/state_publisher/state_publisher.c
+++ b/applications/services/state_publisher/state_publisher.c
@@ -9,6 +9,7 @@
 #include <time/time.h>
 
 #define MAX_MESSAGES             64
+#define MESSAGE_QUEUE_TIMEOUT_MS 3000
 
 #define HEARTBEAT_INTERVAL_MS 991
 
@@ -39,10 +40,14 @@ static void message_queue_callback(FuriEventLoopObject* object, void* context) {
 void state_publisher_send_message(StatePublisher* instance, const Message* message) {
     if(furi_thread_get_current_id() == instance->main_thread_id) {
         message_handlers[message->type](instance, message);
-    } else {
-        furi_check(
-            furi_message_queue_put(instance->message_queue, message, FuriWaitForever) ==
-            FuriStatusOk);
+        return;
+    }
+
+    FuriStatus queue_status =
+        furi_message_queue_put(instance->message_queue, message, MESSAGE_QUEUE_TIMEOUT_MS);
+
+    if(queue_status != FuriStatusOk) {
+        FURI_LOG_E(TAG, "Failed to put an item into message queue.");
     }
 }
 

--- a/applications/services/state_publisher/state_publisher.c
+++ b/applications/services/state_publisher/state_publisher.c
@@ -8,7 +8,7 @@
 
 #include <time/time.h>
 
-#define MAX_MESSAGES 16
+#define MAX_MESSAGES             64
 
 #define HEARTBEAT_INTERVAL_MS 991
 


### PR DESCRIPTION
> [!NOTE]
> * [**FW-927**](https://flipper.atlassian.net/browse/FW-927)

# What's new

- `state_publisher` message queue size increase: 16 => 64
- `state_publisher` message queue timeout (3s)

# Verification 

- lower risc of crash on wait for `furi state`' that are used by `state_publisher`

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
