### PR TITLE
Fix Repository Cloning (`simplicity_sdk` LFS)

### DIFF
--- a/.github/expected-submodule-branches.txt
+++ b/.github/expected-submodule-branches.txt
@@ -14,7 +14,7 @@ lib/matter_zap        origin/dev
 lib/microtar          origin/master
 # lib/mongoose          origin/master  # upstream vendor pin, not on branch tip
 lib/nanopb            origin/maintenance_0.4
-lib/simplicity_sdk    origin/sisdk-2025.12.3
+lib/simplicity_sdk    origin/bsb
 # lib/stb/stb_repo      origin/master  # upstream vendor pin, not on branch tip
 # lib/thorvg            origin/main  # upstream vendor pin, not on branch tip
 lib/tinyusb           origin/ncm_packet_filter


### PR DESCRIPTION
# What's new

- remove `simplicity_sdk`'s `.gitattributes` file

# Verification 

- clone repository (using `git clone -b vanyww/fix-repo-clone https://github.com/flipperdevices/bsb-firmware.git --recursive`): no LFS error messages appear & repo is cloned cleanly

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
