### PR TITLE
[FW-1016] Fix Random Crash In Audio Service

### DIFF
--- a/applications/services/audio/audio.c
+++ b/applications/services/audio/audio.c
@@ -44,6 +44,7 @@
 #define AUDIO_CONFIG_FILE APP_DATA_PATH("audio.json")
 
 typedef enum {
+    AudioBufferIndexNone = 0,
     AudioBufferIndexPing = (1UL << FuriHalSaiEventHalfTransfer),
     AudioBufferIndexPong = (1UL << FuriHalSaiEventTransferComplete),
     AudioBufferIndexBoth = (AudioBufferIndexPing | AudioBufferIndexPong),
@@ -333,6 +334,9 @@ static void audio_custom_event_callback(uint32_t events, void* context) {
     furi_assert(context);
     Audio* instance = context;
     AudioBufferIndex buffer_index = events;
+
+    /* event loop may re-arm its notify flag after event bits were already drained */
+    if(buffer_index == AudioBufferIndexNone) return;
 
     bool should_stop = false;
 


### PR DESCRIPTION
> [!NOTE]
> * [**FW-1016**](https://flipper.atlassian.net/browse/FW-1016)

# What's new

- fix rare data race (event loop's one) consequences in audio service by dropping stale event notifications

# Verification 

- no stable way of reproduction, audio service shouldn't crash & should work as expected

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
