### PR TITLE
[FW-960] HTTP API Text Scroll Delay Parameters

### DIFF
--- a/applications/services/canvas/canvas.c
+++ b/applications/services/canvas/canvas.c
@@ -265,6 +265,11 @@ static Widget* canvas_element_update_specific(
         if(element->text.scroll_rate_cpm) {
             uint32_t scroll_dur =
                 label_calculate_scroll_duration(widget->text, element->text.scroll_rate_cpm);
+            label_set_long_content_anim_start_delay(
+                widget->text, element->text.scroll_start_delay);
+            label_set_long_content_anim_repeat_delay(
+                widget->text, element->text.scroll_repeat_delay);
+
             label_set_long_content_mode(
                 widget->text, LabelLongContentModeScrollCircular, scroll_dur);
         } else {

--- a/applications/services/canvas/canvas.h
+++ b/applications/services/canvas/canvas.h
@@ -56,6 +56,8 @@ typedef struct {
             Color color;
             size_t width;
             size_t scroll_rate_cpm;
+            size_t scroll_start_delay;
+            size_t scroll_repeat_delay;
         } text;
 
         struct {

--- a/applications/services/gui/modules/label.c
+++ b/applications/services/gui/modules/label.c
@@ -9,8 +9,11 @@ struct Label {
     Widget base;
     lv_obj_t* label;
     FuriString* text;
+
     FontRegistry* font_registry;
     const lv_font_t* loaded_font;
+
+    lv_anim_t long_content_anim_template;
 };
 
 const lv_obj_class_t label_lvgl_class;
@@ -48,8 +51,17 @@ static void label_lvgl_constructor(const lv_obj_class_t* class_p, lv_obj_t* obj)
     lv_obj_remove_flag(obj, LV_OBJ_FLAG_SCROLLABLE);
 
     Label* instance = (Label*)obj;
+
     instance->font_registry = furi_record_open(RECORD_FONT_REGISTRY);
+
+    lv_anim_init(&instance->long_content_anim_template);
+    lv_anim_set_delay(&instance->long_content_anim_template, 0);
+    lv_anim_set_repeat_delay(&instance->long_content_anim_template, 0);
+    lv_anim_set_repeat_count(&instance->long_content_anim_template, LV_ANIM_REPEAT_INFINITE);
+
     instance->label = lv_label_create(obj);
+    lv_obj_set_style_anim(instance->label, &instance->long_content_anim_template, LV_PART_MAIN);
+
     instance->text = furi_string_alloc();
 }
 
@@ -161,6 +173,18 @@ void label_set_long_content_mode(Label* instance, LabelLongContentMode mode, uin
 
     lv_obj_set_style_anim_time(instance->label, duration, LV_PART_MAIN);
     lv_label_set_long_mode(instance->label, (lv_label_long_mode_t)mode);
+}
+
+void label_set_long_content_anim_start_delay(Label* instance, uint32_t delay) {
+    furi_check(instance);
+
+    lv_anim_set_delay(&instance->long_content_anim_template, delay);
+}
+
+void label_set_long_content_anim_repeat_delay(Label* instance, uint32_t delay) {
+    furi_check(instance);
+
+    lv_anim_set_repeat_delay(&instance->long_content_anim_template, delay);
 }
 
 uint32_t label_calculate_scroll_duration(const Label* instance, uint32_t rate_ppm) {

--- a/applications/services/gui/modules/label.h
+++ b/applications/services/gui/modules/label.h
@@ -137,6 +137,28 @@ void label_set_text_align(Label* instance, TextAlign align);
 void label_set_long_content_mode(Label* instance, LabelLongContentMode mode, uint32_t duration);
 
 /**
+ * @brief Set the initial delay before the long content animation starts.
+ *
+ * Only applies to scrollable modes (@c LabelLongContentModeScroll,
+ * @c LabelLongContentModeScrollCircular).
+ *
+ * @param[in,out] instance pointer to the Label instance to be modified
+ * @param[in] delay delay in milliseconds before the animation begins
+ */
+void label_set_long_content_anim_start_delay(Label* instance, uint32_t delay);
+
+/**
+ * @brief Set the pause duration between the long content animation repetitions.
+ *
+ * Only applies to scrollable modes (@c LabelLongContentModeScroll,
+ * @c LabelLongContentModeScrollCircular).
+ *
+ * @param[in,out] instance pointer to the Label instance to be modified
+ * @param[in] delay pause duration in milliseconds between successive scroll cycles
+ */
+void label_set_long_content_anim_repeat_delay(Label* instance, uint32_t delay);
+
+/**
  * @brief Calculate scroll duration for `label_set_long_content_mode`.
  * 
  * @param[in] instance pointer to the Label instance

--- a/applications/services/web_server/http_api/api_display.c
+++ b/applications/services/web_server/http_api/api_display.c
@@ -80,6 +80,16 @@ static bool api_display_draw_parse_text_element(
             canvas_element->text.scroll_rate_cpm = (size_t)number;
         }
 
+        if(mg_json_get_num(json_element, "$.scroll_start_delay", &number)) {
+            if(number < -__DBL_EPSILON__) break; // < 0
+            canvas_element->text.scroll_start_delay = (size_t)number;
+        }
+
+        if(mg_json_get_num(json_element, "$.scroll_repeat_delay", &number)) {
+            if(number < -__DBL_EPSILON__) break; // < 0
+            canvas_element->text.scroll_repeat_delay = (size_t)number;
+        }
+
         result = true;
     } while(0);
     return result;

--- a/applications/services/web_server/http_api/http_api.h
+++ b/applications/services/web_server/http_api/http_api.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "../web_server_i.h"
 
-#define API_VERSION {23, 0, 0}
+#define API_VERSION {23, 1, 0}
 
 // Access logging (also used by web_server.c for static-file requests)
 int http_api_extract_status(const struct mg_connection* conn);

--- a/applications/services/web_server/resources/apps_assets/web_server/www/openapi.yaml
+++ b/applications/services/web_server/resources/apps_assets/web_server/www/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: BUSY Bar HTTP API
   description: HTTP API for BUSY Bar web server
-  version: 23.0.0
+  version: 23.1.0
   contact:
     name: tbd
 
@@ -2019,6 +2019,8 @@ components:
             color: "#FFFFFFFF"
             width: 72
             scroll_rate: 1000
+            scroll_start_delay: 1000
+            scroll_repeat_delay: 2500
             display: front
           - id: "1"
             timeout: 6
@@ -2135,6 +2137,14 @@ components:
               type: integer
               minimum: 0
               description: Scroll rate in pixels per minute
+            scroll_start_delay:
+              type: integer
+              minimum: 0
+              description: Delay in milliseconds before the scroll animation begins
+            scroll_repeat_delay:
+              type: integer
+              minimum: 0
+              description: Pause duration in milliseconds between successive scroll cycles
 
     ImageElement:
       allOf:


### PR DESCRIPTION
> [!NOTE]
> * [**FW-960**](https://flipper.atlassian.net/browse/FW-960)

> [!IMPORTANT]
> Please, inform @truetug of this PR's merge, so backend team could update calendar integration to match it's design (see updated parameters [here](https://portal.corp.flipper.net/wiki/spaces/BL/pages/29790830602/Calendar+integration)).

# What's new

- `label` & `canvas` allow setting delay parameters for long-content mode's animation
- HTTP API `/api/display/draw` allow setting delay parameters for text's long-content mode's animation

# Verification 

- call `/api/display/draw` with default example parameters (`scroll_start_delay`: `1000`, `scroll_repeat_delay`: `2500`)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
