### PR TITLE
[FW-1037] HTTP API Firmware Protection Flags

### DIFF
--- a/applications/services/gui/scene_manager.c
+++ b/applications/services/gui/scene_manager.c
@@ -160,6 +160,7 @@ void scene_manager_next_scenes(
     const uint32_t* scene_ids,
     size_t scene_ids_count) {
     furi_check(instance);
+    furi_check(scene_ids);
     furi_check(scene_ids_count > 0);
 
     const Scene* current_scene = scene_manager_get_current_scene(instance);

--- a/applications/services/web_server/http_api/api_status.c
+++ b/applications/services/web_server/http_api/api_status.c
@@ -75,6 +75,22 @@ static bool status_get_device(FuriString* json_str, ApiStatusCtx* context) {
             json_str, ",\"otp_timestamp\":%lu", furi_hal_version_get_hw_timestamp());
     }
 
+    uint32_t security_flags;
+    const char* firmware_security = "unknown";
+    if(updater_get_active_security_flags(&security_flags)) {
+        bool is_nwp_signed = security_flags & UpdateManifestSecurityFlagNwpSigned;
+        bool is_m4_signed = security_flags & UpdateManifestSecurityFlagM4Signed;
+
+        if(is_nwp_signed && is_m4_signed) {
+            firmware_security = "secure";
+        } else if(!is_nwp_signed && !is_m4_signed) {
+            firmware_security = "insecure";
+        } else {
+            firmware_security = "other";
+        }
+    }
+    furi_string_cat_printf(json_str, ",\"firmware_security\":\"%s\"", firmware_security);
+
     furi_string_cat_printf(json_str, "}");
     furi_string_free(temp_str);
     return true;

--- a/applications/services/web_server/http_api/http_api.h
+++ b/applications/services/web_server/http_api/http_api.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "../web_server_i.h"
 
-#define API_VERSION {24, 2, 0}
+#define API_VERSION {24, 3, 0}
 
 // Access logging (also used by web_server.c for static-file requests)
 int http_api_extract_status(const struct mg_connection* conn);

--- a/applications/services/web_server/openapi/openapi.yaml
+++ b/applications/services/web_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: BUSY Bar HTTP API
   description: HTTP API for BUSY Bar web server
-  version: 24.2.0
+  version: 24.3.0
   contact:
     name: tbd
 

--- a/applications/services/web_server/openapi/system.yaml
+++ b/applications/services/web_server/openapi/system.yaml
@@ -244,10 +244,21 @@ schemas:
         type: integer
         description: Production timestamp
         example: 1767225600
+      firmware_security:
+        type: string
+        description: >
+          Summary of firmware signature protection derived from the wireless
+          coprocessor (Si917) NWP and M4 signature state. "secure" - both NWP
+          and M4 firmware signature verification active; "insecure" - neither
+          active; "other" - mixed state (exactly one active); "unknown" -
+          coprocessor info not ready yet.
+        enum: ["secure", "insecure", "other", "unknown"]
+        example: "secure"
     required:
       - serial_number
       - usb_mac
       - otp_valid
+      - firmware_security
 
   StatusFirmware:
     type: object

--- a/applications/system/updater/updater.c
+++ b/applications/system/updater/updater.c
@@ -84,8 +84,7 @@ static UpdaterStatus updater_verify_security_flags(const UpdateManifest* manifes
 }
 #else // SRV_SL_INFO
 bool updater_get_active_security_flags(uint32_t* flags_out) {
-    UNUSED(flags_out);
-
+    *flags_out = 0;
     return false;
 }
 #endif // SRV_SL_INFO

--- a/applications/system/updater/updater.c
+++ b/applications/system/updater/updater.c
@@ -28,7 +28,7 @@ static const SlInfoSecurityMapping sl_security_mappings[] = {
     {"sl_m4_encrypt", "true", UpdateManifestSecurityFlagM4Encrypted},
 };
 
-static bool updater_get_device_security_flags(uint32_t* flags_out) {
+bool updater_get_active_security_flags(uint32_t* flags_out) {
     uint32_t device_flags = 0;
     bool is_ready = true;
     const SlInfo* sl_info = furi_record_open(RECORD_SL_INFO);
@@ -64,7 +64,7 @@ static UpdaterStatus updater_verify_security_flags(const UpdateManifest* manifes
     const uint32_t manifest_flags = updater_manifest_get_security_flags(manifest);
 
     uint32_t device_flags = 0;
-    if(!updater_get_device_security_flags(&device_flags)) {
+    if(!updater_get_active_security_flags(&device_flags)) {
         FURI_LOG_W(TAG, "SL info not ready, skipping security check");
         return UpdaterStatusOk;
     }
@@ -81,6 +81,12 @@ static UpdaterStatus updater_verify_security_flags(const UpdateManifest* manifes
 
     FURI_LOG_I(TAG, "Security flags OK (0x%lx)", manifest_flags);
     return UpdaterStatusOk;
+}
+#else // SRV_SL_INFO
+bool updater_get_active_security_flags(uint32_t* flags_out) {
+    UNUSED(flags_out);
+
+    return false;
 }
 #endif // SRV_SL_INFO
 

--- a/applications/system/updater/updater.h
+++ b/applications/system/updater/updater.h
@@ -8,6 +8,7 @@
 #include "settings/settings.h"
 
 #include <furi.h>
+#include <toolbox/update_lib/update_manifest.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -327,6 +328,18 @@ void updater_resume_autoupdates(Updater* instance);
  * @return     Version string
  */
 const char* updater_get_active_version(void);
+
+/** Get the device's active firmware protection flags
+ *
+ * Computes a bitmask of active UpdateManifestSecurityFlag bits from the
+ * wireless co-processor (Si917) NWP/M4 signature and encryption state.
+ *
+ * @param[out] flags Pointer to receive the security flags bitmask
+ *                   (see UpdateManifestSecurityFlag in update_manifest.h)
+ * @return     true if the info source is ready and the flags are valid,
+ *             false if it is not ready yet (*flags is set to 0)
+ */
+bool updater_get_active_security_flags(uint32_t* flags);
 
 /** Get the current updater settings
  *


### PR DESCRIPTION
> [!NOTE]
> * [**FW-1037**](https://flipper.atlassian.net/browse/FW-1037)

# What's new

- rename `updater_get_device_security_flags` into `updater_get_active_security_flags` & make it public API
- make `/api/status/device` HTTP API endpoint also return `firmware_security` value (enum with 4 possible values)

# Verification 

- `/api/status/device` includes `firmware_security` value
- `firmware_security` value is correct

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
