### PR TITLE
[FW-949] Increase queue get timeout in storage test

### DIFF
--- a/applications/debug/unit_tests/storage_test/storage_test.c
+++ b/applications/debug/unit_tests/storage_test/storage_test.c
@@ -767,7 +767,7 @@ static int32_t shutdown_file_write_thread(void* context) {
 
     File* f = storage_file_alloc(storage);
     do {
-        if(furi_message_queue_get(data->rx, &msg, 10) != FuriStatusOk) {
+        if(furi_message_queue_get(data->rx, &msg, 100) != FuriStatusOk) {
             ret = TestErrorQueueGet1;
             break;
         }
@@ -784,7 +784,7 @@ static int32_t shutdown_file_write_thread(void* context) {
         msg = TestMessageWriteDone;
         furi_message_queue_put(data->tx, &msg, FuriWaitForever);
 
-        if(furi_message_queue_get(data->rx, &msg, 10) != FuriStatusOk) {
+        if(furi_message_queue_get(data->rx, &msg, 100) != FuriStatusOk) {
             ret = TestErrorQueueGet2;
             break;
         }


### PR DESCRIPTION
# What's new

- Fix timeout error

# Verification 

- Run unit tests many times, test_storage_common_shutdown must not fail

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
