### PR TITLE
[FW-990] HTTP API connection close fixes

### DIFF
--- a/applications/debug/unit_tests/timer_test/timer_test.c
+++ b/applications/debug/unit_tests/timer_test/timer_test.c
@@ -3,6 +3,7 @@
 #include <toolbox/timers.h>
 
 #define COARSE_TIMER_TIMEOUT_MS (10)
+#define COARSE_TIMER_ABSTOL_MS  (2)
 
 #define PRECISE_TIMER_TIMEOUT_US (1000)
 #define PRECISE_TIMER_ABSTOL_US  (5)
@@ -44,7 +45,9 @@ MU_TEST(coarse_timer_test) {
 
     mu_assert_int_eq(0, elapsed_start_ms);
     mu_assert_int_between(
-        COARSE_TIMER_TIMEOUT_MS - 1, COARSE_TIMER_TIMEOUT_MS + 1, (int32_t)elapsed_end_ms);
+        COARSE_TIMER_TIMEOUT_MS - COARSE_TIMER_ABSTOL_MS,
+        COARSE_TIMER_TIMEOUT_MS + COARSE_TIMER_ABSTOL_MS,
+        (int32_t)elapsed_end_ms);
 }
 
 MU_TEST(precise_timer_test) {

--- a/applications/services/web_server/http_api/api_account.c
+++ b/applications/services/web_server/http_api/api_account.c
@@ -111,7 +111,7 @@ static void mqtt_link_timeout(void* data) {
     furi_assert(data);
     MqttLinkContext* link_ctx = data;
 
-    MG_REPLY_INTERNAL_ERROR(link_ctx->conn, "PIN request timeout");
+    MG_REPLY_ERROR_CLOSE(link_ctx->conn, 500, "PIN request timeout");
     link_ctx->conn->is_draining = true;
 }
 
@@ -128,7 +128,12 @@ static void mqtt_link_wakeup_callback(struct mg_connection* conn, void* data, si
     furi_string_cat_printf(json_str, "\"%s\":\"%s\",", "code", link_ctx->pin);
     furi_string_cat_printf(json_str, "\"%s\":%lu", "expires_at", link_ctx->pin_expires_at);
 
-    MG_REPLY_OK_BODY(conn, "{%s}\n", furi_string_get_cstr(json_str));
+    mg_http_reply(
+        conn,
+        200,
+        DEFAULT_JSON_HEADERS "Connection: close\r\n",
+        "{%s}\n",
+        furi_string_get_cstr(json_str));
     furi_string_free(json_str);
     conn->is_draining = true;
 }

--- a/applications/services/web_server/http_api/api_account.c
+++ b/applications/services/web_server/http_api/api_account.c
@@ -219,7 +219,7 @@ static bool http_api_account_unlink(
         http_reply_cors_preflight(conn, HttpMethodDelete);
         return true;
     } else if(method != HttpMethodDelete) {
-        http_reply_405_method_not_allowed(conn, HttpMethodDelete);
+        http_reply_405_method_not_allowed(conn, HttpMethodDelete, false);
         return true;
     }
 

--- a/applications/services/web_server/http_api/api_assets.c
+++ b/applications/services/web_server/http_api/api_assets.c
@@ -46,8 +46,7 @@ static bool api_assets_upload_headers_callback(
     if(api_assets_upload_parse_parameters(&msg->query, file_path)) {
         http_upload_start(conn, msg, furi_string_get_cstr(file_path));
     } else {
-        MG_REPLY_BAD_REQUEST(conn);
-        MG_CLOSE_AFTER_HEADERS(conn, msg);
+        MG_REPLY_ERROR_CLOSE(conn, 400, "Bad Request");
     }
 
     furi_string_free(file_path);

--- a/applications/services/web_server/http_api/api_audio.c
+++ b/applications/services/web_server/http_api/api_audio.c
@@ -34,7 +34,7 @@ static void audio_stop_wakeup_callback(struct mg_connection* conn, void* data, s
     StopResponseContext* ctx = conn_ctx->context;
     furi_assert(ctx);
 
-    MG_REPLY_OK(conn);
+    MG_REPLY_OK_CLOSE(conn);
     conn->is_draining = true;
 }
 
@@ -42,7 +42,7 @@ static void audio_stop_timeout(void* data) {
     furi_assert(data);
     StopResponseContext* ctx = data;
 
-    MG_REPLY_INTERNAL_ERROR(ctx->conn, "Audio stop timeout");
+    MG_REPLY_ERROR_CLOSE(ctx->conn, 500, "Audio stop timeout");
     ctx->conn->is_draining = true;
 }
 

--- a/applications/services/web_server/http_api/api_name.c
+++ b/applications/services/web_server/http_api/api_name.c
@@ -74,7 +74,7 @@ bool http_api_name_callback(
 
         furi_string_free(name);
     } else {
-        http_reply_405_method_not_allowed(conn, HttpMethodPost | HttpMethodGet);
+        http_reply_405_method_not_allowed(conn, HttpMethodPost | HttpMethodGet, false);
     }
 
     return true;

--- a/applications/services/web_server/http_api/api_root.c
+++ b/applications/services/web_server/http_api/api_root.c
@@ -555,7 +555,7 @@ bool http_api_root_callback(
         } else if(method == HttpMethodOptions) {
             http_reply_cors_preflight(conn, HttpMethodGet | HttpMethodPost);
         } else {
-            http_reply_405_method_not_allowed(conn, HttpMethodPost | HttpMethodGet);
+            http_reply_405_method_not_allowed(conn, HttpMethodPost | HttpMethodGet, false);
         }
         handled = true;
     } else {

--- a/applications/services/web_server/http_api/api_root.c
+++ b/applications/services/web_server/http_api/api_root.c
@@ -343,17 +343,17 @@ static bool http_api_is_version_allowed(
 
         struct mg_str major_ver_str;
         if(!mg_span(*request_semver, &major_ver_str, NULL, '.')) {
-            MG_REPLY_BAD_REQUEST(conn);
+            MG_REPLY_ERROR_CLOSE(conn, 400, "Bad Request");
             return false;
         }
 
         if(!mg_str_to_num(major_ver_str, 10, &major_ver, sizeof(major_ver))) {
-            MG_REPLY_BAD_REQUEST(conn);
+            MG_REPLY_ERROR_CLOSE(conn, 400, "Bad Request");
             return false;
         }
 
         if(major_ver != api_ver[0]) {
-            MG_REPLY_INVALID_VERSION(conn);
+            MG_REPLY_ERROR_CLOSE(conn, 405, "Incompatible API version");
             return false;
         }
     }
@@ -577,7 +577,7 @@ bool http_api_root_hdr_callback(
     // OPTIONS preflights fall through to MG_EV_HTTP_MSG for http_reply_cors_preflight()
 
     if(!http_api_is_access_allowed(context, path, method, conn, msg)) {
-        MG_REPLY_FORBIDDEN(conn);
+        MG_REPLY_ERROR_CLOSE(conn, 403, "Forbidden");
         http_api_log_access(conn, msg, 403);
         MG_CLOSE_AFTER_HEADERS(conn, msg);
         return true;

--- a/applications/services/web_server/http_api/api_status.c
+++ b/applications/services/web_server/http_api/api_status.c
@@ -198,7 +198,7 @@ bool http_api_status_callback(
             return true;
         }
         if(method != HttpMethodGet) {
-            http_reply_405_method_not_allowed(conn, HttpMethodGet);
+            http_reply_405_method_not_allowed(conn, HttpMethodGet, false);
             return true;
         }
         FuriString* json_response = furi_string_alloc();
@@ -235,7 +235,7 @@ bool http_api_status_callback(
                 return true;
             }
             if(method != HttpMethodGet) {
-                http_reply_405_method_not_allowed(conn, HttpMethodGet);
+                http_reply_405_method_not_allowed(conn, HttpMethodGet, false);
                 return true;
             }
             FuriString* json_response = furi_string_alloc();

--- a/applications/services/web_server/http_api/api_storage.c
+++ b/applications/services/web_server/http_api/api_storage.c
@@ -50,8 +50,7 @@ static bool api_storage_write_headers_callback(
     if(api_storage_parse_path_parameter(&msg->query, "path", file_path)) {
         http_upload_start(conn, msg, furi_string_get_cstr(file_path));
     } else {
-        MG_REPLY_BAD_REQUEST(conn);
-        MG_CLOSE_AFTER_HEADERS(conn, msg);
+        MG_REPLY_ERROR_CLOSE(conn, 400, "Bad Request");
     }
 
     furi_string_free(file_path);

--- a/applications/services/web_server/http_api/api_time.c
+++ b/applications/services/web_server/http_api/api_time.c
@@ -26,7 +26,7 @@ static bool api_time_get_timestamp_callback(
         http_reply_cors_preflight(conn, HttpMethodGet);
         return true;
     } else if(method != HttpMethodGet) {
-        http_reply_405_method_not_allowed(conn, HttpMethodGet);
+        http_reply_405_method_not_allowed(conn, HttpMethodGet, false);
         return true;
     }
 

--- a/applications/services/web_server/http_api/api_update.c
+++ b/applications/services/web_server/http_api/api_update.c
@@ -335,7 +335,7 @@ static bool api_update_raw_hdr_callback(
 
     if(method == HttpMethodOptions) return false; // let MG_EV_HTTP_MSG respond with preflight
     if(method != HttpMethodPost) {
-        http_reply_405_method_not_allowed(conn, HttpMethodPost);
+        http_reply_405_method_not_allowed(conn, HttpMethodPost, true);
         conn->is_draining = 1;
         return true;
     }

--- a/applications/services/web_server/http_api/api_update.c
+++ b/applications/services/web_server/http_api/api_update.c
@@ -169,7 +169,7 @@ static bool
                 "Update not allowed: %s", updater_get_status_string(session_start_status));
 
             FURI_LOG_E(TAG, furi_string_get_cstr(error_string));
-            MG_REPLY_ERROR(conn, 400, furi_string_get_cstr(error_string));
+            MG_REPLY_ERROR_CLOSE(conn, 400, furi_string_get_cstr(error_string));
 
             furi_string_free(error_string);
             break;
@@ -183,7 +183,7 @@ static bool
                 "Update bundle unpack failed: %s", updater_get_status_string(unpack_tar_status));
 
             FURI_LOG_E(TAG, furi_string_get_cstr(error_string));
-            MG_REPLY_ERROR(conn, 400, furi_string_get_cstr(error_string));
+            MG_REPLY_ERROR_CLOSE(conn, 400, furi_string_get_cstr(error_string));
 
             furi_string_free(error_string);
             break;
@@ -197,7 +197,7 @@ static bool
                 updater_get_status_string(installation_prepare_status));
 
             FURI_LOG_E(TAG, furi_string_get_cstr(error_string));
-            MG_REPLY_ERROR(conn, 400, furi_string_get_cstr(error_string));
+            MG_REPLY_ERROR_CLOSE(conn, 400, furi_string_get_cstr(error_string));
 
             furi_string_free(error_string);
             break;
@@ -205,8 +205,11 @@ static bool
 
         FURI_LOG_I(TAG, "Device will reboot...");
 
-        MG_REPLY_OK_BODY(
-            conn, "{\"result\":\"OK\",\"message\":\"Update accepted. System will reboot.\"}\n");
+        mg_http_reply(
+            conn,
+            200,
+            DEFAULT_JSON_HEADERS "Connection: close\r\n",
+            "{\"result\":\"OK\",\"message\":\"Update accepted. System will reboot.\"}\n");
 
         conn->is_draining = 1;
 
@@ -228,6 +231,7 @@ static void api_update_on_data_cb(struct mg_connection* conn, struct mg_iobuf* i
 
     if(!update_ctx || !update_ctx->file_save) {
         FURI_LOG_E(TAG, "on_data: Context or file saver invalid/closed. Draining.");
+        MG_REPLY_ERROR_CLOSE(conn, 500, "Update context invalid");
         mg_iobuf_del(io, 0, io->len); // Consume data to prevent further calls
         conn->is_draining = 1; // Mark connection to be closed
         return;
@@ -250,7 +254,7 @@ static void api_update_on_data_cb(struct mg_connection* conn, struct mg_iobuf* i
                 "on_data: Received more data than expected. Expected %zu, got %zu more.",
                 update_ctx->total_file_size,
                 (update_ctx->received_file_size + data_len) - update_ctx->total_file_size);
-            MG_REPLY_PAYLOAD_TOO_LARGE(conn);
+            MG_REPLY_ERROR_CLOSE(conn, 413, "Payload Too Large");
             conn->is_draining = 1;
             mg_iobuf_del(io, 0, io->len);
             return;
@@ -259,7 +263,7 @@ static void api_update_on_data_cb(struct mg_connection* conn, struct mg_iobuf* i
         if(!fetch_file_save_write(update_ctx->file_save, io->buf, data_len)) {
             FURI_LOG_E(
                 TAG, "on_data: Failed to write data to temp TAR file. Wrote %zu bytes.", data_len);
-            MG_REPLY_INTERNAL_ERROR(conn, "Failed to save update package (write error).");
+            MG_REPLY_ERROR_CLOSE(conn, 500, "Failed to save update package (write error).");
             conn->is_draining = 1;
             mg_iobuf_del(io, 0, io->len);
             return;
@@ -309,6 +313,7 @@ static void api_update_on_poll_cb(struct mg_connection* conn) {
 
     if(mg_timer_expired(&update_ctx->timeout_stamp, UPDATE_UPLOAD_IDLE_TIMEOUT_MS, mg_millis())) {
         FURI_LOG_E(TAG, "Connection data timeout (%lu)", conn->id);
+        MG_REPLY_ERROR_CLOSE(conn, 408, "Upload timeout");
         conn->is_draining = 1; // Force close hanging connection
     }
 }
@@ -337,7 +342,7 @@ static bool api_update_raw_hdr_callback(
 
     if(msg->body.len == 0) {
         FURI_LOG_W(TAG, "on_headers: Content-Length is 0 or missing/invalid. No file to upload?");
-        MG_REPLY_BAD_REQUEST(conn);
+        MG_REPLY_ERROR_CLOSE(conn, 400, "Bad Request");
         conn->is_draining = 1;
         return true;
     }
@@ -356,7 +361,7 @@ static bool api_update_raw_hdr_callback(
             "on_headers: File size %zu exceeds max %u.",
             update_ctx->total_file_size,
             MAX_UPLOAD_FILE_SIZE);
-        MG_REPLY_PAYLOAD_TOO_LARGE(conn);
+        MG_REPLY_ERROR_CLOSE(conn, 413, "Payload Too Large");
         conn->is_draining = 1;
         return true;
     }
@@ -374,7 +379,7 @@ static bool api_update_raw_hdr_callback(
             TAG,
             "on_headers: Failed to initialize file saver for: %s",
             UPDATER_DEFAULT_DOWNLOAD_PATH);
-        MG_REPLY_INTERNAL_ERROR(conn, "Failed to save update package (file init error).");
+        MG_REPLY_ERROR_CLOSE(conn, 500, "Failed to save update package (file init error).");
         conn->is_draining = 1;
         return true;
     }

--- a/applications/services/web_server/web_server.c
+++ b/applications/services/web_server/web_server.c
@@ -65,7 +65,7 @@ static HttpMethod http_method_from_str(struct mg_http_message* msg) {
 #define HTTP_API_METHODS \
     ((HttpMethod)(HttpMethodGet | HttpMethodPost | HttpMethodPut | HttpMethodDelete))
 
-void http_reply_405_method_not_allowed(struct mg_connection* conn, HttpMethod allowed_methods) {
+void http_reply_405_method_not_allowed(struct mg_connection* conn, HttpMethod allowed_methods, bool close) {
     if(allowed_methods & HttpMethodWebSocket) {
         allowed_methods = (HttpMethod)((allowed_methods & ~HttpMethodWebSocket) | HttpMethodGet);
     }
@@ -80,7 +80,9 @@ void http_reply_405_method_not_allowed(struct mg_connection* conn, HttpMethod al
         }
     }
     furi_string_cat(headers, "\r\n");
-    furi_string_cat(headers, "Connection: close\r\n");
+    if(close) {
+        furi_string_cat(headers, "Connection: close\r\n");
+    }
     MG_REPLY_METHOD_NOT_ALLOWED(conn, furi_string_get_cstr(headers));
     furi_string_free(headers);
 }
@@ -450,7 +452,7 @@ bool http_handle_request(
                 break;
             }
             if(method == HttpMethodUnknown) {
-                http_reply_405_method_not_allowed(conn, inst->handler->method);
+                http_reply_405_method_not_allowed(conn, inst->handler->method, false);
                 handled = true;
                 break;
             }
@@ -458,7 +460,7 @@ bool http_handle_request(
                 if(method == HttpMethodOptions) {
                     http_reply_cors_preflight(conn, inst->handler->method);
                 } else {
-                    http_reply_405_method_not_allowed(conn, inst->handler->method);
+                    http_reply_405_method_not_allowed(conn, inst->handler->method, false);
                 }
                 handled = true;
                 break;
@@ -501,7 +503,7 @@ bool http_handle_headers(
                 break;
             }
             if(method == HttpMethodUnknown) {
-                http_reply_405_method_not_allowed(conn, inst->handler->method);
+                http_reply_405_method_not_allowed(conn, inst->handler->method, true);
                 MG_CLOSE_AFTER_HEADERS(conn, msg);
                 handled = true;
                 break;
@@ -509,7 +511,7 @@ bool http_handle_headers(
             if(!(method & inst->handler->method)) {
                 // OPTIONS preflight: let http_handle_request (MG_EV_HTTP_MSG) respond
                 if(method != HttpMethodOptions) {
-                    http_reply_405_method_not_allowed(conn, inst->handler->method);
+                    http_reply_405_method_not_allowed(conn, inst->handler->method, true);
                     MG_CLOSE_AFTER_HEADERS(conn, msg);
                     handled = true;
                 }

--- a/applications/services/web_server/web_server.c
+++ b/applications/services/web_server/web_server.c
@@ -80,6 +80,7 @@ void http_reply_405_method_not_allowed(struct mg_connection* conn, HttpMethod al
         }
     }
     furi_string_cat(headers, "\r\n");
+    furi_string_cat(headers, "Connection: close\r\n");
     MG_REPLY_METHOD_NOT_ALLOWED(conn, furi_string_get_cstr(headers));
     furi_string_free(headers);
 }
@@ -179,6 +180,7 @@ static void http_upload_poll_callback(struct mg_connection* conn) {
 
     if(mg_timer_expired(&upload_ctx->timeout_stamp, HTTP_UPLOAD_IDLE_TIMEOUT_MS, mg_millis())) {
         FURI_LOG_E(TAG, "Connection data timeout (%lu)", conn->id);
+        MG_REPLY_ERROR_CLOSE(conn, 408, "Upload timeout");
         conn->is_draining = 1; // Force close hanging connection
     }
 }
@@ -208,7 +210,7 @@ void http_upload_start(
     upload_ctx->file = http_fs_get()->op(file_path, MG_FS_WRITE); // Open file for writing
 
     if(upload_ctx->file == NULL) {
-        MG_REPLY_INTERNAL_ERROR(conn, "Failed to open file for writing");
+        MG_REPLY_ERROR_CLOSE(conn, 500, "Failed to open file for writing");
         conn->is_draining = 1;
     }
 

--- a/applications/services/web_server/web_server.c
+++ b/applications/services/web_server/web_server.c
@@ -65,7 +65,10 @@ static HttpMethod http_method_from_str(struct mg_http_message* msg) {
 #define HTTP_API_METHODS \
     ((HttpMethod)(HttpMethodGet | HttpMethodPost | HttpMethodPut | HttpMethodDelete))
 
-void http_reply_405_method_not_allowed(struct mg_connection* conn, HttpMethod allowed_methods, bool close) {
+void http_reply_405_method_not_allowed(
+    struct mg_connection* conn,
+    HttpMethod allowed_methods,
+    bool close) {
     if(allowed_methods & HttpMethodWebSocket) {
         allowed_methods = (HttpMethod)((allowed_methods & ~HttpMethodWebSocket) | HttpMethodGet);
     }

--- a/applications/services/web_server/web_server_i.h
+++ b/applications/services/web_server/web_server_i.h
@@ -38,6 +38,14 @@
 #define MG_REPLY_OK_CLOSE(conn) \
     mg_http_reply(conn, 200, DEFAULT_JSON_HEADERS "Connection: close\r\n", RESPONSE_BODY_OK)
 
+#define MG_REPLY_ERROR_CLOSE(conn, code, ...)                                 \
+    mg_http_reply(                                                           \
+        conn,                                                                \
+        code,                                                                \
+        DEFAULT_JSON_HEADERS "Connection: close\r\n",                        \
+        "{\"error\":\"%s\"}\n",                                       \
+        M_IF_EMPTY(__VA_ARGS__)("failed", __VA_ARGS__))
+
 #define MG_REPLY_ERROR(conn, code, ...) \
     _MG_JSON_RESULT(                    \
         conn,                           \

--- a/applications/services/web_server/web_server_i.h
+++ b/applications/services/web_server/web_server_i.h
@@ -179,7 +179,7 @@ void http_handler_remove(HttpHandlersList_t list, const HttpHandler* handler);
 
 void http_handler_remove_all(HttpHandlersList_t list);
 
-void http_reply_405_method_not_allowed(struct mg_connection* conn, HttpMethod allowed_methods);
+void http_reply_405_method_not_allowed(struct mg_connection* conn, HttpMethod allowed_methods, bool close);
 void http_reply_cors_preflight(struct mg_connection* conn, HttpMethod allowed_methods);
 
 void http_upload_start(

--- a/applications/services/web_server/web_server_i.h
+++ b/applications/services/web_server/web_server_i.h
@@ -38,12 +38,12 @@
 #define MG_REPLY_OK_CLOSE(conn) \
     mg_http_reply(conn, 200, DEFAULT_JSON_HEADERS "Connection: close\r\n", RESPONSE_BODY_OK)
 
-#define MG_REPLY_ERROR_CLOSE(conn, code, ...)                                 \
-    mg_http_reply(                                                           \
-        conn,                                                                \
-        code,                                                                \
-        DEFAULT_JSON_HEADERS "Connection: close\r\n",                        \
-        "{\"error\":\"%s\"}\n",                                       \
+#define MG_REPLY_ERROR_CLOSE(conn, code, ...)         \
+    mg_http_reply(                                    \
+        conn,                                         \
+        code,                                         \
+        DEFAULT_JSON_HEADERS "Connection: close\r\n", \
+        "{\"error\":\"%s\"}\n",                       \
         M_IF_EMPTY(__VA_ARGS__)("failed", __VA_ARGS__))
 
 #define MG_REPLY_ERROR(conn, code, ...) \

--- a/applications/services/web_server/web_server_i.h
+++ b/applications/services/web_server/web_server_i.h
@@ -179,7 +179,10 @@ void http_handler_remove(HttpHandlersList_t list, const HttpHandler* handler);
 
 void http_handler_remove_all(HttpHandlersList_t list);
 
-void http_reply_405_method_not_allowed(struct mg_connection* conn, HttpMethod allowed_methods, bool close);
+void http_reply_405_method_not_allowed(
+    struct mg_connection* conn,
+    HttpMethod allowed_methods,
+    bool close);
 void http_reply_cors_preflight(struct mg_connection* conn, HttpMethod allowed_methods);
 
 void http_upload_start(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -351,7 +351,7 @@ def pytest_runtest_teardown(item, nextitem):
 
 
 def _probe_api_health(
-    base_url: str, session: Optional[requests.Session] = None
+    base_url: str, session: Optional[requests.Session] = None, retries: int = 3
 ) -> Optional[str]:
     """Cheap HTTP liveness probe for /api/version.
 
@@ -362,19 +362,38 @@ def _probe_api_health(
     reuse the same connection. Avoid `Connection: close`: on the device-side
     lwIP stack that can make the firmware the active TCP closer and keep TCP
     PCBs occupied long enough to trip the PR #699 overload guard.
+
+    Retries up to *retries* times on ConnectionError (e.g. ConnectionResetError
+    after a debug-probe reset where TCP is open but the HTTP event loop hasn't
+    started yet). Non-connection errors and HTTP error codes are not retried.
     """
     own_session = session is None
     probe_session = session or requests.Session()
+
+    last_error: Optional[str] = None
     try:
-        with probe_session.get(f"{base_url}/api/version", timeout=2.0) as response:
-            if response.status_code != 200:
-                return f"HTTP {response.status_code}"
-    except requests.RequestException as exc:
-        return f"{type(exc).__name__}: {exc}"
+        for attempt in range(retries):
+            try:
+                with probe_session.get(
+                    f"{base_url}/api/version", timeout=2.0
+                ) as response:
+                    if response.status_code != 200:
+                        return f"HTTP {response.status_code}"
+                # Success — clear error, return.
+                last_error = None
+                break
+            except requests.ConnectionError as exc:
+                last_error = f"{type(exc).__name__}: {exc}"
+                if attempt < retries - 1:
+                    time.sleep(0.5 * (attempt + 1))
+            except requests.RequestException as exc:
+                last_error = f"{type(exc).__name__}: {exc}"
+                break
     finally:
         if own_session:
             probe_session.close()
-    return None
+
+    return last_error
 
 
 def _pre_test_reset_reason(device_flasher, web_base_url: str, web_session) -> Optional[str]:

--- a/tests/integration/frontend/busy/test_api_busy.py
+++ b/tests/integration/frontend/busy/test_api_busy.py
@@ -91,6 +91,23 @@ def _front_frame_has_content(frame: bytes) -> bool:
     return any(frame)
 
 
+def _wait_for_front_frame_content(
+    streaming_api: StreamingAPI,
+    *,
+    display: int = 0,
+    attempts: int = 15,
+    poll_interval_s: float = 0.2,
+) -> bytes:
+    """Retry screen capture until the front display contains non-zero pixels."""
+    last_frame = b""
+    for _ in range(attempts):
+        last_frame = streaming_api.get_screen_bytes(display=display)
+        if _front_frame_has_content(last_frame):
+            return last_frame
+        time.sleep(poll_interval_s)
+    return last_frame
+
+
 @allure.feature("5. Web Frontend")
 @allure.story("Busy Timer")
 class TestBusySnapshotAPI:
@@ -306,7 +323,7 @@ class TestBusyThemeRegressions:
         assert busy_api.set_snapshot_raw(body).status_code == 200
         wait_for_snapshot_type(api_session, web_base_url, "SIMPLE")
 
-        frame = streaming_api.get_screen_bytes(display=0)
+        frame = _wait_for_front_frame_content(streaming_api, display=0)
         assert _front_frame_has_content(frame)
 
 

--- a/tests/integration/frontend/state_publisher/test_state_publisher_wifi_regression.py
+++ b/tests/integration/frontend/state_publisher/test_state_publisher_wifi_regression.py
@@ -39,11 +39,13 @@ def test_wifi_connect_disconnect_publishes(state_publisher_ws, wifi_api):
 
     connected_update = state_publisher_ws.wait_for(
         lambda u: u.WhichOneof("state") == "wifi"
-        and u.wifi.WhichOneof("wifi_state") == "connected",
+        and u.wifi.WhichOneof("wifi_state") == "active"
+        and u.wifi.active.status == 0,
         timeout=20.0,
     )
     assert connected_update.WhichOneof("state") == "wifi"
-    assert connected_update.wifi.WhichOneof("wifi_state") == "connected"
+    assert connected_update.wifi.WhichOneof("wifi_state") == "active"
+    assert connected_update.wifi.active.status == 0
 
     # --- disconnect ---
     state_publisher_ws.drain()
@@ -53,8 +55,8 @@ def test_wifi_connect_disconnect_publishes(state_publisher_ws, wifi_api):
 
     disconnected_update = state_publisher_ws.wait_for(
         lambda u: u.WhichOneof("state") == "wifi"
-        and u.wifi.WhichOneof("wifi_state") == "disconnected",
+        and u.wifi.WhichOneof("wifi_state") == "inactive",
         timeout=5.0,
     )
     assert disconnected_update.WhichOneof("state") == "wifi"
-    assert disconnected_update.wifi.WhichOneof("wifi_state") == "disconnected"
+    assert disconnected_update.wifi.WhichOneof("wifi_state") == "inactive"


### PR DESCRIPTION

# What's new

- http server: properly indicate closed connections with the "Connection: close" header

# Verification 

- Run API regression tests

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
