### PR TITLE
[FW-1029] BLE enable/disable could hang HTTP API

### DIFF
--- a/applications/services/ble/ble_api.c
+++ b/applications/services/ble/ble_api.c
@@ -5,7 +5,7 @@
 
 #define TAG "BleAPI"
 
-#define BLE_API_LOCK_TIMEOUT (100)
+#define BLE_API_LOCK_TIMEOUT (200)
 
 ///TODO: Rework command mechanism to reduce complexity
 static void ble_send_message(

--- a/applications/services/ble/ble_system_command_u5.c
+++ b/applications/services/ble/ble_system_command_u5.c
@@ -140,8 +140,8 @@ static bool ble_command_enable_response(BleIntercomFrameGeneric* frame, void* co
         ble_save_enabled_state(true);
     }
 
-    ble_command_unblock_with_result(instance, frame->header.result);
     ble_http_repeater_start(instance);
+    ble_command_unblock_with_result(instance, frame->header.result);
 
     BleState status = {
         .status = instance->status,
@@ -177,8 +177,8 @@ static bool ble_command_disable_response(BleIntercomFrameGeneric* frame, void* c
 
     ble_save_enabled_state(false);
 
-    ble_command_unblock_with_result(instance, frame->header.result);
     ble_http_repeater_stop();
+    ble_command_unblock_with_result(instance, frame->header.result);
 
     BleState status = {
         .status = instance->status,

--- a/applications/services/ble/http/ble_http_repeater.c
+++ b/applications/services/ble/http/ble_http_repeater.c
@@ -18,7 +18,6 @@ typedef struct {
     FuriSemaphore* wait;
     FuriSemaphore* uart_conn_sync;
     Ble* ble;
-    Network* network;
     bool exit;
 
     FuriMutex* session_lock;
@@ -132,7 +131,8 @@ static void ble_event_handler(struct mg_connection* conn, int ev, void* ev_data)
 
 static int32_t ble_http_repeater_thread_handler(void* p) {
     UNUSED(p);
-    network_init_current_thread(ble_http_repeater->network);
+    Network* network = furi_record_open(RECORD_NETWORK);
+    network_init_current_thread(network);
 
     mg_mgr_init(&ble_http_repeater->mgr);
     mg_wakeup_init(&ble_http_repeater->mgr);
@@ -148,7 +148,8 @@ static int32_t ble_http_repeater_thread_handler(void* p) {
     // Cleanup
     FURI_LOG_D(TAG, "Ble repeater stopped");
     mg_mgr_free(&ble_http_repeater->mgr);
-    network_deinit_current_thread(ble_http_repeater->network);
+    network_deinit_current_thread(network);
+    furi_record_close(RECORD_NETWORK);
 
     return 0;
 }
@@ -182,16 +183,12 @@ static void ble_http_repeater_free(BleHttpRepeater* instance) {
     furi_semaphore_free(instance->uart_conn_sync);
     furi_semaphore_free(instance->wait);
     furi_mutex_free(instance->session_lock);
-    furi_record_close(RECORD_NETWORK);
     free(instance);
 }
 
 void ble_http_repeater_init() {
     furi_assert(ble_http_init_mutex == NULL);
     ble_http_init_mutex = furi_mutex_alloc(FuriMutexTypeNormal);
-
-    Network* network = furi_record_open(RECORD_NETWORK);
-    network_init_current_thread(network);
 }
 
 void ble_http_repeater_start(Ble* ble) {

--- a/applications/services/ble/worker/ble_worker.c
+++ b/applications/services/ble/worker/ble_worker.c
@@ -29,6 +29,7 @@ static int32_t ble_worker_thread_callback(void* context) {
     ble_transmitter_subscribe(instance->transport, instance->event_loop, context);
     ble_incoming_nwp_event_processor_subscribe(instance->event_proc, instance->event_loop);
 
+    api_lock_unlock(instance->api_lock);
     furi_event_loop_run(instance->event_loop);
 
     ble_incoming_nwp_event_processor_unsubscribe(instance->event_proc, instance->event_loop);
@@ -46,6 +47,7 @@ BleWorker* ble_worker_init(BleConnectionStateChanged connect_callback, void* ctx
     BleWorker* instance = malloc(sizeof(BleWorker));
     instance->thread =
         furi_thread_alloc_ex("BleWorker", 3072U, ble_worker_thread_callback, instance);
+    instance->api_lock = api_lock_alloc_locked();
 
     instance->on_connection_changed_cb = connect_callback;
     instance->on_connection_changed_ctx = ctx;
@@ -88,10 +90,12 @@ bool ble_worker_register_service(BleServiceObject* service) {
 }
 
 void ble_worker_start() {
-    do {
-        ///TODO: Maybe some checks of thread state
-        furi_thread_start(ble_worker_instance->thread);
-    } while(false);
+    FuriThreadState state = furi_thread_get_state(ble_worker_instance->thread);
+    if(state == FuriThreadStateRunning) return;
+
+    api_lock_relock(ble_worker_instance->api_lock);
+    furi_thread_start(ble_worker_instance->thread);
+    api_lock_wait_unlock(ble_worker_instance->api_lock);
 }
 
 void ble_worker_stop() {

--- a/applications/services/ble/worker/ble_worker.c
+++ b/applications/services/ble/worker/ble_worker.c
@@ -116,6 +116,9 @@ void ble_worker_receive_confirm(uint16_t handle, uint8_t cccd_value) {
 }
 
 bool ble_worker_forget_pairing() {
+    if(ble_device_is_connected(ble_worker_instance->device)) {
+        ble_device_disconnect(ble_worker_instance->device);
+    }
     return ble_device_forget_paired(ble_worker_instance->device);
 }
 

--- a/applications/services/ble/worker/ble_worker_i.h
+++ b/applications/services/ble/worker/ble_worker_i.h
@@ -4,10 +4,12 @@
 
 #include "device/ble_device.h"
 #include "event_processor/ble_incoming_nwp_event_processor.h"
+#include <api_lock.h>
 
 struct BleWorker {
     FuriThread* thread;
     FuriEventLoop* event_loop;
+    FuriApiLock api_lock;
     BleIncomingNwpEventProcessor* event_proc;
     BleTransmitter* transport;
     BleDevice* device;

--- a/applications/services/ble/worker/device/ble_device.c
+++ b/applications/services/ble/worker/device/ble_device.c
@@ -128,11 +128,13 @@ bool ble_device_connection_close(BleDevice* instance) {
         ble_receiver_free(instance->receiver);
         instance->connection = NULL;
         instance->receiver = NULL;
-
-        instance->state = BleDeviceStateIdle;
         ble_service_registry_reset_cccds(instance->registry);
 
-        result = ble_device_start(instance);
+        if(instance->state != BleDeviceStateStopping) {
+            instance->state = BleDeviceStateIdle;
+            result = ble_device_start(instance);
+        } else
+            result = true;
     }
 
     return result;
@@ -169,6 +171,11 @@ bool ble_device_disconnect(BleDevice* instance) {
         result = true;
     }
     return result;
+}
+
+BleDeviceState ble_device_get_state(BleDevice* instance) {
+    furi_assert(instance);
+    return instance->state;
 }
 
 static bool ble_device_start_advertise_with_value(
@@ -229,7 +236,7 @@ static void ble_device_start_advertise(BleDevice* instance) {
 static bool ble_device_stop_advertise(BleDevice* instance) {
     bool result = false;
 
-    if(instance->state == BleDeviceStateAdvertising) {
+    if(instance->state == BleDeviceStateAdvertising || instance->state == BleDeviceStateStopping) {
         sl_status_t status = rsi_ble_stop_advertising();
 
         if(status != RSI_SUCCESS) {
@@ -258,16 +265,16 @@ bool ble_device_start(BleDevice* instance) {
 
 bool ble_device_stop(BleDevice* instance) {
     furi_assert(instance);
-
     bool result = false;
-    do {
-        if(!ble_device_disconnect(instance)) break;
-        if(!ble_device_stop_advertise(instance)) break;
-
+    if(instance->state == BleDeviceStateConnected) {
+        result = ble_device_disconnect(instance);
+        instance->state = result ? BleDeviceStateStopping : BleDeviceStateError;
+        result = false;
+    } else {
+        ble_device_stop_advertise(instance);
         instance->state = BleDeviceStateIdle;
-
         result = true;
-    } while(false);
+    }
     return result;
 }
 

--- a/applications/services/ble/worker/device/ble_device.h
+++ b/applications/services/ble/worker/device/ble_device.h
@@ -11,6 +11,7 @@ typedef enum {
     BleDeviceStateIdle,
     BleDeviceStateAdvertising,
     BleDeviceStateConnected,
+    BleDeviceStateStopping,
     BleDeviceStateError,
 } BleDeviceState;
 
@@ -37,6 +38,8 @@ void ble_device_connection_update(BleDevice* instance, FuriEventLoop* event_loop
 bool ble_device_disconnect(BleDevice* instance);
 
 bool ble_device_is_connected(BleDevice* instance);
+
+BleDeviceState ble_device_get_state(BleDevice* instance);
 
 void ble_device_set_name(BleDevice* instance, const char* name);
 

--- a/applications/services/ble/worker/event_processor/ble_event_handlers_gap.c
+++ b/applications/services/ble/worker/event_processor/ble_event_handlers_gap.c
@@ -63,7 +63,13 @@ bool ble_event_handler_gap_disconnected(size_t data_size, void* data, void* cont
 
     bool result = ble_device_connection_close(instance->device);
 
-    ble_worker_invoke_disconnect_callback(instance);
+    BleDeviceState state = ble_device_get_state(instance->device);
+    if(state == BleDeviceStateStopping) {
+        ble_incoming_nwp_event_processor_spawn_event(
+            instance->event_proc, BleIncomingNwpEventTypeExit, 0, NULL);
+    } else {
+        ble_worker_invoke_disconnect_callback(instance);
+    }
 
     return result;
 }
@@ -147,8 +153,8 @@ bool ble_event_handler_gap_exit(size_t data_size, void* data, void* context) {
     UNUSED(data);
     BleWorker* instance = context;
 
-    ble_device_stop(instance->device);
-
-    furi_event_loop_stop(instance->event_loop);
+    if(ble_device_stop(instance->device)) {
+        furi_event_loop_stop(instance->event_loop);
+    }
     return true;
 }


### PR DESCRIPTION
# What's new

- Proper network record open close in http repeater
- Http repeater start/stop is now done before api lock release
- Proper disconnect logic for case when bsb was connected to the remote during disable command
- Api timeout increased a little

# Verification 

- Run `repro_ble_enable_disable.sh` from ticket description

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
