### PR TITLE
[FW-933] device_info service

### DIFF
--- a/applications/services/application.fam
+++ b/applications/services/application.fam
@@ -22,6 +22,7 @@ App(
         "power_srv",
         "status_bar",
         "brightness_control",
+        "device_info",
     ],
     targets=["f20", "f21", "f22"],
 )
@@ -74,6 +75,7 @@ App(
         "nvm",
         "matter",
         "startup_dfu_hook",
+        "device_info",
     ],
     targets=["f64", "f65"],
 )

--- a/applications/services/cli_si917/application.fam
+++ b/applications/services/cli_si917/application.fam
@@ -3,5 +3,6 @@ App(
     apptype=FlipperAppType.STARTUP,
     entry_point="cli_on_system_start",
     stack_size=512,
+    order=20,
     targets=["f64", "f65"],
 )

--- a/applications/services/cli_si917/cli_commands.c
+++ b/applications/services/cli_si917/cli_commands.c
@@ -1,7 +1,6 @@
 #include <core/thread.h>
 #include <core/thread_list.h>
 #include <furi_hal.h>
-#include <furi_hal_info.h>
 #include <task_control_block.h>
 #include <time.h>
 #include <cli/args.h>
@@ -9,6 +8,7 @@
 #include <cli/cli_ansi.h>
 #include <cli/cli_commands.h>
 #include <applications.h>
+#include <device_info/device_info.h>
 
 static void
     cli_command_device_info_callback(const char* key, const char* value, bool last, void* context) {
@@ -21,7 +21,10 @@ void cli_command_device_info(PipeSide* pipe, FuriString* args, void* context) {
     UNUSED(pipe);
     UNUSED(args);
     UNUSED(context);
-    furi_hal_info_get(cli_command_device_info_callback, '_', NULL);
+
+    DeviceInfo* dev_info = furi_record_open(RECORD_DEVICE_INFO);
+    device_info_query(dev_info, cli_command_device_info_callback, '_', NULL);
+    furi_record_close(RECORD_DEVICE_INFO);
 }
 
 static void cli_commands_init(CliRegistry* registry) {

--- a/applications/services/cli_u5/application.fam
+++ b/applications/services/cli_u5/application.fam
@@ -4,5 +4,5 @@ App(
     entry_point="cli_on_system_start",
     stack_size=512,
     targets=["f20", "f21", "f22"],
-    order=10,
+    order=20,
 )

--- a/applications/services/cli_u5/cli_commands.c
+++ b/applications/services/cli_u5/cli_commands.c
@@ -16,14 +16,12 @@
 #include <loader/loader.h>
 #include <cli/args.h>
 #include <cli/cli_commands.h>
-#include <furi_hal_info.h>
 #include <intercom/intercom.h>
 #include <cli/cli_registry.h>
 #include <cli/cli_ansi.h>
 #include <applications.h>
 #include <storage/storage_backup.h>
-#include <device_name/device_name.h>
-#include <sl_info/sl_info.h>
+#include <device_info/device_info.h>
 
 #include "cli_debug_mode.h"
 
@@ -58,38 +56,14 @@ static void
     printf("%-30s: %s\r\n", key, value);
 }
 
-static void cli_command_device_info_print_name() {
-    FuriString* name = furi_string_alloc();
-#ifdef SRV_NAME
-    DeviceName* device_name = furi_record_open(RECORD_DEVICE_NAME);
-    device_name_get(device_name, name);
-    furi_record_close(RECORD_DEVICE_NAME);
-#else // SRV_NAME
-    furi_string_set_str(name, "BUSY Bar");
-#endif // SRV_NAME
-    cli_command_device_info_callback("name", furi_string_get_cstr(name), false, NULL);
-    furi_string_free(name);
-}
-
 static void cli_command_device_info(PipeSide* pipe, FuriString* args, void* context) {
     UNUSED(pipe);
     UNUSED(args);
     UNUSED(context);
 
-    cli_command_device_info_print_name();
-    furi_hal_info_get(cli_command_device_info_callback, '_', NULL);
-#ifdef SRV_SL_INFO
-    const SlInfo* sl_info = furi_record_open(RECORD_SL_INFO);
-    const SlInfoStatus sl_info_status =
-        sl_info_get_values(sl_info, cli_command_device_info_callback, NULL);
-    furi_record_close(RECORD_SL_INFO);
-#else // SRV_SL_INFO
-    const SlInfoStatus sl_info_status = SlInfoStatusNotReady;
-#endif // SRV_SL_INFO
-    printf(
-        "%-30s: %s\r\n",
-        "sl_intercom_status",
-        (sl_info_status == SlInfoStatusOk) ? "ok" : "error");
+    DeviceInfo* dev_info = furi_record_open(RECORD_DEVICE_INFO);
+    device_info_query(dev_info, cli_command_device_info_callback, '_', NULL);
+    furi_record_close(RECORD_DEVICE_INFO);
 }
 
 static void cli_commands_init(CliRegistry* registry) {

--- a/applications/services/device_info/application.fam
+++ b/applications/services/device_info/application.fam
@@ -1,0 +1,7 @@
+App(
+    appid="device_info",
+    apptype=FlipperAppType.STARTUP,
+    entry_point="device_info_on_system_start",
+    stack_size=1024,
+    targets=["f20", "f21", "f22", "f64", "f65"],
+)

--- a/applications/services/device_info/application.fam
+++ b/applications/services/device_info/application.fam
@@ -3,5 +3,6 @@ App(
     apptype=FlipperAppType.STARTUP,
     entry_point="device_info_on_system_start",
     stack_size=1024,
+    order=10,
     targets=["f20", "f21", "f22", "f64", "f65"],
 )

--- a/applications/services/device_info/device_info.c
+++ b/applications/services/device_info/device_info.c
@@ -1,0 +1,129 @@
+#include "device_info.h"
+#include <m-array.h>
+#include <furi_hal_info.h>
+
+// =====
+// Types
+// =====
+
+typedef struct {
+    DeviceInfoCallback callback;
+    void* context;
+} DeviceInfoSegment;
+
+ARRAY_DEF(DeviceInfoSegments, DeviceInfoSegment, M_POD_OPLIST)
+
+struct DeviceInfo {
+    FuriMutex* mutex;
+    DeviceInfoSegments_t segments;
+};
+
+typedef struct {
+    PropertyValueCallback print_callback;
+    void* print_context;
+    bool is_last_segment;
+} DeviceInfoFilterContext;
+
+// ===========
+// Private API
+// ===========
+
+static DeviceInfo* device_info_alloc(void) {
+    DeviceInfo* dev_info = malloc(sizeof(DeviceInfo));
+
+    dev_info->mutex = furi_mutex_alloc(FuriMutexTypeNormal);
+    DeviceInfoSegments_init(dev_info->segments);
+
+    return dev_info;
+}
+
+static void
+    device_info_filter(const char* key, const char* value, bool last_in_segment, void* context) {
+    furi_check(context);
+    DeviceInfoFilterContext* filter_context = context;
+
+    bool report_as_last = filter_context->is_last_segment && last_in_segment;
+
+    filter_context->print_callback(key, value, report_as_last, filter_context->print_context);
+}
+
+// ==========
+// Public API
+// ==========
+
+void device_info_register_segment(DeviceInfo* dev_info, DeviceInfoCallback callback, void* context) {
+    furi_check(dev_info);
+    furi_check(callback);
+
+    furi_check(furi_mutex_acquire(dev_info->mutex, FuriWaitForever) == FuriStatusOk);
+
+    DeviceInfoSegment* segment = DeviceInfoSegments_push_new(dev_info->segments);
+    segment->callback = callback;
+    segment->context = context;
+
+    furi_check(furi_mutex_release(dev_info->mutex) == FuriStatusOk);
+}
+
+void device_info_unregister_segment(DeviceInfo* dev_info, DeviceInfoCallback callback) {
+    furi_check(dev_info);
+    furi_check(callback);
+
+    furi_check(furi_mutex_acquire(dev_info->mutex, FuriWaitForever) == FuriStatusOk);
+
+    DeviceInfoSegments_it_ct it;
+    for(DeviceInfoSegments_it(it, dev_info->segments); !DeviceInfoSegments_end_p(it);
+        DeviceInfoSegments_next(it)) {
+        const DeviceInfoSegment* segment = DeviceInfoSegments_cref(it);
+        if(segment->callback == callback) DeviceInfoSegments_remove(dev_info->segments, it);
+    }
+
+    furi_check(furi_mutex_release(dev_info->mutex) == FuriStatusOk);
+}
+
+void device_info_query(
+    DeviceInfo* dev_info,
+    PropertyValueCallback print_callback,
+    char separator,
+    void* print_context) {
+    furi_check(dev_info);
+    furi_check(print_callback);
+
+    furi_check(furi_mutex_acquire(dev_info->mutex, FuriWaitForever) == FuriStatusOk);
+
+    DeviceInfoSegments_it_ct it;
+    for(DeviceInfoSegments_it(it, dev_info->segments); !DeviceInfoSegments_end_p(it);
+        DeviceInfoSegments_next(it)) {
+        const DeviceInfoSegment* segment = DeviceInfoSegments_cref(it);
+
+        DeviceInfoFilterContext filter_ctx = {
+            .print_callback = print_callback,
+            .print_context = print_context,
+            .is_last_segment = DeviceInfoSegments_last_p(it),
+        };
+
+        segment->callback(device_info_filter, separator, segment->context, &filter_ctx);
+    }
+
+    furi_check(furi_mutex_release(dev_info->mutex) == FuriStatusOk);
+}
+
+// ============
+// Startup hook
+// ============
+
+static void furi_hal_adapter_for_device_info(
+    PropertyValueCallback print_callback,
+    char separator,
+    void* info_context,
+    void* print_context) {
+    UNUSED(info_context);
+    furi_hal_info_get(print_callback, separator, print_context);
+}
+
+void device_info_on_system_start(void) {
+    DeviceInfo* dev_info = device_info_alloc();
+
+    device_info_register_segment(dev_info, furi_hal_adapter_for_device_info, NULL);
+
+    furi_record_create(RECORD_DEVICE_INFO, dev_info);
+}

--- a/applications/services/device_info/device_info.h
+++ b/applications/services/device_info/device_info.h
@@ -1,0 +1,62 @@
+/**
+ * @file device_info.h
+ * Device Info service. Aggregates info publishers and provides access to them
+ * to info queriers.
+ */
+
+#pragma once
+
+#include <furi.h>
+#include <toolbox/property.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct DeviceInfo DeviceInfo;
+
+/**
+ * Type `DeviceInfo*`
+ */
+#define RECORD_DEVICE_INFO "device_info"
+
+typedef void (*DeviceInfoCallback)(
+    PropertyValueCallback print_callback,
+    char separator,
+    void* info_context,
+    void* print_context);
+
+/**
+ * Register a callback that provides a piece of information about the system.
+ * 
+ * @param[inout] dev_info Device info service
+ * @param[in] callback Function that will be called when system information is requested
+ * @param[inout] context Passed verbatim to `callback` parameter. May be NULL.
+ */
+void device_info_register_segment(DeviceInfo* dev_info, DeviceInfoCallback callback, void* context);
+
+/**
+ * De-register a callback that provides a piece of information about the system.
+ * 
+ * @param[inout] dev_info Device info service
+ * @param[in] callback Function that will no longer be called when system information is requested
+ */
+void device_info_unregister_segment(DeviceInfo* dev_info, DeviceInfoCallback callback);
+
+/**
+ * Query all registered information about the system
+ * 
+ * @param[inout] dev_info Device info service
+ * @param[in] callback Function that will be called for each key-value pair of system information
+ * @param[in] separator Placed in between parts of the key
+ * @param[inout] context Passed verbatim to `callback` parameter. May be NULL.
+ */
+void device_info_query(
+    DeviceInfo* dev_info,
+    PropertyValueCallback callback,
+    char separator,
+    void* context);
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications/services/device_name/device_name.c
+++ b/applications/services/device_name/device_name.c
@@ -1,6 +1,7 @@
 #include "device_name_i.h"
 
 #include <cjson/cJSON.h>
+#include <device_info/device_info.h>
 
 #define DEVICE_NAME_MQTT_PREFIX "state"
 #define DEVICE_NAME_KEY         "name"
@@ -148,6 +149,22 @@ static void device_name_mqtt_events_pubsub_callback(const void* msg, void* conte
     }
 }
 
+static void device_name_adapter_for_device_info(
+    PropertyValueCallback print_callback,
+    char separator,
+    void* info_context,
+    void* print_context) {
+    DeviceName* instance = info_context;
+
+    FuriString* dev_name = furi_string_alloc();
+    device_name_get(instance, dev_name);
+
+    print_callback("name", furi_string_get_cstr(dev_name), true, print_context);
+    UNUSED(separator); // key consists of one part
+
+    furi_string_free(dev_name);
+}
+
 static DeviceName* device_name_alloc(void) {
     DeviceName* instance = malloc(sizeof(DeviceName));
 
@@ -169,6 +186,10 @@ static DeviceName* device_name_alloc(void) {
     instance->mqtt_events_pubsub = mqtt_get_pubsub(instance->mqtt);
     furi_pubsub_subscribe(
         instance->mqtt_events_pubsub, device_name_mqtt_events_pubsub_callback, instance);
+
+    DeviceInfo* dev_info = furi_record_open(RECORD_DEVICE_INFO);
+    device_info_register_segment(dev_info, device_name_adapter_for_device_info, instance);
+    furi_record_close(RECORD_DEVICE_INFO);
 
     furi_record_create(RECORD_DEVICE_NAME, instance);
 

--- a/applications/services/sl_info/sl_info.c
+++ b/applications/services/sl_info/sl_info.c
@@ -3,6 +3,7 @@
 #include <m-array.h>
 
 #include <intercom/intercom.h>
+#include <device_info/device_info.h>
 
 #include "sl_info_common_i.h"
 
@@ -47,12 +48,13 @@ static const char* sl_info_find_value(const SlInfo* instance, const char* key) {
 static void sl_info_output_values(
     const SlInfo* instance,
     PropertyValueCallback value_callback,
-    void* context) {
+    void* context,
+    bool output_is_last) {
     SlInfoItemVec_it_ct it;
     for(SlInfoItemVec_it(it, instance->items); !SlInfoItemVec_end_p(it); SlInfoItemVec_next(it)) {
         const SlInfoItem* item = SlInfoItemVec_cref(it);
         const bool is_last = SlInfoItemVec_last_p(it);
-        value_callback(item->key, item->value, is_last, context);
+        value_callback(item->key, item->value, output_is_last ? is_last : false, context);
     }
 }
 
@@ -72,6 +74,22 @@ static void sl_info_intercom_rx_callback(const void* data, size_t data_size, voi
     }
 }
 
+static void sl_info_adapter_for_device_info(
+    PropertyValueCallback print_callback,
+    char separator,
+    void* info_context,
+    void* print_context) {
+    SlInfo* instance = info_context;
+
+    if(instance && instance->is_ready) {
+        UNUSED(separator); // unfortunately, 917 has already decided on '_' for us! :C
+        sl_info_output_values(instance, print_callback, print_context, false);
+        print_callback("sl_intercom_status", "ok", true, print_context);
+    } else {
+        print_callback("sl_intercom_status", "error", true, print_context);
+    }
+}
+
 static void sl_info_wait_for_data(SlInfo* instance) {
     FURI_LOG_D(TAG, "Waiting for data...");
 
@@ -80,11 +98,20 @@ static void sl_info_wait_for_data(SlInfo* instance) {
         intercom, IntercomChannelIdSlInfo, sl_info_intercom_rx_callback, instance);
     // Not sending anything to the intercom channel
     UNUSED(info_channel);
+
+    DeviceInfo* dev_info = furi_record_open(RECORD_DEVICE_INFO);
+    device_info_unregister_segment(dev_info, sl_info_adapter_for_device_info);
+    device_info_register_segment(dev_info, sl_info_adapter_for_device_info, instance);
+    furi_record_close(RECORD_DEVICE_INFO);
 }
 
 static SlInfo* sl_info_alloc(void) {
     SlInfo* instance = malloc(sizeof(SlInfo));
     SlInfoItemVec_init(instance->items);
+
+    DeviceInfo* dev_info = furi_record_open(RECORD_DEVICE_INFO);
+    device_info_register_segment(dev_info, sl_info_adapter_for_device_info, NULL);
+    furi_record_close(RECORD_DEVICE_INFO);
 
     furi_record_create(RECORD_SL_INFO, instance);
     return instance;
@@ -134,7 +161,7 @@ SlInfoStatus sl_info_get_values(
             break;
         }
 
-        sl_info_output_values(instance, value_callback, context);
+        sl_info_output_values(instance, value_callback, context, true);
         status = SlInfoStatusOk;
 
     } while(false);


### PR DESCRIPTION
# What's new
- FW-933: centralized registry for decentralized definition of `device_info` segments

# Verification 
- Verify that `device_info` command (on main CLI and 917 CLI) look the same (except that some entries may be reordered, this is fine)
- Verify that after rebooting u5 with 917 held in reset, there's an `sl_intercom_status : error` entry

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
