### PR TITLE
[FW-991] Document charge limit command

### DIFF
--- a/applications/services/power/power_cli.c
+++ b/applications/services/power/power_cli.c
@@ -327,6 +327,7 @@ static void power_cli_command_print_usage(void) {
     printf("\tboot\t - reboot to DFU bootloader\r\n");
     printf("\tch\t - charge on/off\r\n");
     printf("\tch_current\t - charge current limit\r\n");
+    printf("\tch_limit\t - charge percentage limit\r\n");
     printf("\tpd_info\t - USB PD info\r\n");
     printf("\tpd_set\t - Request USB PD profile\r\n");
 }


### PR DESCRIPTION
# What's new
- FW-991: `power ch_limit` is mentioned in `power` usage (when invoked without arguments)

# Verification 
- Run `power`
- Verify that the help string mentions `ch_limit`

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
