### PR TITLE
Fix Updater Disconnecting Wi-Fi

### DIFF
--- a/applications/system/updater/updater.c
+++ b/applications/system/updater/updater.c
@@ -234,7 +234,7 @@ static UpdaterStatus updater_do_installation_apply(Updater* instance, UpdaterMes
     FURI_LOG_D(TAG, "Boot mode set to \"update\", device will reboot...");
 
     furi_delay_ms(UPDATE_INSTALLATION_APPLY_REBOOT_DELAY);
-    furi_hal_power_reset();
+    power_reboot(instance->power, PowerRebootNormalU5);
 
     furi_crash();
 }


### PR DESCRIPTION
# What's new

- make updater call `power_reboot` instead of `furi_hal_power_reset`

# Verification 

- wi-fi doesn't loose it's connection after updates

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
