### PR TITLE
[FW-1036] ci: tactical sleep before invoking device_info

### DIFF
--- a/.github/workflows/brick-test.yml
+++ b/.github/workflows/brick-test.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: 'Update submodules'
         run: |
-          git submodule update --init --depth 1 --filter=blob:none --recursive --jobs="$(nproc)" scripts/toolchain fbt_layers/fbtng
+          git submodule update --init --depth 1 --filter=blob:none --jobs="$(nproc)" || (git lfs logs last && exit 1)
 
       - name: 'Download brick firmware package'
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: 'Update submodules'
         run: |
-          git submodule update --init --depth 1 --filter=blob:none --recursive --jobs="$(nproc)" scripts/toolchain fbt_layers/fbtng
+          git submodule update --init --depth 1 --filter=blob:none --jobs="$(nproc)" || (git lfs logs last && exit 1)
 
       - name: 'Download unit test package'
         run: |

--- a/.github/workflows/updater-test.yml
+++ b/.github/workflows/updater-test.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: 'Update submodules'
         run: |
-          git submodule update --init --depth 1 --filter=blob:none --recursive --jobs=$(nproc) scripts/toolchain fbt_layers/fbtng
+          git submodule update --init --depth 1 --filter=blob:none --jobs="$(nproc)" || (git lfs logs last && exit 1)
 
       - name: 'Download update package'
         run: |

--- a/scripts/testops.py
+++ b/scripts/testops.py
@@ -542,6 +542,8 @@ class BusyBarDevice:
         Runs 'device_info' and returns the output.
         """
         with self._telnet(timeout=timeout) as tn:
+            # sleep to make sure the device is ready to respond after reboot/reflash
+            sleep(1)
             res = tn.run("device_info", timeout=timeout)
             return res.ok, (res.stdout or "(No output received)")
 


### PR DESCRIPTION
# What's new

- Added sleep to workaround device_info not ready after reboot/reflash

# Verification 

- Multiple updater jobs rerun

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
