### PR TITLE
[FW-954, FW-934] Matter reboot bugs

### DIFF
--- a/applications/services/matter/matter.c
+++ b/applications/services/matter/matter.c
@@ -346,6 +346,15 @@ static MatterStatus matter_get_commissioned_fabrics_api_message_handler(
     return MatterStatusOk;
 }
 
+static void matter_deferred_reboot(void* context) {
+    UNUSED(context);
+
+    Power* power = furi_record_open(RECORD_POWER);
+    power_reboot(power, PowerRebootNormal);
+    while(1)
+        ;
+}
+
 static MatterStatus
     matter_factory_reset_api_message_handler(Matter* instance, MatterApiMessageData* data) {
     UNUSED(data);
@@ -356,18 +365,19 @@ static MatterStatus
     MatterStatus status = matter_send_frame(instance, &frame);
     if(status != MatterStatusOk) return status;
 
-    MatterEvent event = {
-        .type = MatterEventTypeWillReboot,
-    };
-    furi_pubsub_publish(instance->pubsub, &event);
+    if(data->factory_reset.reboot_mode == MatterRebootAutomatically) {
+        MatterEvent event = {
+            .type = MatterEventTypeWillReboot,
+        };
+        furi_pubsub_publish(instance->pubsub, &event);
 
-    furi_delay_ms(REBOOT_TIMER_MS);
+        // this object leaks
+        // it's fine - it'll be freed by the ultimate garbage collector! a reset!
+        FuriTimer* timer = furi_timer_alloc(matter_deferred_reboot, FuriTimerTypeOnce, NULL);
+        furi_timer_start(timer, furi_ms_to_ticks(REBOOT_TIMER_MS));
+    }
 
-    Power* power = furi_record_open(RECORD_POWER);
-
-    power_reboot(power, PowerRebootNormal);
-    while(1)
-        ;
+    return MatterStatusOk;
 }
 
 static const MatterApiMessageHandler matter_api_message_handlers[MatterApiMessageTypeMax] = {

--- a/applications/services/matter/matter.h
+++ b/applications/services/matter/matter.h
@@ -146,14 +146,20 @@ MatterStatus matter_enable_commissioning(Matter* instance, MatterCommissioningIn
  */
 MatterStatus matter_get_commissioned_fabrics(Matter* instance, MatterCommissionedFabrics* fabrics);
 
+typedef enum {
+    MatterRebootAutomatically, //<! The Matter service will reboot the device on its own
+    MatterRebootManually, //<! The calling service promises to reboot the device later, when it's more appropriate
+} MatterReboot;
+
 /**
  * @brief Delete all Matter pairing data, then reboot on success
  *
  * @param[in,out] instance pointer to the service instance
+ * @param[in] reboot reboot mode, see `MatterReboot` enum
  *
  * @returns @c MatterStatus enum on error. @c MatterStatusOk is never returned.
  */
-MatterStatus matter_factory_reset(Matter* instance);
+MatterStatus matter_factory_reset(Matter* instance, MatterReboot reboot);
 
 /**
  * @brief Set the preferred certification config.

--- a/applications/services/matter/matter_api.c
+++ b/applications/services/matter/matter_api.c
@@ -67,12 +67,14 @@ MatterStatus matter_set_switch_startup_mode(Matter* instance, MatterSwitchStartu
     return matter_api_send_message(instance, &api_message);
 }
 
-MatterStatus matter_factory_reset(Matter* instance) {
+MatterStatus matter_factory_reset(Matter* instance, MatterReboot reboot) {
     furi_check(instance);
 
     MatterApiMessage api_message = {
         .type = MatterApiMessageTypeFactoryReset,
-    };
+        .data.factory_reset = {
+            .reboot_mode = reboot,
+        }};
 
     return matter_api_send_message(instance, &api_message);
 }

--- a/applications/services/matter/matter_cli.c
+++ b/applications/services/matter/matter_cli.c
@@ -169,7 +169,7 @@ static void matter_cli_cmd_reset(PipeSide* pipe, FuriString* args, void* context
     furi_assert(context);
     MatterCli* matter_cli = context;
 
-    matter_factory_reset(matter_cli->matter);
+    matter_factory_reset(matter_cli->matter, MatterRebootAutomatically);
 
     printf("Done. Device will reboot shortly.\r\n");
 }

--- a/applications/services/matter/matter_i.h
+++ b/applications/services/matter/matter_i.h
@@ -37,11 +37,16 @@ typedef struct {
     MatterCommissionedFabrics* fabrics;
 } MatterApiMessageGetFabrics;
 
+typedef struct {
+    MatterReboot reboot_mode;
+} MatterApiMessageFactoryReset;
+
 typedef union {
     MatterApiMessageSetSwitchState set_switch_state;
     MatterApiMessageSetSwitchStartupMode set_switch_startup_mode;
     MatterApiMessageStartCommissioning start_commissioning;
     MatterApiMessageGetFabrics get_fabrics;
+    MatterApiMessageFactoryReset factory_reset;
 } MatterApiMessageData;
 
 typedef struct {

--- a/applications/services/web_server/http_api/api_smart_home.c
+++ b/applications/services/web_server/http_api/api_smart_home.c
@@ -89,7 +89,7 @@ static void api_smart_home_factory_reset(struct mg_connection* conn, struct mg_h
     UNUSED(msg);
 
     Matter* matter = furi_record_open(RECORD_MATTER);
-    MatterStatus matter_status = matter_factory_reset(matter);
+    MatterStatus matter_status = matter_factory_reset(matter, MatterRebootAutomatically);
     furi_record_close(RECORD_MATTER);
 
     if(matter_status == MatterStatusOk) {

--- a/applications/settings/matter_settings/scenes/scene_main.c
+++ b/applications/settings/matter_settings/scenes/scene_main.c
@@ -101,7 +101,7 @@ static bool matter_scene_on_event(const SceneManagerEvent* event, void* context)
             if(scene->menu_idx == SceneSubmenuIndexPairing) {
                 scene_manager_next_scene(app->scene_manager, SceneIdPairing);
             } else if(scene->menu_idx == SceneSubmenuIndexReset) {
-                matter_factory_reset(app->matter);
+                matter_factory_reset(app->matter, MatterRebootAutomatically);
             } else {
                 furi_crash();
             }

--- a/lib/toolbox/update_lib/factory_reset.c
+++ b/lib/toolbox/update_lib/factory_reset.c
@@ -46,7 +46,7 @@ static void reset_matter_pairing(void) {
 
     if(furi_record_exists(RECORD_MATTER)) {
         Matter* matter = furi_record_open(RECORD_MATTER);
-        matter_factory_reset(matter);
+        matter_factory_reset(matter, MatterRebootManually);
         furi_record_close(RECORD_MATTER);
         printf("Matter pairing reset done\r\n");
     } else {


### PR DESCRIPTION
# What's new
- FW-934: Matter reset HTTP API response is returned correctly
- FW-954: Matter service doesn't reboot the device on factory reset

# Verification 
- FW-934: Execute `DELETE /api/smart_home/pairing`, verify that a 200 response is returned. A pairing is not required before executing this endpoint.
- FW-954: Execute a factory reset via CLI or GUI. Verify that it completes.

# Checklist (For Reviewer)
- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
