### PR TITLE
[FW-996] Clock App Crash Fix

### DIFF
--- a/applications/main/clock/scenes/scene_clock.c
+++ b/applications/main/clock/scenes/scene_clock.c
@@ -55,11 +55,11 @@ static void clock_scene_clock_on_enter(void* context) {
         mirror_card_set_show_footer(scene->back_card, false);
         widget_set_align(mirror_card_get_base(scene->back_card), AlignCenter);
         widget_set_margin(mirror_card_get_base(scene->back_card), 0, 0, 2, 2);
+
+        transition_overlay_start(instance->front_transition_overlay);
     });
 
     free(time_settings);
-
-    transition_overlay_start(instance->front_transition_overlay);
 }
 
 static void clock_scene_clock_on_exit(void* context) {

--- a/applications/main/clock/scenes/scene_main.c
+++ b/applications/main/clock/scenes/scene_main.c
@@ -91,11 +91,11 @@ static void clock_scene_main_on_enter(void* context) {
             ClockSceneMainEventSetup,
             clock_scene_main_menu_callback,
             instance);
+
+        transition_overlay_start(instance->front_transition_overlay);
     });
 
     free(time_settings);
-
-    transition_overlay_start(instance->front_transition_overlay);
 }
 
 static void clock_scene_main_on_exit(void* context) {


### PR DESCRIPTION
> [!NOTE]
> * [**FW-996**](https://flipper.atlassian.net/browse/FW-996)

# What's new

- fix GUI calls to transition_overlay_start outside of GUI lock in clock app

# Verification 

_see Jira task description_

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
