### PR TITLE
[FW-1013] Fix DFU Mode Indication On F65 Target

### DIFF
--- a/applications/services/startup_dfu_hook/startup_dfu_hook_f64.c
+++ b/applications/services/startup_dfu_hook/startup_dfu_hook_f64.c
@@ -12,10 +12,10 @@
 #define DFU_WARN_TIMEOUT_MS 3000
 
 typedef enum {
-    StartupDfuHookFlagStartRelease = 1 << 0,
+    StartupDfuHookFlagButtonRelease = 1 << 0,
     StartupDfuHookFlagIntercomSync = 1 << 1,
 
-    StartupDfuHookFlagAny = StartupDfuHookFlagStartRelease | StartupDfuHookFlagIntercomSync
+    StartupDfuHookFlagAny = StartupDfuHookFlagButtonRelease | StartupDfuHookFlagIntercomSync
 } StartupDfuHookFlag;
 
 typedef enum {
@@ -44,9 +44,9 @@ static void startup_dfu_hook_input_events_callback(const void* message, void* co
     FuriThreadId thread_id = context;
 
     if(event->device == InputDeviceButton) {
-        if(event->button_event.button == InputButtonStart &&
+        if(event->button_event.button == dfu_boot_button &&
            event->button_event.action == InputActionRelease) {
-            furi_thread_flags_set(thread_id, StartupDfuHookFlagStartRelease);
+            furi_thread_flags_set(thread_id, StartupDfuHookFlagButtonRelease);
         }
     }
 }
@@ -139,7 +139,7 @@ static void startup_dfu_hook_teardown(StartupDfuHook* instance) {
 static bool startup_dfu_hook_should_run(const StartupDfuHook* instance) {
     // TODO [FW-503]: use furi_state
     const InputAbsoluteState input_state = input_get_absolute_state(instance->input);
-    return (input_state.buttons & InputButtonMaskStart);
+    return (input_state.buttons & dfu_boot_button_mask);
 }
 
 void startup_dfu_hook_on_system_start(void) {

--- a/targets/README.md
+++ b/targets/README.md
@@ -29,4 +29,4 @@
 | Target | Pairs with | Note |
 | ------ | ---------- | ---- |
 | `f64`  | `f20`, `f21` | |
-| `f65`  | `f22` | No changes compared to `f64`. |
+| `f65`  | `f22` | DFU enter button is `OK` (was `Start`). |

--- a/targets/f64/furi_hal/furi_hal_resources.h
+++ b/targets/f64/furi_hal/furi_hal_resources.h
@@ -91,6 +91,10 @@ extern const GpioPin gpio_sw_ok;
 extern const InputPin input_pins[];
 extern const size_t input_pins_count;
 
+/* DFU enter button */
+extern const InputButton dfu_boot_button;
+extern const InputButtonMask dfu_boot_button_mask;
+
 void furi_hal_resources_init_early(void);
 
 void furi_hal_resources_deinit_early(void);

--- a/targets/f64/furi_hal/furi_hal_resources_device.c
+++ b/targets/f64/furi_hal/furi_hal_resources_device.c
@@ -1,0 +1,4 @@
+#include <furi_hal_resources.h>
+
+const InputButton dfu_boot_button = InputButtonStart;
+const InputButtonMask dfu_boot_button_mask = InputButtonMaskStart;

--- a/targets/f65/furi_hal/furi_hal_resources_device.c
+++ b/targets/f65/furi_hal/furi_hal_resources_device.c
@@ -1,0 +1,4 @@
+#include <furi_hal_resources.h>
+
+const InputButton dfu_boot_button = InputButtonOk;
+const InputButtonMask dfu_boot_button_mask = InputButtonMaskOk;

--- a/targets/f65/target.json
+++ b/targets/f65/target.json
@@ -1,3 +1,7 @@
 {
-    "inherit": "f64"
+    "inherit": "f64",
+    "sources": [
+        "*/*.c",
+        "f64:!furi_hal/furi_hal_resources_device.c"
+    ]
 }


### PR DESCRIPTION
> [!NOTE]
> * [**FW-1002**](https://flipper.atlassian.net/browse/FW-1013)

# What's new

- target-specific DFU entry button definitions
- DFU startup hook uses new target-specific button definitions

# Verification 

> [!IMPORTANT]
> Please, check F65 target's DFU entry indication as i don't have the hardware.

- both F64 & F65 targets correctly indicate DFU entry using status lights

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
