### PR TITLE
[FW-1026] Drop BUSY timer snapshots from the future

### DIFF
--- a/applications/services/busy_timer/busy_timer.c
+++ b/applications/services/busy_timer/busy_timer.c
@@ -549,11 +549,6 @@ static void busy_timer_apply_snapshot(BusyTimer* instance, const BusyTimerSnapsh
         return;
     }
 
-    if(!busy_timer_snapshot_is_valid(snapshot)) {
-        FURI_LOG_W(TAG, "Ignoring invalid snapshot with timestamp %llu", snapshot_timestamp_ms);
-        return;
-    }
-
     busy_timer_stop_timer(instance);
 
     BusyTimerMode new_mode;

--- a/applications/services/busy_timer/busy_timer_snapshot.c
+++ b/applications/services/busy_timer/busy_timer_snapshot.c
@@ -19,7 +19,7 @@
 #define KEY_SNAPSHOT_INTERVAL_CURRENT_LEFT  "current_interval_time_left_ms"
 #define KEY_SNAPSHOT_INTERVAL_SETTINGS      "interval_settings"
 
-#define TIMESTAMP_TOLERANCE_MS (S_TO_MS(15))
+#define TIMESTAMP_TOLERANCE_MS (M_TO_MS(1))
 
 static const char* const snapshot_type_values[BusyTimerSnapshotTypeMax] = {
     [BusyTimerSnapshotTypeNotStarted] = "NOT_STARTED",

--- a/applications/services/busy_timer/busy_timer_snapshot.c
+++ b/applications/services/busy_timer/busy_timer_snapshot.c
@@ -2,6 +2,7 @@
 #include "busy_timer_common_i.h"
 
 #include <furi.h>
+#include <furi_hal_rtc.h>
 
 #define KEY_SNAPSHOT  "snapshot"
 #define KEY_TIMESTAMP "snapshot_timestamp_ms"
@@ -17,6 +18,8 @@
 #define KEY_SNAPSHOT_INTERVAL_CURRENT_TOTAL "current_interval_time_total_ms"
 #define KEY_SNAPSHOT_INTERVAL_CURRENT_LEFT  "current_interval_time_left_ms"
 #define KEY_SNAPSHOT_INTERVAL_SETTINGS      "interval_settings"
+
+#define TIMESTAMP_TOLERANCE_MS (S_TO_MS(15))
 
 static const char* const snapshot_type_values[BusyTimerSnapshotTypeMax] = {
     [BusyTimerSnapshotTypeNotStarted] = "NOT_STARTED",
@@ -246,6 +249,46 @@ static bool
     return success;
 }
 
+static bool busy_timer_snapshot_is_valid_timestamp(time_t timestamp_ms) {
+    bool is_valid = true;
+
+    const time_t now_timestamp_ms = furi_hal_rtc_get_timestamp_ms();
+
+    if(timestamp_ms > now_timestamp_ms) {
+        if(timestamp_ms - now_timestamp_ms > TIMESTAMP_TOLERANCE_MS) {
+            is_valid = false;
+        }
+    }
+
+    return is_valid;
+}
+
+static bool busy_timer_snapshot_is_valid_interval_state(const BusyTimerIntervalState* state) {
+    bool is_valid = false;
+
+    do {
+        if(state->index > (BUSY_TIMER_CYCLE_COUNT_MAX * 2) - 2) {
+            break;
+        }
+
+        if(state->time_left_ms > state->time_total_ms) {
+            break;
+        }
+
+        const bool is_rest = state->index % 2;
+        const uint32_t upper_bound_ms = is_rest ? M_TO_MS(BUSY_TIMER_REST_TIME_MAX_MN) :
+                                                  M_TO_MS(BUSY_TIMER_WORK_TIME_MAX_MN);
+
+        if(state->time_left_ms > upper_bound_ms) {
+            break;
+        }
+
+        is_valid = true;
+    } while(false);
+
+    return is_valid;
+}
+
 // Internal functions
 
 bool busy_timer_snapshot_serialize_raw(const BusyTimerSnapshot* snapshot, cJSON* json) {
@@ -293,6 +336,10 @@ bool busy_timer_snapshot_deserialize_raw(BusyTimerSnapshot* snapshot, const cJSO
 
         snapshot->timestamp_ms = cJSON_GetNumberValue(item);
 
+        if(!busy_timer_snapshot_is_valid(snapshot)) {
+            break;
+        }
+
         success = true;
     } while(false);
 
@@ -331,6 +378,10 @@ bool busy_timer_snapshot_is_valid(const BusyTimerSnapshot* snapshot) {
     bool is_valid = false;
 
     do {
+        if(!busy_timer_snapshot_is_valid_timestamp(snapshot->timestamp_ms)) {
+            break;
+        }
+
         const BusyTimerSnapshotType type = snapshot->type;
 
         if(type == BusyTimerSnapshotTypeNotStarted) {
@@ -361,19 +412,7 @@ bool busy_timer_snapshot_is_valid(const BusyTimerSnapshot* snapshot) {
                 break;
             }
 
-            const BusyTimerIntervalState* state = &interval->state;
-            if(state->index > (BUSY_TIMER_CYCLE_COUNT_MAX * 2) - 2) {
-                break;
-            }
-            if(state->time_left_ms > state->time_total_ms) {
-                break;
-            }
-
-            const bool is_rest = state->index % 2;
-            const uint32_t upper_bound_ms = is_rest ? M_TO_MS(BUSY_TIMER_REST_TIME_MAX_MN) :
-                                                      M_TO_MS(BUSY_TIMER_WORK_TIME_MAX_MN);
-
-            if(state->time_left_ms > upper_bound_ms) {
+            if(!busy_timer_snapshot_is_valid_interval_state(&interval->state)) {
                 break;
             }
 

--- a/tests/integration/frontend/busy/test_api_busy.py
+++ b/tests/integration/frontend/busy/test_api_busy.py
@@ -388,7 +388,7 @@ class TestBusySnapshotRegressions:
         assert updated.snapshot["type"] == "SIMPLE"
         assert 0 < updated.snapshot["time_left_ms"] <= 240000
 
-    @allure.title("BUSY timer rejects snapshots more than 15 seconds in the future")
+    @allure.title("BUSY timer rejects snapshots more than 60 seconds in the future")
     def test_busy_timer_future_snapshot_is_rejected(
         self, busy_api: BusyAPI, api_session, web_base_url, busy_state_guard
     ):

--- a/tests/integration/frontend/busy/test_api_busy.py
+++ b/tests/integration/frontend/busy/test_api_busy.py
@@ -7,6 +7,7 @@ import pytest
 from clients.api import BusyAPI, StorageAPI, StreamingAPI
 from utils.busy_timer import (
     STATE_SETTLE_S,
+    TS_MAX_FUTURE_MS,
     WORK_CARD_UUID,
     next_timestamp,
     wait_for_snapshot_type,
@@ -386,6 +387,31 @@ class TestBusySnapshotRegressions:
         assert updated.snapshot_timestamp_ms == current.snapshot_timestamp_ms
         assert updated.snapshot["type"] == "SIMPLE"
         assert 0 < updated.snapshot["time_left_ms"] <= 240000
+
+    @allure.title("BUSY timer rejects snapshots more than 15 seconds in the future")
+    def test_busy_timer_future_snapshot_is_rejected(
+        self, busy_api: BusyAPI, api_session, web_base_url, busy_state_guard
+    ):
+        settings = _current_busy_settings(busy_state_guard)
+        baseline = _simple_snapshot(
+            next_timestamp(api_session, web_base_url), settings, time_left_ms=240000
+        )
+        assert busy_api.set_snapshot_raw(baseline).status_code == 200
+        time.sleep(STATE_SETTLE_S)
+        before = busy_api.get_snapshot()
+
+        future_ts = int(time.time() * 1000) + TS_MAX_FUTURE_MS + 15000
+        future = _infinite_snapshot(future_ts, settings)
+        response = busy_api.set_snapshot_raw(future)
+        assert response.status_code == 400, (
+            "Expected BUSY snapshot parser to reject timestamps more than "
+            f"{TS_MAX_FUTURE_MS}ms in the future, got {response.status_code}: "
+            f"{response.text[:200]}"
+        )
+
+        after = busy_api.get_snapshot()
+        assert after.snapshot_timestamp_ms == before.snapshot_timestamp_ms
+        assert after.snapshot == before.snapshot
 
     @allure.title("BUSY timer invalid semantic snapshots do not change current state")
     @pytest.mark.parametrize(

--- a/tests/integration/frontend/display/test_api_display_priority.py
+++ b/tests/integration/frontend/display/test_api_display_priority.py
@@ -522,18 +522,12 @@ class TestDrawBusyTimerTransitions:
                     "card_id": "00000000-0000-0000-0000-000000000001",
                     "is_paused": is_paused,
                 }
-            # Always fetch the device's current timestamp and advance it so the
-            # snapshot is not rejected as stale/own by busy_timer.
-            current = api_session.get(f"{web_base_url}/api/busy/snapshot", timeout=10)
-            current.raise_for_status()
-            device_ts = current.json().get("snapshot_timestamp_ms", 0)
-            next_ts = max(device_ts, int(time.time() * 1000)) + 2000
             body_snapshot["busy_bar_settings"] = busy_state_guard.get(
                 "snapshot", {}
             ).get("busy_bar_settings", {})
             body = {
                 "snapshot": body_snapshot,
-                "snapshot_timestamp_ms": next_ts,
+                "snapshot_timestamp_ms": next_timestamp(api_session, web_base_url),
             }
             r = api_session.put(
                 f"{web_base_url}/api/busy/snapshot", json=body, timeout=10

--- a/tests/utils/busy_timer.py
+++ b/tests/utils/busy_timer.py
@@ -19,8 +19,8 @@ WORK_CARD_UUID = "00000000-0000-0000-0000-000000000001"
 TS_ADVANCE_MS = 2000
 TS_MIN_ADVANCE_MS = 1
 
-# Firmware rejects snapshots more than 15 seconds ahead of RTC.
-TS_MAX_FUTURE_MS = 15000
+# Firmware rejects snapshots more than 60 seconds ahead of RTC.
+TS_MAX_FUTURE_MS = 60 * 1000
 TS_FUTURE_WAIT_TIMEOUT_S = 20.0
 TS_FUTURE_POLL_INTERVAL_S = 0.1
 

--- a/tests/utils/busy_timer.py
+++ b/tests/utils/busy_timer.py
@@ -17,6 +17,12 @@ WORK_CARD_UUID = "00000000-0000-0000-0000-000000000001"
 # How far (ms) ahead of the device's last-known timestamp we stamp new snapshots.
 # busy_timer rejects any snapshot whose timestamp <= last_known_snapshot.timestamp_ms.
 TS_ADVANCE_MS = 2000
+TS_MIN_ADVANCE_MS = 1
+
+# Firmware rejects snapshots more than 15 seconds ahead of RTC.
+TS_MAX_FUTURE_MS = 15000
+TS_FUTURE_WAIT_TIMEOUT_S = 20.0
+TS_FUTURE_POLL_INTERVAL_S = 0.1
 
 # Time (seconds) to wait after setting a busy timer snapshot so the busy app
 # processes the state change and updates the loader priority.  0.3 s was too
@@ -31,10 +37,33 @@ def get_snapshot(session: requests.Session, base_url: str) -> dict:
 
 
 def next_timestamp(session: requests.Session, base_url: str) -> int:
-    """Return a timestamp strictly greater than whatever the device currently holds."""
-    current = get_snapshot(session, base_url)
-    device_ts = current.get("snapshot_timestamp_ms", 0)
-    return max(device_ts, int(time.time() * 1000)) + TS_ADVANCE_MS
+    """Return a valid timestamp strictly greater than the current device snapshot.
+
+    The firmware rejects snapshots from more than 15 seconds in the future. If
+    the current device snapshot is already close to that limit, advance it by
+    the smallest possible amount instead of pushing the test state past the
+    accepted future window.
+    """
+    deadline = time.monotonic() + TS_FUTURE_WAIT_TIMEOUT_S
+
+    while True:
+        current = get_snapshot(session, base_url)
+        device_ts = current.get("snapshot_timestamp_ms", 0)
+        now_ms = int(time.time() * 1000)
+        future_limit_ms = now_ms + TS_MAX_FUTURE_MS
+
+        candidate = max(device_ts + TS_MIN_ADVANCE_MS, now_ms + TS_ADVANCE_MS)
+        if candidate <= future_limit_ms:
+            return candidate
+
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                "Cannot build a fresh BUSY snapshot timestamp within the "
+                f"{TS_MAX_FUTURE_MS}ms future limit: "
+                f"device_ts={device_ts}, now_ms={now_ms}"
+            )
+
+        time.sleep(TS_FUTURE_POLL_INTERVAL_S)
 
 
 def set_snapshot(session: requests.Session, base_url: str, body: dict) -> None:


### PR DESCRIPTION
# What's new

[FW-1026]

- Do not accept BUSY timer snapshots if they are more than 15s from the future
- Validate snapshots during parsing instead of an additional step
- Refactor snapshot validation code for better modularity

# Verification 

1. Flash the firmware bundle
2. Follow the reproduction procedure from [FW-1026]
3. Ensure that the bug is no more reproducible
4. Ensure that there are no regressions in timer synchronisation

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-1026]: https://flipper.atlassian.net/browse/FW-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FW-1026]: https://flipper.atlassian.net/browse/FW-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ