### PR TITLE
[FW-880, FW-921, FW-967, FW-981] Name and wifi API, canvas small fixes

### DIFF
--- a/applications/services/canvas/canvas.c
+++ b/applications/services/canvas/canvas.c
@@ -647,6 +647,7 @@ static void canvas_screen_close(CanvasSrv* canvas) {
         gui_layer_remove_input_callback(input_layer, canvas_srv_input_callback);
 
         mirror_card_free(canvas->display_mirror);
+        canvas->display_mirror = NULL;
         for(GuiDisplayId i = 0; i < GuiDisplayIdMax; i++) {
             widget_free(canvas->display[i]);
             canvas->display[i] = NULL;

--- a/applications/services/canvas/canvas.c
+++ b/applications/services/canvas/canvas.c
@@ -533,7 +533,7 @@ static void canvas_srv_queue_event_callback(FuriEventLoopObject* object, void* c
             res = CanvasResultOk;
         }
     } else if(event.type == CanvasSrvEventExit) {
-        canvas_srv_clear_all(canvas);
+        if(canvas->gui) canvas_srv_clear_all(canvas);
         res = CanvasResultOk;
 
     } else if(event.type == CanvasSrvEventReevaluatePriority) {

--- a/applications/services/canvas/canvas.c
+++ b/applications/services/canvas/canvas.c
@@ -5,13 +5,13 @@
 #include <gui/modules/anim_player.h>
 #include <gui/modules/label.h>
 #include <gui/modules/countdown.h>
+#include <gui/modules/mirror_card.h>
 #include <loader/loader.h>
 #include <m-dict.h>
 #include <toolbox/m_cstr_dup.h>
 #include <toolbox/api_lock.h>
 #include <furi_hal_rtc.h>
 #include "canvas.h"
-#include <gui/modules/front_display_mirror.h>
 #include <lvgl.h>
 #include <font_registry/fonts.h>
 #include <back_display/back_display.h>
@@ -70,7 +70,7 @@ struct CanvasSrv {
     Widget* background[GuiDisplayIdMax];
     Widget* display[GuiDisplayIdMax];
     CanvasWidgetsDict_t widgets;
-    DisplayMirror* display_mirror;
+    MirrorCard* display_mirror;
     Loader* loader;
     FuriPubSubSubscription* loader_subscription;
     char* app_id;
@@ -100,7 +100,7 @@ static void canvas_check_back_screen_empty(CanvasSrv* canvas) {
         }
     }
     with_gui(canvas->gui, {
-        widget_set_visible(display_mirror_get_base(canvas->display_mirror), back_empty);
+        widget_set_visible(mirror_card_get_base(canvas->display_mirror), back_empty);
     });
 }
 
@@ -597,10 +597,13 @@ static void canvas_screen_open(CanvasSrv* canvas) {
         GuiLayer* draw_layer = gui_get_layer(canvas->gui, GuiLayerIdTop);
         Color background = COLOR_MAKE_HEXA(0x000000FF);
         for(GuiDisplayId i = 0; i < GuiDisplayIdMax; i++) {
-            Widget* root = gui_layer_get_root_widget(draw_layer, i);
-            size_t root_w = widget_get_width(root);
-            size_t root_h = widget_get_height(root);
+            // Get a size from main layer not to cover status bar on back display
+            Widget* main_layer_root =
+                gui_layer_get_root_widget(gui_get_layer(canvas->gui, GuiLayerIdMain), i);
+            size_t root_w = widget_get_width(main_layer_root);
+            size_t root_h = widget_get_height(main_layer_root);
 
+            Widget* root = gui_layer_get_root_widget(draw_layer, i);
             canvas->background[i] = widget_alloc(root);
             widget_set_background_color(canvas->background[i], background);
             widget_set_pos(canvas->background[i], 0, 0);
@@ -619,7 +622,14 @@ static void canvas_screen_open(CanvasSrv* canvas) {
             widget_set_size(canvas->display[i], root_w, root_h);
             widget_set_max_size(canvas->display[i], root_w, root_h);
         }
-        canvas->display_mirror = display_mirror_alloc(canvas->display[GuiDisplayIdBack]);
+        canvas->display_mirror = mirror_card_alloc(canvas->display[GuiDisplayIdBack]);
+        mirror_card_set_header_text(canvas->display_mirror, "ACTIVE");
+        mirror_card_set_show_footer(canvas->display_mirror, false);
+
+        Widget* mirror_base = mirror_card_get_base(canvas->display_mirror);
+        widget_set_align(mirror_base, AlignCenter);
+        widget_set_margin(mirror_base, 0, 0, 2, 2);
+        widget_set_visible(mirror_base, false);
     });
 
     if(is_in_power_off(canvas)) {
@@ -636,7 +646,7 @@ static void canvas_screen_close(CanvasSrv* canvas) {
         GuiLayer* input_layer = gui_get_layer(canvas->gui, GuiLayerIdSystem);
         gui_layer_remove_input_callback(input_layer, canvas_srv_input_callback);
 
-        display_mirror_free(canvas->display_mirror);
+        mirror_card_free(canvas->display_mirror);
         for(GuiDisplayId i = 0; i < GuiDisplayIdMax; i++) {
             widget_free(canvas->display[i]);
             canvas->display[i] = NULL;

--- a/applications/services/device_name/device_name.c
+++ b/applications/services/device_name/device_name.c
@@ -23,10 +23,6 @@ DeviceNameError device_name_validate(const char* name) {
         return DeviceNameErrorEmpty;
     }
 
-    if(strnlen(name, DEVICE_NAME_MAX_SIZE) > DEVICE_NAME_MAX_LENGTH) {
-        return DeviceNameErrorTooLong;
-    }
-
     bool only_contains_spaces = true;
 
     for(size_t i = 0; i < strlen(name); i++) {
@@ -41,6 +37,10 @@ DeviceNameError device_name_validate(const char* name) {
 
     if(only_contains_spaces) {
         return DeviceNameErrorOnlySpaces;
+    }
+
+    if(strnlen(name, DEVICE_NAME_MAX_SIZE) > DEVICE_NAME_MAX_LENGTH) {
+        return DeviceNameErrorTooLong;
     }
 
     return DeviceNameErrorNone;

--- a/applications/services/web_server/http_api/api_wifi.c
+++ b/applications/services/web_server/http_api/api_wifi.c
@@ -176,7 +176,7 @@ static bool api_wifi_get_networks_callback(
             const char* security_str = (mode < WifiSecurityModeMax) ? security_modes[mode] :
                                                                       "Unknown";
             cJSON_AddStringToObject(item, WIFI_JSON_KEY_SECURITY, security_str);
-            cJSON_AddNumberToObject(item, WIFI_JSON_KEY_RSSI, results[i].rssi);
+            cJSON_AddNumberToObject(item, WIFI_JSON_KEY_RSSI, -results[i].rssi);
             cJSON_AddItemToArray(array, item);
         }
 

--- a/applications/services/web_server/resources/apps_assets/web_server/www/openapi.yaml
+++ b/applications/services/web_server/resources/apps_assets/web_server/www/openapi.yaml
@@ -2453,7 +2453,7 @@ components:
           $ref: "#/components/schemas/WifiSecurityMethod"
         rssi:
           type: integer
-          example: 58
+          example: -58
 
     StatusResponse:
       type: object


### PR DESCRIPTION
# What's new
FW-880, FW-921, FW-967, FW-981
- Name set: validating for unsupported chars before length validation
- Wifi scan: rssi values now are negative
- Canvas: MirrorCard instead of DisplayMirror for back screen mirrorring

# Verification 

- See tasks

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
