### PR TITLE
[FW-931] Include firmware version in update bundles

### DIFF
--- a/scripts/fbt_env_modules/bsbdist/update.scons
+++ b/scripts/fbt_env_modules/bsbdist/update.scons
@@ -18,13 +18,14 @@ sil_env = SIL_ENV
 fw_env = u5_env["FW_ENV"]
 
 # Environment with update bundle builder, configured with common bundle parameters
+_fw_version_json = fw_env.get("FW_VERSION_JSON")
 bundle_env = dist_env.Clone(
     tools=["bsb_update_bundle"],
     BUNDLE_TARGET_HW=u5_env.subst("$TARGET_HW"),
     BUNDLE_STAGE=u5_env["UPD_ENV"]["FW_BIN"][0],
     BUNDLE_DFU=fw_env["FW_DFU"][0],
     BUNDLE_SIL_FW=sil_env["FW_ENV"]["FW_RPS"][0],
-    BUNDLE_VERSION_JSON=fw_env["FW_VERSION_JSON"],
+    **({"BUNDLE_VERSION_JSON": _fw_version_json} if _fw_version_json else {}),
 )
 
 # Common dependencies shared by all bundle variants
@@ -32,7 +33,7 @@ base_deps = [
     u5_env["UPD_ENV"]["FW_BIN"],
     fw_env["FW_DFU"],
     sil_env["FW_ENV"]["FW_RPS"],
-    fw_env["FW_VERSION_JSON"],
+    *([_fw_version_json] if _fw_version_json else []),
 ]
 
 # --- Full update bundle (with resources + radio firmware) ---

--- a/scripts/fbt_env_modules/bsbdist/update.scons
+++ b/scripts/fbt_env_modules/bsbdist/update.scons
@@ -24,6 +24,7 @@ bundle_env = dist_env.Clone(
     BUNDLE_STAGE=u5_env["UPD_ENV"]["FW_BIN"][0],
     BUNDLE_DFU=fw_env["FW_DFU"][0],
     BUNDLE_SIL_FW=sil_env["FW_ENV"]["FW_RPS"][0],
+    BUNDLE_VERSION_JSON=fw_env["FW_VERSION_JSON"],
 )
 
 # Common dependencies shared by all bundle variants
@@ -31,6 +32,7 @@ base_deps = [
     u5_env["UPD_ENV"]["FW_BIN"],
     fw_env["FW_DFU"],
     sil_env["FW_ENV"]["FW_RPS"],
+    fw_env["FW_VERSION_JSON"],
 ]
 
 # --- Full update bundle (with resources + radio firmware) ---

--- a/scripts/fbt_tools/bsb_update_bundle.py
+++ b/scripts/fbt_tools/bsb_update_bundle.py
@@ -24,6 +24,7 @@ def _update_bundle_action(target, source, env):
         ("BUNDLE_RESOURCES", "--resources"),
         ("BUNDLE_BKP_RESOURCES", "--bkp-resources"),
         ("BUNDLE_SECURITY_FLAGS", "--security-flags"),
+        ("BUNDLE_VERSION_JSON", "--version-json"),
     ]:
         val = env.get(env_key)
         if val:

--- a/scripts/update_bundle.py
+++ b/scripts/update_bundle.py
@@ -51,6 +51,13 @@ class Main(App):
         )
         self.parser.add_argument("--dfu", required=False, help="Updater DFU file")
         self.parser.add_argument(
+            "--version-json",
+            required=False,
+            help="Path to firmware version JSON (to embed firmware_version in manifest)",
+            type=str,
+            default=None,
+        )
+        self.parser.add_argument(
             "--update-name",
             help="Optional short description of the update",
             type=str,
@@ -111,6 +118,11 @@ class Main(App):
 
         try:
             manifest = {"target": args.target, "version": 1}
+            if args.version_json:
+                with open(args.version_json, "r") as vf:
+                    version_data = json.load(vf)
+                if "firmware_version" in version_data:
+                    manifest["firmware_version"] = version_data["firmware_version"]
             if args.update_name:
                 manifest["update_name"] = args.update_name
             if args.security_flags:

--- a/scripts/update_bundle.py
+++ b/scripts/update_bundle.py
@@ -119,10 +119,8 @@ class Main(App):
         try:
             manifest = {"target": args.target, "version": 1}
             if args.version_json:
-                shutil.copy2(
-                    args.version_json,
-                    os.path.join(actual_output_path, "version.json"),
-                )
+                with open(args.version_json, "r") as vf:
+                    manifest["firmware_info"] = json.load(vf)
             if args.update_name:
                 manifest["update_name"] = args.update_name
             if args.security_flags:

--- a/scripts/update_bundle.py
+++ b/scripts/update_bundle.py
@@ -121,8 +121,12 @@ class Main(App):
             if args.version_json:
                 with open(args.version_json, "r") as vf:
                     version_data = json.load(vf)
-                if "firmware_version" in version_data:
-                    manifest["firmware_version"] = version_data["firmware_version"]
+                if "firmware_version" not in version_data:
+                    self.logger.error(
+                        f"'firmware_version' key missing from {args.version_json}"
+                    )
+                    return 1
+                manifest["firmware_version"] = version_data["firmware_version"]
             if args.update_name:
                 manifest["update_name"] = args.update_name
             if args.security_flags:

--- a/scripts/update_bundle.py
+++ b/scripts/update_bundle.py
@@ -119,14 +119,10 @@ class Main(App):
         try:
             manifest = {"target": args.target, "version": 1}
             if args.version_json:
-                with open(args.version_json, "r") as vf:
-                    version_data = json.load(vf)
-                if "firmware_version" not in version_data:
-                    self.logger.error(
-                        f"'firmware_version' key missing from {args.version_json}"
-                    )
-                    return 1
-                manifest["firmware_version"] = version_data["firmware_version"]
+                shutil.copy2(
+                    args.version_json,
+                    os.path.join(actual_output_path, "version.json"),
+                )
             if args.update_name:
                 manifest["update_name"] = args.update_name
             if args.security_flags:


### PR DESCRIPTION
# What's new

- [FW-931]  Included firmware version string in updater's json file as `firmware_version`

# Verification 

- Check that firmware is installable and string is present and matches the firmware

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-931]: https://flipper.atlassian.net/browse/FW-931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ