### PR TITLE
Fix Clock Fault On Scenes Exit

### DIFF
--- a/applications/main/clock/scenes/scene_clock.c
+++ b/applications/main/clock/scenes/scene_clock.c
@@ -100,11 +100,12 @@ static bool clock_scene_clock_on_event(const SceneManagerEvent* event, void* con
     } else if(event->type == SceneManagerEventTypeBack) {
         with_gui(instance->gui, {
             widget_set_visible(nav_bar_get_base(instance->back_nav_bar), true);
-        });
 
-        transition_overlay_set_preset(
-            instance->front_transition_overlay, &clock_scene_clock_back_transition_overlay_preset);
-        transition_overlay_show(instance->front_transition_overlay);
+            transition_overlay_set_preset(
+                instance->front_transition_overlay,
+                &clock_scene_clock_back_transition_overlay_preset);
+            transition_overlay_show(instance->front_transition_overlay);
+        });
 
         if(!scene_manager_previous_scene(instance->scene_manager)) {
             scene_manager_next_scene(instance->scene_manager, ClockSceneIdxMain);

--- a/applications/main/clock/scenes/scene_main.c
+++ b/applications/main/clock/scenes/scene_main.c
@@ -134,12 +134,12 @@ static bool clock_scene_main_on_event(const SceneManagerEvent* event, void* cont
         case ClockSceneMainEventStart:
             with_gui(instance->gui, {
                 widget_set_visible(nav_bar_get_base(instance->back_nav_bar), false);
-            });
 
-            transition_overlay_set_preset(
-                instance->front_transition_overlay,
-                &clock_scene_main_start_transition_overlay_preset);
-            transition_overlay_show(instance->front_transition_overlay);
+                transition_overlay_set_preset(
+                    instance->front_transition_overlay,
+                    &clock_scene_main_start_transition_overlay_preset);
+                transition_overlay_show(instance->front_transition_overlay);
+            });
 
             scene_manager_next_scene(instance->scene_manager, ClockSceneIdxClock);
             return true;


### PR DESCRIPTION
> [!NOTE]
> Follow-up to [PR](https://github.com/flipperdevices/bsb-firmware/pull/812).

# What's new

- fix some more calls to `transition overlay` being done from outside of GUI lock (see [slack](https://flipperdevices.slack.com/archives/C01QP4L3486/p1781636350406129)

# Verification 

- switch scenes in clock application => no faults

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
