### PR TITLE
[FW-995] Timer unit test fix

### DIFF
--- a/applications/debug/unit_tests/timer_test/timer_test.c
+++ b/applications/debug/unit_tests/timer_test/timer_test.c
@@ -28,6 +28,9 @@ static bool true_after_expire(void* context) {
 }
 
 MU_TEST(coarse_timer_test) {
+    FuriThreadPriority old_priority = furi_thread_get_current_priority();
+    furi_thread_set_current_priority(FuriThreadPriorityHighest);
+
     FURI_CRITICAL_ENTER();
     const CoarseTimer timer = coarse_timer_create(COARSE_TIMER_TIMEOUT_MS);
 
@@ -39,13 +42,14 @@ MU_TEST(coarse_timer_test) {
 
     const uint32_t elapsed_end_ms = coarse_timer_get_elapsed(timer);
     const bool is_expired_end = coarse_timer_is_expired(timer);
+    furi_thread_set_current_priority(old_priority);
 
     mu_check(!is_expired_start);
     mu_check(is_expired_end);
 
     mu_assert_int_eq(0, elapsed_start_ms);
     mu_assert_int_between(
-        COARSE_TIMER_TIMEOUT_MS - COARSE_TIMER_ABSTOL_MS,
+        COARSE_TIMER_TIMEOUT_MS,
         COARSE_TIMER_TIMEOUT_MS + COARSE_TIMER_ABSTOL_MS,
         (int32_t)elapsed_end_ms);
 }


### PR DESCRIPTION
# What's new
[FW-995]
- Fixed rare coarse_timer_test fail

# Verification 

- Run unit tests

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-995]: https://flipper.atlassian.net/browse/FW-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ