### PR TITLE
[FW-1059] Fix NavBar flickering in Apps and Settings menus

### DIFF
--- a/applications/main/settings_menu/settings.c
+++ b/applications/main/settings_menu/settings.c
@@ -105,6 +105,7 @@ static SettingsApp* settings_alloc(void* app_arg) {
         nav_bar_set_header_text(instance->back_nav_bar, "SETTINGS");
         widget_set_height(nav_bar_get_base(instance->back_nav_bar), SETTINGS_NAV_BAR_HEIGHT);
         widget_set_padding(nav_bar_get_base(instance->back_nav_bar), 1, 0, 0, 2);
+        widget_set_visible(nav_bar_get_base(instance->back_nav_bar), false);
 
         instance->back_scene_window = widget_alloc(flex_layout_get_base(instance->back_container));
         flex_layout_set_child_widget_grow(

--- a/applications/system/apps_menu/apps_menu.c
+++ b/applications/system/apps_menu/apps_menu.c
@@ -137,6 +137,7 @@ static AppsMenu* apps_menu_alloc(void* launching_application) {
         nav_bar_set_header_text(instance->back_nav_bar, "APPS");
         widget_set_height(nav_bar_get_base(instance->back_nav_bar), 14);
         widget_set_padding(nav_bar_get_base(instance->back_nav_bar), 1, 0, 0, 0);
+        widget_set_visible(nav_bar_get_base(instance->back_nav_bar), false);
 
         instance->back_scene_window = widget_alloc(flex_layout_get_base(instance->back_container));
         flex_layout_set_child_widget_grow(


### PR DESCRIPTION
# What's new

[FW-1059]

- Fix NavBar flickering in Apps and Settings menus by not showing it by default

# Verification 

1. Flash the firmware bundle
2. Exit the currently running app (clock) so that the `APPS` screen is showing
3. Rapidly switch between `APPS` and `SETTINGS`
4. Ensure that there is no flickering navbar with `apps` or `settings` text

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-1059]: https://flipper.atlassian.net/browse/FW-1059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ