### PR TITLE
[FW-964] Front display power off

### DIFF
--- a/applications/debug/front_display_test/front_display_test.c
+++ b/applications/debug/front_display_test/front_display_test.c
@@ -79,6 +79,16 @@ static const FrontDisplayTestColorData front_display_test_color[FrontDisplayTest
                     .b = 0xff,
                 },
         },
+    [FrontDisplayTestColorBlank] =
+        {
+            .name = "Black",
+            .color =
+                {
+                    .r = 0x00,
+                    .g = 0x00,
+                    .b = 0x00,
+                },
+        },
 };
 
 typedef void (*FrontDisplayTestPatternSet)(Canvas* canvas, Color color);

--- a/applications/debug/front_display_test/front_display_test.h
+++ b/applications/debug/front_display_test/front_display_test.h
@@ -33,6 +33,7 @@ typedef enum {
     FrontDisplayTestColorCian,
     FrontDisplayTestColorPurple,
     FrontDisplayTestColorWhite,
+    FrontDisplayTestColorBlank,
 
     FrontDisplayTestColorNum,
 } FrontDisplayTestColor;

--- a/applications/debug/front_display_test/front_display_test_app.c
+++ b/applications/debug/front_display_test/front_display_test_app.c
@@ -75,7 +75,16 @@ static void
         instance->color = (instance->color == 0) ? FrontDisplayTestColorNum - 1 :
                                                    instance->color - 1;
     } else if(event == FrontDisplayTestAppEventDisplayPower) {
-        furi_hal_display_power_disable();
+        if(instance->power_on) {
+            FrontDisplaySrv* front_display = furi_record_open(RECORD_FRONT_DISPLAY);
+            front_display_sleep_mode(front_display, true);
+            furi_record_close(RECORD_FRONT_DISPLAY);
+        } else {
+            FrontDisplaySrv* front_display = furi_record_open(RECORD_FRONT_DISPLAY);
+            front_display_sleep_mode(front_display, false);
+            furi_record_close(RECORD_FRONT_DISPLAY);
+        }
+        instance->power_on = !instance->power_on;
     } else if(event == FrontDisplayTestAppEventExit) {
         furi_event_loop_stop(instance->event_loop);
     }
@@ -134,6 +143,7 @@ static FrontDisplayTestApp* front_display_test_app_alloc(void) {
 
     instance->pattern = FrontDisplayTestPatternChess;
     instance->color = FrontDisplayTestColorRed;
+    instance->power_on = true;
 
     front_display_test_app_update(instance);
     furi_event_loop_timer_start(instance->timer, 1000 / 60);

--- a/applications/debug/front_display_test/front_display_test_app_i.h
+++ b/applications/debug/front_display_test/front_display_test_app_i.h
@@ -37,4 +37,5 @@ typedef struct {
 
     FrontDisplayTestPattern pattern;
     FrontDisplayTestColor color;
+    bool power_on;
 } FrontDisplayTestApp;

--- a/applications/main/soft_off/soft_off.c
+++ b/applications/main/soft_off/soft_off.c
@@ -8,9 +8,11 @@
 #include <gui/modules/anim_player.h>
 
 #include <back_display/back_display.h>
+#include <front_display/front_display.h>
 
 typedef enum {
     SoftOffThreadFlagExit = 1 << 0,
+    SoftOffThreadFlagAnimationCompleted = 1 << 1,
 } SoftOffThreadFlag;
 
 static bool soft_off_signal_callback(uint32_t signal, void* arg, void* context) {
@@ -28,6 +30,20 @@ static bool soft_off_signal_callback(uint32_t signal, void* arg, void* context) 
     return false;
 }
 
+static void soft_off_animation_finished_callback(
+    AnimPlayer* anim_player,
+    const AnimFileFrameInfo* frame,
+    void* context) {
+    furi_assert(context);
+    UNUSED(anim_player);
+
+    if(frame->flags & AnimFileFrameFlagError) return;
+    if(!(frame->flags & AnimFileFrameFlagFinished)) return;
+
+    FuriThread* thread = context;
+    furi_thread_flags_set(thread, SoftOffThreadFlagAnimationCompleted);
+}
+
 int32_t soft_off_app(void* arg) {
     UNUSED(arg);
 
@@ -36,8 +52,10 @@ int32_t soft_off_app(void* arg) {
 
     Gui* gui = furi_record_open(RECORD_GUI);
     BackDisplaySrv* back_display = furi_record_open(RECORD_BACK_DISPLAY);
+    FrontDisplaySrv* front_display = furi_record_open(RECORD_FRONT_DISPLAY);
 
     back_display_sleep_mode(back_display, true);
+    // Turn off front display only after animation finish
 
     FuriThread* thread = furi_thread_get_current();
     furi_thread_set_signal_callback(thread, soft_off_signal_callback, thread);
@@ -49,18 +67,34 @@ int32_t soft_off_app(void* arg) {
 
         anim_player = anim_player_alloc(root);
         anim_player_set_source(anim_player, SOFT_OFF_ANIM_PATH("turn_off_72x16.anim"));
+        anim_player_set_frame_callback(anim_player, soft_off_animation_finished_callback, thread);
 
         anim_player_set_section(anim_player, AnimFilePlayFlagNone, ANIM_FILE_DEFAULT_SECTION);
     });
 
-    furi_thread_flags_wait(SoftOffThreadFlagExit, FuriFlagWaitAny, FuriWaitForever);
+    while(1) {
+        uint32_t flags = furi_thread_flags_wait(
+            SoftOffThreadFlagExit | SoftOffThreadFlagAnimationCompleted,
+            FuriFlagWaitAny,
+            FuriWaitForever);
+        furi_check((flags & FuriFlagError) == 0);
+        if(flags & SoftOffThreadFlagExit) {
+            break;
+        }
+        if(flags & SoftOffThreadFlagAnimationCompleted) {
+            front_display_sleep_mode(front_display, true);
+        }
+    }
     furi_thread_set_signal_callback(thread, NULL, NULL);
 
     with_gui(gui, { anim_player_free(anim_player); });
 
     back_display_sleep_mode(back_display, false);
+    front_display_sleep_mode(front_display, false);
 
     furi_record_close(RECORD_BACK_DISPLAY);
+    furi_record_close(RECORD_FRONT_DISPLAY);
+
     furi_record_close(RECORD_GUI);
     furi_record_close(RECORD_LOADER);
 

--- a/applications/services/canvas/canvas.c
+++ b/applications/services/canvas/canvas.c
@@ -15,6 +15,7 @@
 #include <lvgl.h>
 #include <font_registry/fonts.h>
 #include <back_display/back_display.h>
+#include <front_display/front_display.h>
 
 #define CANVAS_DEFERRED_TIMEOUT_MS 1500U
 
@@ -623,10 +624,13 @@ static void canvas_screen_open(CanvasSrv* canvas) {
     });
 
     if(is_in_power_off(canvas)) {
-        // FIXME: Back display was shut down in power_off, we need to turn it on
+        // FIXME: Displays were shut down in power_off, we need to turn them on
         BackDisplaySrv* back_display = furi_record_open(RECORD_BACK_DISPLAY);
+        FrontDisplaySrv* front_display = furi_record_open(RECORD_FRONT_DISPLAY);
         back_display_sleep_mode(back_display, false);
+        front_display_sleep_mode(front_display, false);
         furi_record_close(RECORD_BACK_DISPLAY);
+        furi_record_close(RECORD_FRONT_DISPLAY);
     }
 }
 
@@ -649,8 +653,11 @@ static void canvas_screen_close(CanvasSrv* canvas) {
     canvas->priority = 0;
     if(is_in_power_off(canvas)) {
         BackDisplaySrv* back_display = furi_record_open(RECORD_BACK_DISPLAY);
+        FrontDisplaySrv* front_display = furi_record_open(RECORD_FRONT_DISPLAY);
         back_display_sleep_mode(back_display, true);
+        front_display_sleep_mode(front_display, true);
         furi_record_close(RECORD_BACK_DISPLAY);
+        furi_record_close(RECORD_FRONT_DISPLAY);
     }
 }
 

--- a/applications/services/front_display/front_display.c
+++ b/applications/services/front_display/front_display.c
@@ -37,6 +37,7 @@ struct FrontDisplaySrv {
     bool send_in_progress;
     bool need_update;
     bool is_blanked;
+    bool power_off_pending;
 
     uint8_t last_frame[FRONT_DISPLAY_FRAME_SIZE];
     uint8_t brightness_override;
@@ -48,6 +49,7 @@ typedef enum {
     FrontDisplayMessageTypeDrawEnd,
     FrontDisplayMessageTypeBrightness,
     FrontDisplayMessageTypeBlanking,
+    FrontDisplayMessageTypeSleep,
     FrontDisplayMessageTypeOn,
     FrontDisplayMessageTypeOff,
 } FrontDisplayMessageType;
@@ -58,7 +60,7 @@ typedef struct {
     union {
         const uint8_t* frame_buffer;
         uint8_t brightness; // Brightness value (0-100) or FRONT_DISPLAY_BRIGHTNESS_AUTO
-        bool is_blanked;
+        bool bool_param;
     };
 } FrontDisplayMessage;
 
@@ -93,7 +95,19 @@ void front_display_set_blanked(FrontDisplaySrv* instance, bool is_blanked) {
     const FrontDisplayMessage message = {
         .api_lock = NULL, // No need for API lock here
         .type = FrontDisplayMessageTypeBlanking,
-        .is_blanked = is_blanked,
+        .bool_param = is_blanked,
+    };
+
+    furi_check(
+        furi_message_queue_put(instance->message_queue, &message, FuriWaitForever) ==
+        FuriStatusOk);
+}
+
+void front_display_sleep_mode(FrontDisplaySrv* instance, bool sleep) {
+    const FrontDisplayMessage message = {
+        .api_lock = NULL, // No need for API lock here
+        .type = FrontDisplayMessageTypeSleep,
+        .bool_param = sleep,
     };
 
     furi_check(
@@ -218,6 +232,10 @@ static void front_display_message_queue_callback(FuriEventLoopObject* object, vo
         break;
     case FrontDisplayMessageTypeDrawEnd:
         display->send_in_progress = false;
+        if(display->power_off_pending) {
+            furi_hal_display_power_disable();
+            display->power_off_pending = false;
+        }
         FRONT_DISPLAY_DEBUG("Front display draw end");
         break;
     case FrontDisplayMessageTypeBrightness:
@@ -230,11 +248,25 @@ static void front_display_message_queue_callback(FuriEventLoopObject* object, vo
         display->need_update = true;
         break;
     case FrontDisplayMessageTypeBlanking:
-        front_display_handle_set_blanked(display, message.is_blanked);
+        front_display_handle_set_blanked(display, message.bool_param);
+        break;
+    case FrontDisplayMessageTypeSleep:
+        if((message.bool_param == true) && (display->enabled == true)) {
+            memset(display->last_frame, 0, FRONT_DISPLAY_FRAME_SIZE);
+            display->need_update = true;
+
+            front_display_scan_output_enable(false);
+            display->power_off_pending = true;
+        } else if(message.bool_param == false) {
+            furi_hal_display_power_enable();
+            if(display->power_off_pending) {
+                display->power_off_pending = false;
+            }
+        }
         break;
     case FrontDisplayMessageTypeOn:
         if(!display->enabled) {
-            FRONT_DISPLAY_DEBUG("Turning on front display");
+            FRONT_DISPLAY_DEBUG("Power turned on, reinitializing");
 
             front_display_power_reset();
             front_display_start(display);
@@ -242,10 +274,9 @@ static void front_display_message_queue_callback(FuriEventLoopObject* object, vo
             display->enabled = true;
             display->need_update = true; // Force an update after enabling
         }
-
         break;
     case FrontDisplayMessageTypeOff:
-        FRONT_DISPLAY_DEBUG("Turning off front display");
+        FRONT_DISPLAY_DEBUG("Power turned off");
         front_display_stop();
         display->enabled = false;
         display->send_in_progress = false;

--- a/applications/services/front_display/front_display.h
+++ b/applications/services/front_display/front_display.h
@@ -35,3 +35,14 @@ void front_display_set_brightness(FrontDisplaySrv* instance, FrontDisplayBrightn
  * @param is_blanked blank the display if @c true, unblank otherwise
  */
 void front_display_set_blanked(FrontDisplaySrv* instance, bool is_blanked);
+
+/**
+ * @brief Enter or exit low-power sleep mode.
+ *
+ * Display power is completely shut down in sleep mode. 
+ * When exiting sleep mode, the display will be re-initialized, which may cause a delay before it starts showing content again.
+ *
+ * @param instance Pointer to the FrontDisplaySrv instance
+ * @param sleep enter sleep mode if @c true, exit sleep mode otherwise
+ */
+void front_display_sleep_mode(FrontDisplaySrv* instance, bool sleep);

--- a/applications/services/front_display/front_display_driver.c
+++ b/applications/services/front_display/front_display_driver.c
@@ -269,9 +269,10 @@ static void octospi_deinit(void) {
     furi_hal_bus_reset(FuriHalBusOCTOSPIM);
     furi_hal_bus_disable(FuriHalBusOCTOSPI1);
     furi_hal_bus_disable(FuriHalBusOCTOSPIM);
-    furi_hal_gpio_init_simple(&gpio_front_display_sdi_ospi_d0, GpioModeInput);
-    furi_hal_gpio_init_simple(&gpio_front_display_le_ospi_d1, GpioModeInput);
-    furi_hal_gpio_init_simple(&gpio_front_display_dclk_ospi_clk, GpioModeInput);
+    furi_hal_gpio_init(&gpio_front_display_sdi_ospi_d0, GpioModeInput, GpioPullDown, GpioSpeedLow);
+    furi_hal_gpio_init(&gpio_front_display_le_ospi_d1, GpioModeInput, GpioPullDown, GpioSpeedLow);
+    furi_hal_gpio_init(
+        &gpio_front_display_dclk_ospi_clk, GpioModeInput, GpioPullDown, GpioSpeedLow);
 }
 
 static FURI_ALWAYS_INLINE void led_driver_add_le_cmd(uint8_t* tx_data, LedDriverCommand cmd) {
@@ -504,6 +505,11 @@ void front_display_driver_init(uint8_t initial_brightness) {
     octospi_dma_init(&led_driver);
 
     front_display_driver_send_init(&led_driver);
+
+    led_driver_encode_empty_buffer(&led_driver);
+    octospi_send_buf_prepare(&led_driver, led_driver.spi_buf, sizeof(led_driver.spi_buf));
+    front_display_driver_send_buf_start();
+    octospi_wait_end(&led_driver);
 }
 
 void front_display_driver_deinit(void) {

--- a/applications/services/front_display/front_display_scan.c
+++ b/applications/services/front_display/front_display_scan.c
@@ -82,7 +82,7 @@ static void gclk_tim_init(void) {
 static void gclk_tim_deinit(void) {
     furi_hal_bus_reset(FuriHalBusTIM8);
     furi_hal_bus_disable(FuriHalBusTIM8);
-    furi_hal_gpio_init_simple(&gpio_front_display_gclk, GpioModeInput);
+    furi_hal_gpio_init(&gpio_front_display_gclk, GpioModeInput, GpioPullDown, GpioSpeedLow);
 }
 
 static void scan_tim_init(void) {
@@ -135,7 +135,7 @@ static void scan_tim_init(void) {
 static void scan_tim_deinit(void) {
     furi_hal_bus_reset(FuriHalBusTIM5);
     furi_hal_bus_disable(FuriHalBusTIM5);
-    furi_hal_gpio_init_simple(&gpio_front_display_scan_latch, GpioModeInput);
+    furi_hal_gpio_init(&gpio_front_display_scan_latch, GpioModeInput, GpioPullDown, GpioSpeedLow);
 
     NVIC_DisableIRQ(TIM5_IRQn);
 }
@@ -269,8 +269,8 @@ static void spi_595_init(void) {
 static void spi_595_deinit(void) {
     furi_hal_bus_reset(FuriHalBusSPI2);
     furi_hal_bus_disable(FuriHalBusSPI2);
-    furi_hal_gpio_init_simple(&gpio_front_display_scan_clk, GpioModeInput);
-    furi_hal_gpio_init_simple(&gpio_front_display_scan_sdi, GpioModeInput);
+    furi_hal_gpio_init(&gpio_front_display_scan_clk, GpioModeInput, GpioPullDown, GpioSpeedLow);
+    furi_hal_gpio_init(&gpio_front_display_scan_sdi, GpioModeInput, GpioPullDown, GpioSpeedLow);
 }
 
 static void scan_dma_tc_irq(void* context) {

--- a/applications/settings/system_settings/scenes/system_settings_scene_power_shut_down_confirm.c
+++ b/applications/settings/system_settings/scenes/system_settings_scene_power_shut_down_confirm.c
@@ -70,12 +70,16 @@ static bool system_settings_scene_shut_down_confirm_on_event(
     bool consumed = false;
     if(event->type == SceneManagerEventTypeCustom) {
         if(event->event == SceneEventConfirm) {
+            FrontDisplaySrv* front_display = furi_record_open(RECORD_FRONT_DISPLAY);
+            front_display_sleep_mode(front_display, true);
             bool power_off_success = power_off(instance->power);
 
             if(!power_off_success) {
+                front_display_sleep_mode(front_display, false);
                 system_settings_pop_location(instance);
                 consumed = scene_manager_previous_scene(instance->scene_manager);
             }
+            furi_record_close(RECORD_FRONT_DISPLAY);
         } else if(event->event == SceneEventCancel) {
             system_settings_pop_location(instance);
             consumed = scene_manager_search_and_switch_to_previous_scene(


### PR DESCRIPTION
# What's new
FW-964
- Power down front display in Off mode to save ~70mA
- Some hacks to minimize flickering during display on/off

# Verification 

- Check battery power consumption in Off mode, should be ~80mA instead of ~150

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
