### PR TITLE
[FW-982] Prevent potential Silabs thread stalls

### DIFF
--- a/applications/services/wifi/wifi.c
+++ b/applications/services/wifi/wifi.c
@@ -5,6 +5,9 @@
 
 #include "wifi_state.h"
 
+#define RESPONSE_QUEUE_SIZE       (4)
+#define RESPONSE_QUEUE_TIMEOUT_MS (200)
+
 #define WIFI_REQUEST_TIMEOUT_MS (5000)
 
 static void wifi_intercom_state_callback(const void* item, void* context) {
@@ -26,8 +29,14 @@ static void wifi_intercom_rx_callback(const void* data, size_t data_size, void* 
     furi_assert(context);
 
     Wifi* instance = context;
-    furi_check(
-        furi_message_queue_put(instance->response_queue, data, FuriWaitForever) == FuriStatusOk);
+
+    const FuriStatus status = furi_message_queue_put(
+        instance->response_queue, data, furi_ms_to_ticks(RESPONSE_QUEUE_TIMEOUT_MS));
+
+    if(status != FuriStatusOk) {
+        furi_check(status == FuriStatusErrorTimeout);
+        FURI_LOG_E(TAG, "BUG: response queue overrun");
+    }
 }
 
 static void wifi_print_connection_info(Wifi* instance) {
@@ -339,7 +348,7 @@ static Wifi* wifi_alloc(void) {
 
     instance->event_loop = furi_event_loop_alloc();
     instance->override_queue = furi_message_queue_alloc(1, sizeof(WifiMessage));
-    instance->response_queue = furi_message_queue_alloc(3, sizeof(WifiResponse));
+    instance->response_queue = furi_message_queue_alloc(RESPONSE_QUEUE_SIZE, sizeof(WifiResponse));
     instance->api_semaphore = furi_semaphore_alloc(1, 1);
     instance->dhcp_semaphore = furi_semaphore_alloc(1, 0);
     instance->state = furi_state_alloc(sizeof(WifiInfo));

--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -287,8 +287,9 @@ static void wifi_net_intercom_rx_callback(const void* data, size_t data_size, vo
         sl_wifi_send_raw_data_frame(SL_WIFI_CLIENT_INTERFACE, data, data_size);
 
     if(status != SL_STATUS_OK) {
-        ++instance->drop_count;
-        FURI_LOG_W(TAG, "Dropped packet (%lu total), reason: 0x%lX", instance->drop_count, status);
+        ++instance->tx_drop_count;
+        FURI_LOG_W(
+            TAG, "TX: Dropped packet (%lu total), reason: 0x%lX", instance->tx_drop_count, status);
     }
 }
 

--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -9,6 +9,8 @@
 #include "wifi_config.h"
 #include "wifi_backend_util.h"
 
+#define EVENT_QUEUE_SIZE 4
+
 #define NUM_CONNECTION_ATTEMPTS 3
 #define SCAN_INTERVAL_S         5
 #define BEACON_MISSED_COUNT     40
@@ -567,7 +569,7 @@ static Wifi* wifi_alloc(void) {
     Wifi* instance = malloc(sizeof(Wifi));
 
     instance->event_loop = furi_event_loop_alloc();
-    instance->event_queue = furi_message_queue_alloc(3, sizeof(WifiEvent));
+    instance->event_queue = furi_message_queue_alloc(EVENT_QUEUE_SIZE, sizeof(WifiEvent));
     instance->event_pubsub = furi_pubsub_alloc();
     instance->info_timer = furi_event_loop_timer_alloc(
         instance->event_loop, wifi_backend_info_callback, FuriEventLoopTimerTypePeriodic, instance);

--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -9,7 +9,8 @@
 #include "wifi_config.h"
 #include "wifi_backend_util.h"
 
-#define EVENT_QUEUE_SIZE 4
+#define EVENT_QUEUE_SIZE       8
+#define EVENT_QUEUE_TIMEOUT_MS 200
 
 #define NUM_CONNECTION_ATTEMPTS 3
 #define SCAN_INTERVAL_S         5
@@ -276,9 +277,13 @@ static void wifi_intercom_rx_callback(const void* data, size_t data_size, void* 
 
     memcpy(&wifi_event.request_received, data, data_size);
 
-    furi_check(
-        furi_message_queue_put(instance->event_queue, &wifi_event, FuriWaitForever) ==
-        FuriStatusOk);
+    const FuriStatus status = furi_message_queue_put(
+        instance->event_queue, &wifi_event, furi_ms_to_ticks(EVENT_QUEUE_TIMEOUT_MS));
+
+    if(status != FuriStatusOk) {
+        furi_check(status == FuriStatusErrorTimeout);
+        FURI_LOG_E(TAG, "BUG: %s failed to deliver event", __FUNCTION__);
+    }
 }
 
 static void wifi_net_intercom_rx_callback(const void* data, size_t data_size, void* context) {
@@ -474,9 +479,13 @@ static sl_status_t wifi_scan_callback(
                 },
         };
 
-        furi_check(
-            furi_message_queue_put(instance->event_queue, &wifi_event, FuriWaitForever) ==
-            FuriStatusOk);
+        const FuriStatus status = furi_message_queue_put(
+            instance->event_queue, &wifi_event, furi_ms_to_ticks(EVENT_QUEUE_TIMEOUT_MS));
+
+        if(status != FuriStatusOk) {
+            furi_check(status == FuriStatusErrorTimeout);
+            FURI_LOG_E(TAG, "BUG: %s failed to deliver event", __FUNCTION__);
+        }
     }
 
     return ret;
@@ -507,9 +516,13 @@ static sl_status_t
                 },
         };
 
-        furi_check(
-            furi_message_queue_put(instance->event_queue, &wifi_event, FuriWaitForever) ==
-            FuriStatusOk);
+        const FuriStatus status = furi_message_queue_put(
+            instance->event_queue, &wifi_event, furi_ms_to_ticks(EVENT_QUEUE_TIMEOUT_MS));
+
+        if(status != FuriStatusOk) {
+            furi_check(status == FuriStatusErrorTimeout);
+            FURI_LOG_E(TAG, "BUG: %s failed to deliver event", __FUNCTION__);
+        }
     }
 
     return ret;

--- a/applications/services/wifi/wifi_backend_i.h
+++ b/applications/services/wifi/wifi_backend_i.h
@@ -22,7 +22,8 @@ struct Wifi {
     FuriSemaphore* tcpip_lock;
     FuriSemaphore* ipv6_ready_semaphore;
     struct netif netif;
-    uint32_t drop_count;
+    uint32_t tx_drop_count;
+    uint32_t rx_drop_count;
     WifiBackendState state;
     bool scan_in_progress;
 };

--- a/applications/services/wifi/wifi_backend_net.c
+++ b/applications/services/wifi/wifi_backend_net.c
@@ -20,6 +20,8 @@
 #define MAX_TRANSFER_UNIT    (1500U)
 #define IP6_READY_TIMEOUT_MS (5000U)
 
+#define INTERCOM_TX_TIMEOUT_MS (200)
+
 static Wifi* instance;
 
 // Tcpip thread synchronisation
@@ -99,8 +101,12 @@ static void wifi_net_intercom_input(const uint8_t* data, uint16_t data_len) {
     furi_check(instance);
 
     const size_t tx_size =
-        intercom_tx(instance->intercom_ch_data, data, data_len, FuriWaitForever);
-    furi_check(tx_size == data_len);
+        intercom_tx(instance->intercom_ch_data, data, data_len, INTERCOM_TX_TIMEOUT_MS);
+
+    if(tx_size != data_len) {
+        ++instance->rx_drop_count;
+        FURI_LOG_W(TAG, "RX: Dropped packet (%lu total)", instance->tx_drop_count);
+    }
 }
 
 static void wifi_net_tcpip_netif_status_callback(struct netif* netif) {


### PR DESCRIPTION
# What's new

[FW-982]

- Prevent potential Silabs thread stalls by introducing finite timeouts instead of `FuriWaitForever`s

# Verification 

1. Flash the firmware bundle.
2. Under normal operation, there should be no errors about failed event deliveries or queue overruns

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-982]: https://flipper.atlassian.net/browse/FW-982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ