### PR TITLE
[FW-660] Reset MQTT credentials if server rejects them

### DIFF
--- a/applications/services/mqtt/mqtt_connection.c
+++ b/applications/services/mqtt/mqtt_connection.c
@@ -273,6 +273,17 @@ static void mqtt_close_mg_event_handler(
     }
 }
 
+static void mqtt_handle_subscribe_error(Mqtt* instance, MqttReason reason) {
+    FURI_LOG_E(TAG, "Subscribe error 0x%02X", reason);
+
+    if((reason == MqttReasonNotAuthorized) && (instance->status == MqttStatusConnectedLinked)) {
+        FURI_LOG_W(TAG, "Outdated or invalid credentials, resetting");
+        mqtt_reset_saved_state(instance);
+    }
+
+    mqtt_connection_close(instance, false);
+}
+
 static void mqtt_mqtt_cmd_mg_event_handler(
     Mqtt* instance,
     struct mg_connection* connection,
@@ -280,14 +291,12 @@ static void mqtt_mqtt_cmd_mg_event_handler(
     const uint8_t cmd = message->cmd;
 
     if(cmd == MQTT_CMD_SUBACK) {
-        const size_t packet_len = message->dgram.len;
-        const uint8_t sub_reason = message->dgram.buf[packet_len - 1];
+        const MqttReason reason = mqtt_message_get_reason(message);
 
-        FURI_LOG_T(TAG, "MQTT SUBACK: 0x%02X", sub_reason);
+        FURI_LOG_T(TAG, "MQTT SUBACK: 0x%02X", reason);
 
-        if(sub_reason >= MqttQosMax) {
-            FURI_LOG_E(TAG, "Subscribe error 0x%02X", sub_reason);
-            mqtt_connection_close(instance, false);
+        if(reason > MqttReasonGrantedQoS2) {
+            mqtt_handle_subscribe_error(instance, reason);
         }
 
     } else if(cmd == MQTT_CMD_PINGRESP) {

--- a/applications/services/mqtt/mqtt_connection.c
+++ b/applications/services/mqtt/mqtt_connection.c
@@ -291,7 +291,7 @@ static void mqtt_mqtt_cmd_mg_event_handler(
     const uint8_t cmd = message->cmd;
 
     if(cmd == MQTT_CMD_SUBACK) {
-        const MqttReason reason = mqtt_message_get_reason(message);
+        const MqttReason reason = mqtt_message_get_reason_code(message);
 
         FURI_LOG_T(TAG, "MQTT SUBACK: 0x%02X", reason);
 

--- a/applications/services/mqtt/mqtt_connection.c
+++ b/applications/services/mqtt/mqtt_connection.c
@@ -273,10 +273,11 @@ static void mqtt_close_mg_event_handler(
     }
 }
 
-static void mqtt_handle_subscribe_error(Mqtt* instance, MqttReason reason) {
-    FURI_LOG_E(TAG, "Subscribe error 0x%02X", reason);
+static void mqtt_handle_subscribe_error(Mqtt* instance, MqttReasonCode reason_code) {
+    FURI_LOG_E(TAG, "Failed to subscribe, reason: 0x%02X", reason_code);
 
-    if((reason == MqttReasonNotAuthorized) && (instance->status == MqttStatusConnectedLinked)) {
+    if((reason_code == MqttReasonCodeNotAuthorized) &&
+       (instance->status == MqttStatusConnectedLinked)) {
         FURI_LOG_W(TAG, "Outdated or invalid credentials, resetting");
         mqtt_reset_saved_state(instance);
     }
@@ -291,12 +292,13 @@ static void mqtt_mqtt_cmd_mg_event_handler(
     const uint8_t cmd = message->cmd;
 
     if(cmd == MQTT_CMD_SUBACK) {
-        const MqttReason reason = mqtt_message_get_reason_code(message);
+        const struct mg_str datagram = message->dgram;
+        const MqttReasonCode reason_code = datagram.buf[datagram.len - 1];
 
-        FURI_LOG_T(TAG, "MQTT SUBACK: 0x%02X", reason);
+        FURI_LOG_T(TAG, "MQTT SUBACK: 0x%02X", reason_code);
 
-        if(reason > MqttReasonGrantedQoS2) {
-            mqtt_handle_subscribe_error(instance, reason);
+        if(reason_code > MqttReasonCodeGrantedQoS2) {
+            mqtt_handle_subscribe_error(instance, reason_code);
         }
 
     } else if(cmd == MQTT_CMD_PINGRESP) {

--- a/applications/services/mqtt/mqtt_i.h
+++ b/applications/services/mqtt/mqtt_i.h
@@ -40,7 +40,7 @@
 #define TO_RAW_MESSAGE(msg)  ((struct mg_mqtt_message*)(msg))
 #define TO_MQTT_MESSAGE(msg) ((MqttMessage*)(msg))
 
-// Source: https://www.emqx.com/en/blog/mqtt5-new-features-reason-code-and-ack
+// Source: https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901031
 typedef enum {
     MqttReasonSuccess = 0x0,
     MqttReasonGrantedQoS0 = MqttReasonSuccess,

--- a/applications/services/mqtt/mqtt_i.h
+++ b/applications/services/mqtt/mqtt_i.h
@@ -220,7 +220,7 @@ bool mqtt_publish_internal(
     const MqttProperty* props,
     uint32_t props_count);
 
-MqttReason mqtt_message_get_reason(const struct mg_mqtt_message* message);
+MqttReason mqtt_message_get_reason_code(const struct mg_mqtt_message* message);
 
 void mqtt_property_to_raw(const MqttProperty* property, struct mg_mqtt_prop* raw_property);
 

--- a/applications/services/mqtt/mqtt_i.h
+++ b/applications/services/mqtt/mqtt_i.h
@@ -40,6 +40,17 @@
 #define TO_RAW_MESSAGE(msg)  ((struct mg_mqtt_message*)(msg))
 #define TO_MQTT_MESSAGE(msg) ((MqttMessage*)(msg))
 
+// Source: https://www.emqx.com/en/blog/mqtt5-new-features-reason-code-and-ack
+typedef enum {
+    MqttReasonSuccess = 0x0,
+    MqttReasonGrantedQoS0 = MqttReasonSuccess,
+    MqttReasonGrantedQoS1,
+    MqttReasonGrantedQoS2,
+    // Reason codes 0x4 ... 0x86 omitted for clarity
+    MqttReasonNotAuthorized = 0x87,
+    // Reason codse 0x88 ... 0xA2 omitted for clarity
+} MqttReason;
+
 typedef enum {
     MqttScopeDevice,
     MqttScopeSession,
@@ -208,6 +219,8 @@ bool mqtt_publish_internal(
     size_t data_size,
     const MqttProperty* props,
     uint32_t props_count);
+
+MqttReason mqtt_message_get_reason(const struct mg_mqtt_message* message);
 
 void mqtt_property_to_raw(const MqttProperty* property, struct mg_mqtt_prop* raw_property);
 

--- a/applications/services/mqtt/mqtt_i.h
+++ b/applications/services/mqtt/mqtt_i.h
@@ -48,7 +48,7 @@ typedef enum {
     MqttReasonGrantedQoS2,
     // Reason codes 0x4 ... 0x86 omitted for clarity
     MqttReasonNotAuthorized = 0x87,
-    // Reason codse 0x88 ... 0xA2 omitted for clarity
+    // Reason codes 0x88 ... 0xA2 omitted for clarity
 } MqttReason;
 
 typedef enum {

--- a/applications/services/mqtt/mqtt_i.h
+++ b/applications/services/mqtt/mqtt_i.h
@@ -42,14 +42,16 @@
 
 // Source: https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901031
 typedef enum {
-    MqttReasonSuccess = 0x0,
-    MqttReasonGrantedQoS0 = MqttReasonSuccess,
-    MqttReasonGrantedQoS1,
-    MqttReasonGrantedQoS2,
-    // Reason codes 0x4 ... 0x86 omitted for clarity
-    MqttReasonNotAuthorized = 0x87,
+    MqttReasonCodeSuccess = 0x0,
+    MqttReasonCodeGrantedQoS0 = MqttReasonCodeSuccess,
+    MqttReasonCodeGrantedQoS1,
+    MqttReasonCodeGrantedQoS2,
+    // Reason codes 0x4 ... 0x19 omitted for clarity
+    MqttReasonCodeUnspecifiedError = 0x80,
+    // Reason codes 0x81 ... 0x86 omitted for clarity
+    MqttReasonCodeNotAuthorized = 0x87,
     // Reason codes 0x88 ... 0xA2 omitted for clarity
-} MqttReason;
+} MqttReasonCode;
 
 typedef enum {
     MqttScopeDevice,
@@ -219,8 +221,6 @@ bool mqtt_publish_internal(
     size_t data_size,
     const MqttProperty* props,
     uint32_t props_count);
-
-MqttReason mqtt_message_get_reason_code(const struct mg_mqtt_message* message);
 
 void mqtt_property_to_raw(const MqttProperty* property, struct mg_mqtt_prop* raw_property);
 

--- a/applications/services/mqtt/mqtt_message.c
+++ b/applications/services/mqtt/mqtt_message.c
@@ -126,23 +126,6 @@ bool mqtt_message_get_integer_property(
     return success;
 }
 
-MqttReason mqtt_message_get_reason_code(const struct mg_mqtt_message* message) {
-    MqttReason reason;
-
-    const uint8_t command = message->cmd;
-    const struct mg_str datagram = message->dgram;
-
-    if(command == MQTT_CMD_SUBACK) {
-        reason = datagram.buf[datagram.len - 1];
-
-    } else {
-        // TODO: Implement more command types as needed
-        furi_crash("No MQTT reason code spec for this command");
-    }
-
-    return reason;
-}
-
 // https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901029
 static const MqttPropertyDesc mqtt_property_desc_table[MqttPropertyTypeMax] = {
     [MqttPropertyTypeExpiryInterval] =

--- a/applications/services/mqtt/mqtt_message.c
+++ b/applications/services/mqtt/mqtt_message.c
@@ -126,6 +126,11 @@ bool mqtt_message_get_integer_property(
     return success;
 }
 
+MqttReason mqtt_message_get_reason(const struct mg_mqtt_message* message) {
+    const struct mg_str dgram = message->dgram;
+    return dgram.buf[dgram.len - 1];
+}
+
 // https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901029
 static const MqttPropertyDesc mqtt_property_desc_table[MqttPropertyTypeMax] = {
     [MqttPropertyTypeExpiryInterval] =

--- a/applications/services/mqtt/mqtt_message.c
+++ b/applications/services/mqtt/mqtt_message.c
@@ -126,9 +126,21 @@ bool mqtt_message_get_integer_property(
     return success;
 }
 
-MqttReason mqtt_message_get_reason(const struct mg_mqtt_message* message) {
-    const struct mg_str dgram = message->dgram;
-    return dgram.buf[dgram.len - 1];
+MqttReason mqtt_message_get_reason_code(const struct mg_mqtt_message* message) {
+    MqttReason reason;
+
+    const uint8_t command = message->cmd;
+    const struct mg_str datagram = message->dgram;
+
+    if(command == MQTT_CMD_SUBACK) {
+        reason = datagram.buf[datagram.len - 1];
+
+    } else {
+        // TODO: Implement more command types as needed
+        furi_crash("No MQTT reason code spec for this command");
+    }
+
+    return reason;
 }
 
 // https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901029


### PR DESCRIPTION
# What's new

[FW-660]

- Reset MQTT credentials and if the server returns an authorisation error and reconnect

# Verification 

1. Flash the firmware bundle
2. Ensure that the DUT is linked to the cloud
3. Change one or more characters in `token` field in `/ext/apps_data/mqtt/state.json` file
4. Reboot the DUT while paying attention to the logs
5. Ensure that after one authorisation error, the above file is reset
6. Go to `Settings->Account` and ensure that DUT is no more linked
7. Perform the linking procedure and ensure that it works as expected

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-660]: https://flipper.atlassian.net/browse/FW-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ