### PR TITLE
[FW-1021] Settings Broken Back Animations On Re-Enter

### DIFF
--- a/applications/main/clock/clock.c
+++ b/applications/main/clock/clock.c
@@ -165,7 +165,7 @@ static Clock* clock_alloc(const char* arguments) {
         });
 
         static const uint32_t scenes[] = {ClockSceneIdxMain, ClockSceneIdxClock};
-        scene_manager_set_initial_scenes(instance->scene_manager, scenes, COUNT_OF(scenes));
+        scene_manager_next_scenes(instance->scene_manager, scenes, COUNT_OF(scenes));
     } else {
         scene_manager_next_scene(instance->scene_manager, ClockSceneIdxMain);
     }

--- a/applications/main/clock/clock.c
+++ b/applications/main/clock/clock.c
@@ -159,18 +159,16 @@ static Clock* clock_alloc(const char* arguments) {
 
     furi_event_loop_timer_start(instance->timer, furi_ms_to_ticks(TIMER_INTERVAL_MS));
 
-    ClockSceneIdx initial_scene_idx;
     if(instance->arguments.do_skip_menu) {
         with_gui(instance->gui, {
             widget_set_visible(nav_bar_get_base(instance->back_nav_bar), false);
         });
 
-        initial_scene_idx = ClockSceneIdxClock;
+        static const uint32_t scenes[] = {ClockSceneIdxMain, ClockSceneIdxClock};
+        scene_manager_set_initial_scenes(instance->scene_manager, scenes, COUNT_OF(scenes));
     } else {
-        initial_scene_idx = ClockSceneIdxMain;
+        scene_manager_next_scene(instance->scene_manager, ClockSceneIdxMain);
     }
-
-    scene_manager_next_scene(instance->scene_manager, initial_scene_idx);
 
     return instance;
 }

--- a/applications/main/clock/scenes/scene_clock.c
+++ b/applications/main/clock/scenes/scene_clock.c
@@ -107,9 +107,7 @@ static bool clock_scene_clock_on_event(const SceneManagerEvent* event, void* con
             transition_overlay_show(instance->front_transition_overlay);
         });
 
-        if(!scene_manager_previous_scene(instance->scene_manager)) {
-            scene_manager_next_scene(instance->scene_manager, ClockSceneIdxMain);
-        }
+        scene_manager_previous_scene(instance->scene_manager);
 
         return true;
     }

--- a/applications/main/settings_menu/settings.c
+++ b/applications/main/settings_menu/settings.c
@@ -127,7 +127,7 @@ static SettingsApp* settings_alloc(void* app_arg) {
 
     if(instance->launching_subapp) {
         static const uint32_t scenes[] = {SettingsAppSceneIdStart, SettingsAppSceneIdMain};
-        scene_manager_set_initial_scenes(instance->scene_manager, scenes, COUNT_OF(scenes));
+        scene_manager_next_scenes(instance->scene_manager, scenes, COUNT_OF(scenes));
     } else {
         scene_manager_next_scene(instance->scene_manager, SettingsAppSceneIdStart);
     }

--- a/applications/main/settings_menu/settings.c
+++ b/applications/main/settings_menu/settings.c
@@ -125,9 +125,12 @@ static SettingsApp* settings_alloc(void* app_arg) {
         settings_event_queue_callback,
         instance);
 
-    scene_manager_next_scene(instance->scene_manager, SettingsAppSceneIdStart);
-    if(instance->launching_subapp)
-        scene_manager_next_scene(instance->scene_manager, SettingsAppSceneIdMain);
+    if(instance->launching_subapp) {
+        static const uint32_t scenes[] = {SettingsAppSceneIdStart, SettingsAppSceneIdMain};
+        scene_manager_set_initial_scenes(instance->scene_manager, scenes, COUNT_OF(scenes));
+    } else {
+        scene_manager_next_scene(instance->scene_manager, SettingsAppSceneIdStart);
+    }
 
     return instance;
 }

--- a/applications/services/gui/scene_manager.c
+++ b/applications/services/gui/scene_manager.c
@@ -155,13 +155,18 @@ SceneData* scene_manager_get_scene_data(const SceneManager* instance, uint32_t s
     return instance->scene_data[scene_id];
 }
 
-void scene_manager_set_initial_scenes(
+void scene_manager_next_scenes(
     SceneManager* instance,
     const uint32_t* scene_ids,
     size_t scene_ids_count) {
     furi_check(instance);
     furi_check(scene_ids_count > 0);
-    furi_check(SceneIdStack_size(instance->scene_id_stack) == 0);
+
+    const Scene* current_scene = scene_manager_get_current_scene(instance);
+
+    if(current_scene) {
+        current_scene->exit_callback(instance->context);
+    }
 
     for(size_t i = 0; i < scene_ids_count; ++i) {
         furi_check(scene_ids[i] < instance->scene_count);
@@ -173,19 +178,7 @@ void scene_manager_set_initial_scenes(
 }
 
 void scene_manager_next_scene(SceneManager* instance, uint32_t scene_id) {
-    furi_check(instance);
-    furi_check(scene_id < instance->scene_count);
-
-    const Scene* current_scene = scene_manager_get_current_scene(instance);
-
-    if(current_scene) {
-        current_scene->exit_callback(instance->context);
-    }
-
-    SceneIdStack_push_back(instance->scene_id_stack, scene_id);
-
-    const Scene* next_scene = scene_manager_get_current_scene(instance);
-    next_scene->enter_callback(instance->context);
+    scene_manager_next_scenes(instance, &scene_id, 1);
 }
 
 bool scene_manager_previous_scene(SceneManager* instance) {

--- a/applications/services/gui/scene_manager.c
+++ b/applications/services/gui/scene_manager.c
@@ -155,6 +155,23 @@ SceneData* scene_manager_get_scene_data(const SceneManager* instance, uint32_t s
     return instance->scene_data[scene_id];
 }
 
+void scene_manager_set_initial_scenes(
+    SceneManager* instance,
+    const uint32_t* scene_ids,
+    size_t scene_ids_count) {
+    furi_check(instance);
+    furi_check(scene_ids_count > 0);
+    furi_check(SceneIdStack_size(instance->scene_id_stack) == 0);
+
+    for(size_t i = 0; i < scene_ids_count; ++i) {
+        furi_check(scene_ids[i] < instance->scene_count);
+        SceneIdStack_push_back(instance->scene_id_stack, scene_ids[i]);
+    }
+
+    const Scene* next_scene = scene_manager_get_current_scene(instance);
+    next_scene->enter_callback(instance->context);
+}
+
 void scene_manager_next_scene(SceneManager* instance, uint32_t scene_id) {
     furi_check(instance);
     furi_check(scene_id < instance->scene_count);

--- a/applications/services/gui/scene_manager.h
+++ b/applications/services/gui/scene_manager.h
@@ -57,6 +57,11 @@ uint32_t scene_manager_get_current_scene_id(const SceneManager* instance);
 
 SceneData* scene_manager_get_scene_data(const SceneManager* instance, uint32_t scene_id);
 
+void scene_manager_set_initial_scenes(
+    SceneManager* instance,
+    const uint32_t* scene_ids,
+    size_t scene_ids_count);
+
 void scene_manager_next_scene(SceneManager* instance, uint32_t scene_id);
 
 bool scene_manager_previous_scene(SceneManager* instance);

--- a/applications/services/gui/scene_manager.h
+++ b/applications/services/gui/scene_manager.h
@@ -57,7 +57,7 @@ uint32_t scene_manager_get_current_scene_id(const SceneManager* instance);
 
 SceneData* scene_manager_get_scene_data(const SceneManager* instance, uint32_t scene_id);
 
-void scene_manager_set_initial_scenes(
+void scene_manager_next_scenes(
     SceneManager* instance,
     const uint32_t* scene_ids,
     size_t scene_ids_count);

--- a/applications/system/apps_menu/apps_menu.c
+++ b/applications/system/apps_menu/apps_menu.c
@@ -143,10 +143,11 @@ static AppsMenu* apps_menu_alloc(void* launching_application) {
             instance->back_container, instance->back_scene_window, 1);
     });
 
-    scene_manager_next_scene(instance->scene_manager, AppsMenuSceneIdStart);
-
     if(instance->launching_application) {
-        scene_manager_next_scene(instance->scene_manager, AppsMenuSceneIdMain);
+        static const uint32_t scenes[] = {AppsMenuSceneIdStart, AppsMenuSceneIdMain};
+        scene_manager_set_initial_scenes(instance->scene_manager, scenes, COUNT_OF(scenes));
+    } else {
+        scene_manager_next_scene(instance->scene_manager, AppsMenuSceneIdStart);
     }
 
     return instance;

--- a/applications/system/apps_menu/apps_menu.c
+++ b/applications/system/apps_menu/apps_menu.c
@@ -145,7 +145,7 @@ static AppsMenu* apps_menu_alloc(void* launching_application) {
 
     if(instance->launching_application) {
         static const uint32_t scenes[] = {AppsMenuSceneIdStart, AppsMenuSceneIdMain};
-        scene_manager_set_initial_scenes(instance->scene_manager, scenes, COUNT_OF(scenes));
+        scene_manager_next_scenes(instance->scene_manager, scenes, COUNT_OF(scenes));
     } else {
         scene_manager_next_scene(instance->scene_manager, AppsMenuSceneIdStart);
     }


### PR DESCRIPTION
> [!NOTE]
> * [**FW-1021**](https://flipper.atlassian.net/browse/FW-1021)

# What's new

- `scene_manager` `scene_manager_set_initial_scenes` API
- update some apps (`clock`, `apps_menu`, `settings_menu`) to use new `scene_manager`'s API
- entirely skip initial scenes loading if it has to be instantly replaced

# Verification 

- `clock`, `apps_menu`, `settings_menu` navigation logic didn't change
- re-entering `settings_menu` from it's subapplications doesn't cause main scene to be shown for a split second (back screen)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
