### PR TITLE
Wiseconnect: fix crashes during scanning in the presence of malformed packets

### DIFF
--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -352,7 +352,7 @@ static void wifi_scan_finished_event_handler(Wifi* instance, const WifiScanFinis
                 const sl_wifi_extended_scan_result_t* result_in = &scan_results[i];
                 WifiScanResult* result_out = &response.scan_results.data[i];
 
-                strncpy(result_out->ssid, (const char*)result_in->ssid, SSID_MAX_LEN);
+                strlcpy(result_out->ssid, (const char*)result_in->ssid, SSID_MAX_LEN);
                 result_out->security_mode = wifi_decode_security_mode(result_in->security_mode);
                 result_out->rssi = result_in->rssi;
             }


### PR DESCRIPTION
# What's new

- Fix memory corruption that could occur in the presence of malformed beacon packets

# Verification 

1. Install the firmware bundle
2. Open the web interface and press "Select network"
3. Run the Wifi fuzzing device nearby
4. Wait for a long time. No crashes should occur.

# Checklist (For Reviewer)

# Merge https://github.com/flipperdevices/wiseconnect/pull/7 first and adjust commit

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
