### PR TITLE
[FW-936] BUSY Timer settings fixes

### DIFF
--- a/applications/services/busy_timer/busy_timer_common.c
+++ b/applications/services/busy_timer/busy_timer_common.c
@@ -8,6 +8,12 @@ static const char* const busy_timer_common_mode_names[BusyTimerModeMax] = {
     [BusyTimerModeInterval] = "INTERVAL",
 };
 
+static void busy_timer_common_serialize_timer_mode(cJSON* json, BusyTimerMode timer_mode) {
+    furi_assert(timer_mode < BusyTimerModeMax);
+    cJSON_AddStringToObject(
+        json, KEY_COMMON_TIMER_SETTINGS_TYPE, busy_timer_common_mode_names[timer_mode]);
+}
+
 void busy_timer_common_serialize_app_config(cJSON* json, const BusyAppConfig* app_config) {
     cJSON* busy_bar_settings_json = cJSON_AddObjectToObject(json, KEY_COMMON_BUSY_BAR_SETTINGS);
     cJSON_AddStringToObject(
@@ -23,21 +29,14 @@ void busy_timer_common_serialize_app_config(cJSON* json, const BusyAppConfig* ap
 }
 
 void busy_timer_common_serialize_infinite_config(cJSON* json) {
-    cJSON_AddStringToObject(
-        json, KEY_COMMON_TIMER_SETTINGS_TYPE, busy_timer_common_mode_names[BusyTimerModeInfinite]);
-}
-
-void busy_timer_common_serialize_timer_mode(cJSON* json, BusyTimerMode timer_mode) {
-    furi_assert(timer_mode < BusyTimerModeMax);
-    cJSON_AddStringToObject(
-        json, KEY_COMMON_TIMER_SETTINGS_TYPE, busy_timer_common_mode_names[timer_mode]);
+    busy_timer_common_serialize_timer_mode(json, BusyTimerModeInfinite);
 }
 
 void busy_timer_common_serialize_simple_config(
     cJSON* json,
     const BusyTimerSimpleConfig* simple_config) {
-    cJSON_AddStringToObject(
-        json, KEY_COMMON_TIMER_SETTINGS_TYPE, busy_timer_common_mode_names[BusyTimerModeSimple]);
+    busy_timer_common_serialize_timer_mode(json, BusyTimerModeSimple);
+
     cJSON_AddNumberToObject(
         json, KEY_COMMON_SIMPLE_SETTINGS_TOTAL_TIME, simple_config->total_time_ms);
 }
@@ -45,8 +44,8 @@ void busy_timer_common_serialize_simple_config(
 void busy_timer_common_serialize_interval_config(
     cJSON* json,
     const BusyTimerIntervalConfig* interval_config) {
-    cJSON_AddStringToObject(
-        json, KEY_COMMON_TIMER_SETTINGS_TYPE, busy_timer_common_mode_names[BusyTimerModeInterval]);
+    busy_timer_common_serialize_timer_mode(json, BusyTimerModeInterval);
+
     cJSON_AddNumberToObject(
         json, KEY_COMMON_INTERVAL_SETTINGS_WORK, interval_config->work_time_ms);
     cJSON_AddNumberToObject(

--- a/applications/services/busy_timer/busy_timer_common_i.h
+++ b/applications/services/busy_timer/busy_timer_common_i.h
@@ -26,8 +26,6 @@ void busy_timer_common_serialize_app_config(cJSON* json, const BusyAppConfig* ap
 
 void busy_timer_common_serialize_infinite_config(cJSON* json);
 
-void busy_timer_common_serialize_timer_mode(cJSON* json, BusyTimerMode timer_mode);
-
 void busy_timer_common_serialize_simple_config(
     cJSON* json,
     const BusyTimerSimpleConfig* simple_config);

--- a/applications/services/busy_timer/busy_timer_profile.c
+++ b/applications/services/busy_timer/busy_timer_profile.c
@@ -27,9 +27,10 @@ static void busy_timer_profile_serialize_timer_settings(
     cJSON* timer_settings_json = cJSON_AddObjectToObject(json, KEY_PROFILE_TIMER_SETTINGS);
 
     const BusyTimerMode timer_mode = timer_settings->mode;
-    busy_timer_common_serialize_timer_mode(timer_settings_json, timer_mode);
 
-    if(timer_mode == BusyTimerModeSimple) {
+    if(timer_mode == BusyTimerModeInfinite) {
+        busy_timer_common_serialize_infinite_config(timer_settings_json);
+    } else if(timer_mode == BusyTimerModeSimple) {
         busy_timer_common_serialize_simple_config(timer_settings_json, &timer_settings->simple);
     } else if(timer_mode == BusyTimerModeInterval) {
         busy_timer_common_serialize_interval_config(

--- a/applications/services/busy_timer/settings/busy_timer_settings_interface_v1.c
+++ b/applications/services/busy_timer/settings/busy_timer_settings_interface_v1.c
@@ -116,12 +116,10 @@ static const time_t busy_timer_settings_v1_timestamp_default = 0;
 static bool busy_timer_settings_v1_timer_config_serialize_cb(
     const SettingProviderSetting* setting,
     const void* value,
-    FuriString* string) {
+    cJSON* json) {
     UNUSED(setting);
 
     const BusyTimerConfig* timer_settings = value;
-
-    cJSON* json = cJSON_CreateObject();
 
     if(timer_settings->mode == BusyTimerModeInfinite) {
         busy_timer_common_serialize_infinite_config(json);
@@ -131,26 +129,16 @@ static bool busy_timer_settings_v1_timer_config_serialize_cb(
         busy_timer_common_serialize_interval_config(json, &timer_settings->interval);
     }
 
-    char* json_text = cJSON_PrintUnformatted(json);
-    furi_check(json_text);
-
-    furi_string_set(string, json_text);
-    free(json_text);
-
-    cJSON_Delete(json);
-
     return true;
 }
 
 static bool busy_timer_settings_v1_timer_config_deserialize_cb(
     const SettingProviderSetting* setting,
-    const char* string,
+    const cJSON* json,
     void* value) {
     UNUSED(setting);
 
     bool success = false;
-
-    cJSON* json = cJSON_Parse(string);
 
     do {
         if(!cJSON_IsObject(json)) {
@@ -176,8 +164,6 @@ static bool busy_timer_settings_v1_timer_config_deserialize_cb(
 
         success = true;
     } while(false);
-
-    cJSON_Delete(json);
 
     return success;
 }
@@ -291,14 +277,14 @@ static const SettingProviderSetting busy_timer_settings_v1_profile[] = {
         {
             .name = "timer_config",
             .interface =
-                &(const SettingProviderCustomInterface){
+                &(const SettingProviderRawInterface){
                     .default_value = &busy_timer_settings_v1_timer_config_default,
                     .serialize_callback = busy_timer_settings_v1_timer_config_serialize_cb,
                     .deserialize_callback = busy_timer_settings_v1_timer_config_deserialize_cb,
                     .default_value_size = sizeof(busy_timer_settings_v1_timer_config_default),
                 },
             .field_offset = offsetof(BusyTimerProfile, timer_config),
-            .type = SettingProviderSettingTypeCustom,
+            .type = SettingProviderSettingTypeRaw,
         },
     [BusyTimerSettingsV1ProfileIdxMetadata] =
         {


### PR DESCRIPTION
# What's new

- Use `SettingProviderSettingTypeRaw` to store the `timer_config` field
- Remove redundant timer type field serialisation

# Verification 

1. Flash the firmware bundle
2. Ensure that there are no regressions in BUSY Timer synchronisation (snapshots, profiles, etc)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
