### PR TITLE
[FW-983] ISR time stats fix

### DIFF
--- a/applications/services/cli_commands_common/cli_commands.c
+++ b/applications/services/cli_commands_common/cli_commands.c
@@ -95,7 +95,7 @@ void cli_command_top(PipeSide* pipe, FuriString* args, void* context) {
             "Threads: %zu, ISR Time: %0.2f%%, Uptime: %luh%lum%lus" ANSI_ERASE_LINE(
                 ANSI_ERASE_FROM_CURSOR_TO_END) "\r\n",
             furi_thread_list_size(thread_list),
-            (double)furi_thread_list_get_isr_time(thread_list),
+            (double)furi_thread_list_get_isr_time(thread_list) * 100.,
             uptime / 60 / 60,
             uptime / 60 % 60,
             uptime % 60);

--- a/applications/services/cli_commands_common/cli_commands.c
+++ b/applications/services/cli_commands_common/cli_commands.c
@@ -95,7 +95,7 @@ void cli_command_top(PipeSide* pipe, FuriString* args, void* context) {
             "Threads: %zu, ISR Time: %0.2f%%, Uptime: %luh%lum%lus" ANSI_ERASE_LINE(
                 ANSI_ERASE_FROM_CURSOR_TO_END) "\r\n",
             furi_thread_list_size(thread_list),
-            (double)furi_thread_list_get_isr_time(thread_list) * 100.,
+            (double)(furi_thread_list_get_isr_time(thread_list) * 100.),
             uptime / 60 / 60,
             uptime / 60 % 60,
             uptime % 60);

--- a/targets/f21/furi_hal/furi_hal_interrupt.c
+++ b/targets/f21/furi_hal/furi_hal_interrupt.c
@@ -7,12 +7,27 @@
 
 #define FURI_HAL_INTERRUPT_DEFAULT_PRIORITY (configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY + 5)
 
+#ifdef FURI_RAM_EXEC
+#define FURI_HAL_INTERRUPT_ACCOUNT_START()
+#define FURI_HAL_INTERRUPT_ACCOUNT_END()
+#else
+#define FURI_HAL_INTERRUPT_ACCOUNT_START() const uint32_t _isr_start = DWT->CYCCNT;
+#define FURI_HAL_INTERRUPT_ACCOUNT_END()                    \
+    const uint32_t _time_in_isr = DWT->CYCCNT - _isr_start; \
+    furi_hal_interrupt.counter_time_in_isr_total += _time_in_isr;
+#endif
+
 typedef struct {
     FuriHalInterruptISR isr;
     void* context;
 } FuriHalInterruptISRPair;
 
-FuriHalInterruptISRPair furi_hal_interrupt_isr[FuriHalInterruptIdMax] = {0};
+typedef struct {
+    FuriHalInterruptISRPair isr[FuriHalInterruptIdMax];
+    uint32_t counter_time_in_isr_total;
+} FuriHalInterrupt;
+
+static FuriHalInterrupt furi_hal_interrupt = {};
 
 const IRQn_Type furi_hal_interrupt_irqn[FuriHalInterruptIdMax] = {
     // SDMMC
@@ -78,8 +93,10 @@ const IRQn_Type furi_hal_interrupt_irqn[FuriHalInterruptIdMax] = {
 
 __attribute__((always_inline)) static inline void
     furi_hal_interrupt_call(FuriHalInterruptId index) {
-    furi_check(furi_hal_interrupt_isr[index].isr);
-    furi_hal_interrupt_isr[index].isr(furi_hal_interrupt_isr[index].context);
+    FURI_HAL_INTERRUPT_ACCOUNT_START();
+    furi_check(furi_hal_interrupt.isr[index].isr);
+    furi_hal_interrupt.isr[index].isr(furi_hal_interrupt.isr[index].context);
+    FURI_HAL_INTERRUPT_ACCOUNT_END();
 }
 
 __attribute__((always_inline)) static inline void
@@ -155,15 +172,15 @@ void furi_hal_interrupt_set_isr_ex(
 
     if(isr) {
         // Pre ISR set
-        furi_check(furi_hal_interrupt_isr[index].isr == NULL);
+        furi_check(furi_hal_interrupt.isr[index].isr == NULL);
     } else {
         // Pre ISR clear
         furi_hal_interrupt_disable(index);
         furi_hal_interrupt_clear_pending(index);
     }
 
-    furi_hal_interrupt_isr[index].isr = isr;
-    furi_hal_interrupt_isr[index].context = context;
+    furi_hal_interrupt.isr[index].isr = isr;
+    furi_hal_interrupt.isr[index].context = context;
     __DMB();
 
     if(isr) {
@@ -635,8 +652,7 @@ const char* furi_hal_interrupt_get_name(uint8_t exception_number) {
 }
 
 uint32_t furi_hal_interrupt_get_time_in_isr_total(void) {
-    // return furi_hal_interrupt.counter_time_in_isr_total; // TODO
-    return 0;
+    return furi_hal_interrupt.counter_time_in_isr_total;
 }
 
 void furi_hal_interrupt_assert_valid_priority(void) {


### PR DESCRIPTION
# What's new
FW-983
- Fixed isr time calculation and display in `top` command output

# Verification 

- Check `ISR Time:` value in `top` CLI command output

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
