### PR TITLE
[FW-966] force Matter switch to OFF if timer not running

### DIFF
--- a/applications/services/busy_timer/busy_timer_smart_home.c
+++ b/applications/services/busy_timer/busy_timer_smart_home.c
@@ -16,6 +16,8 @@ static void
         if(instance->is_timer_running) {
             const bool is_work = (event->state_changed.state == BusyTimerStateWork);
             switch_state = is_work ? MatterSwitchStateOn : MatterSwitchStateOff;
+        } else {
+            switch_state = MatterSwitchStateOff;
         }
 
     } else if(event_type == BusyTimerEventTypePaused) {


### PR DESCRIPTION
# What's new

[FW-966]

- Force Matter switch to OFF if timer not running

# Verification 

1. Flash the firmware bundle.
2. Pair BSB to a Matter hub
3. Press matter switch to “ON” or start the timer on BSB
4. Exit from BUSY app via Back button or rotary switch
5. Ensure that Matter switch returns to “OFF” state

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-966]: https://flipper.atlassian.net/browse/FW-966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ