### PR TITLE
[FW-1060] Reconnect to AP after being kicked from it

### DIFF
--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -9,8 +9,10 @@
 #include "wifi_config.h"
 #include "wifi_backend_util.h"
 
-#define EVENT_QUEUE_SIZE       8
+#define EVENT_QUEUE_SIZE       16
 #define EVENT_QUEUE_TIMEOUT_MS 200
+
+#define REQUEST_QUEUE_SIZE 1
 
 #define NUM_CONNECTION_ATTEMPTS 3
 #define SCAN_INTERVAL_S         5
@@ -35,15 +37,10 @@
 #define INFO_TIMER_PERIOD_MS (15 * 1000)
 
 typedef enum {
-    WifiEventTypeRequestReceived,
     WifiEventTypeScanFinished,
     WifiEventTypeModuleStats,
     WifiEventTypeMax,
 } WifiEventType;
-
-typedef struct {
-    WifiRequest request;
-} WifiRequestReceivedEvent;
 
 typedef struct {
     sl_status_t status;
@@ -57,7 +54,6 @@ typedef struct {
 typedef struct {
     WifiEventType type;
     union {
-        WifiRequestReceivedEvent request_received;
         WifiScanFinishedEvent scan_finished;
         WifiModuleStatsEvent module_stats;
     };
@@ -274,19 +270,8 @@ static void wifi_intercom_rx_callback(const void* data, size_t data_size, void* 
 
     Wifi* instance = context;
 
-    WifiEvent wifi_event = {
-        .type = WifiEventTypeRequestReceived,
-    };
-
-    memcpy(&wifi_event.request_received, data, data_size);
-
-    const FuriStatus status = furi_message_queue_put(
-        instance->event_queue, &wifi_event, furi_ms_to_ticks(EVENT_QUEUE_TIMEOUT_MS));
-
-    if(status != FuriStatusOk) {
-        furi_check(status == FuriStatusErrorTimeout);
-        FURI_LOG_E(TAG, "BUG: %s failed to deliver event", __FUNCTION__);
-    }
+    const WifiRequest* request = data;
+    furi_check(furi_message_queue_put(instance->request_queue, request, 0) == FuriStatusOk);
 }
 
 static void wifi_net_intercom_rx_callback(const void* data, size_t data_size, void* context) {
@@ -300,23 +285,6 @@ static void wifi_net_intercom_rx_callback(const void* data, size_t data_size, vo
         ++instance->tx_drop_count;
         FURI_LOG_W(
             TAG, "TX: Dropped packet (%lu total), reason: 0x%lX", instance->tx_drop_count, status);
-    }
-}
-
-static void
-    wifi_request_received_event_handler(Wifi* instance, const WifiRequestReceivedEvent* event) {
-    const WifiRequest* request = &event->request;
-    const WifiRequestType request_type = request->type;
-    furi_check(request_type < WifiRequestTypeBackendInfo);
-
-    WifiResponse response = {0};
-    const sl_status_t status = wifi_request_handlers[request_type](instance, request, &response);
-
-    if(status != SL_STATUS_IN_PROGRESS) {
-        response.type = request_type;
-        response.status = wifi_decode_sl_status(status);
-
-        wifi_send_response(instance, &response);
     }
 }
 
@@ -477,9 +445,7 @@ static void wifi_event_queue_callback(FuriEventLoopObject* object, void* context
     while(furi_message_queue_get(instance->event_queue, &event, 0) == FuriStatusOk) {
         const WifiEventType event_type = event.type;
 
-        if(event_type == WifiEventTypeRequestReceived) {
-            wifi_request_received_event_handler(instance, &event.request_received);
-        } else if(event_type == WifiEventTypeScanFinished) {
+        if(event_type == WifiEventTypeScanFinished) {
             wifi_scan_finished_event_handler(instance, &event.scan_finished);
         } else if(event_type == WifiEventTypeModuleStats) {
             wifi_module_stats_event_handler(instance, &event.module_stats);
@@ -487,6 +453,45 @@ static void wifi_event_queue_callback(FuriEventLoopObject* object, void* context
             furi_crash("Invalid WifiEventType");
         }
     }
+}
+
+static void wifi_request_queue_callback(FuriEventLoopObject* object, void* context) {
+    furi_assert(context);
+
+    Wifi* instance = context;
+    furi_assert(object == instance->request_queue);
+
+    WifiRequest request;
+    furi_check(furi_message_queue_get(instance->request_queue, &request, 0) == FuriStatusOk);
+
+    const WifiRequestType request_type = request.type;
+    furi_check(request_type < WifiRequestTypeBackendInfo);
+
+    WifiResponse response = {0};
+    const sl_status_t status = wifi_request_handlers[request_type](instance, &request, &response);
+
+    if(status != SL_STATUS_IN_PROGRESS) {
+        response.type = request_type;
+        response.status = wifi_decode_sl_status(status);
+
+        wifi_send_response(instance, &response);
+    }
+}
+
+static bool wifi_send_event(Wifi* instance, const WifiEvent* event) {
+    bool success;
+
+    const FuriStatus status = furi_message_queue_put(
+        instance->event_queue, event, furi_ms_to_ticks(EVENT_QUEUE_TIMEOUT_MS));
+
+    if(status == FuriStatusOk) {
+        success = true;
+    } else {
+        furi_check(status == FuriStatusErrorTimeout);
+        success = false;
+    }
+
+    return success;
 }
 
 static sl_status_t wifi_scan_callback(
@@ -517,11 +522,7 @@ static sl_status_t wifi_scan_callback(
                 },
         };
 
-        const FuriStatus status = furi_message_queue_put(
-            instance->event_queue, &wifi_event, furi_ms_to_ticks(EVENT_QUEUE_TIMEOUT_MS));
-
-        if(status != FuriStatusOk) {
-            furi_check(status == FuriStatusErrorTimeout);
+        if(!wifi_send_event(instance, &wifi_event)) {
             FURI_LOG_E(TAG, "BUG: %s failed to deliver event", __FUNCTION__);
         }
     }
@@ -554,11 +555,7 @@ static sl_status_t
                 },
         };
 
-        const FuriStatus status = furi_message_queue_put(
-            instance->event_queue, &wifi_event, furi_ms_to_ticks(EVENT_QUEUE_TIMEOUT_MS));
-
-        if(status != FuriStatusOk) {
-            furi_check(status == FuriStatusErrorTimeout);
+        if(!wifi_send_event(instance, &wifi_event)) {
             FURI_LOG_E(TAG, "BUG: %s failed to deliver event", __FUNCTION__);
         }
     }
@@ -621,6 +618,7 @@ static Wifi* wifi_alloc(void) {
 
     instance->event_loop = furi_event_loop_alloc();
     instance->event_queue = furi_message_queue_alloc(EVENT_QUEUE_SIZE, sizeof(WifiEvent));
+    instance->request_queue = furi_message_queue_alloc(REQUEST_QUEUE_SIZE, sizeof(WifiRequest));
     instance->event_pubsub = furi_pubsub_alloc();
     instance->info_timer = furi_event_loop_timer_alloc(
         instance->event_loop, wifi_backend_info_callback, FuriEventLoopTimerTypePeriodic, instance);
@@ -634,6 +632,13 @@ static Wifi* wifi_alloc(void) {
         instance->event_queue,
         FuriEventLoopEventIn,
         wifi_event_queue_callback,
+        instance);
+
+    furi_event_loop_subscribe_message_queue(
+        instance->event_loop,
+        instance->request_queue,
+        FuriEventLoopEventIn,
+        wifi_request_queue_callback,
         instance);
 
     Intercom* intercom = furi_record_open(RECORD_INTERCOM);

--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -416,6 +416,11 @@ static void wifi_module_stats_event_handler(Wifi* instance, const WifiModuleStat
     } else if(state_code == STATE_CODE_UNSPECIFIED) {
         if(reason_code == REASON_CODE_UNSPECIFIED) {
             /* Nothing, occurs under normal operation */
+        } else if(reason_code == REASON_CODE_NO_RESPONSE) {
+            if(instance->state != WifiBackendStateReconnecting) {
+                FURI_LOG_W(TAG, "No response from AP while connected/disconnected");
+            }
+
         } else if(reason_code == REASON_CODE_ASSOC_DENIAL) {
             FURI_LOG_W(TAG, "Forcefully disconnected from AP");
 
@@ -424,6 +429,11 @@ static void wifi_module_stats_event_handler(Wifi* instance, const WifiModuleStat
                 wifi_net_tcpip_netif_down(instance);
 
                 wifi_stop_info_polling(instance);
+            }
+
+        } else if(reason_code == REASON_CODE_AP_NOT_FOUND) {
+            if(instance->state != WifiBackendStateReconnecting) {
+                FURI_LOG_W(TAG, "AP not found while connected/disconnected");
             }
 
         } else {

--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -19,17 +19,18 @@
 #define STATE_CODE_UPPER_MASK 0xF0
 #define REASON_CODE_MSB_MASK  0x7F
 
-#define STATE_CODE_NO_REASON    0x00
+#define STATE_CODE_UNSPECIFIED  0x00
 #define STATE_CODE_ASSOCIATED   0x80
 #define STATE_CODE_DEASSOCIATED 0x90
 
-#define REASON_CODE_NO_REASON    0x00
+#define REASON_CODE_UNSPECIFIED  0x00
 #define REASON_CODE_NO_RESPONSE  0x01
 #define REASON_CODE_ASSOC_DENIAL 0x02
 #define REASON_CODE_AP_NOT_FOUND 0x03
 #define REASON_CODE_DEAUTH_USER  0x06
 #define REASON_CODE_KEY_FAILURE  0x08
 #define REASON_CODE_BEACON_LOSS  0x10
+#define REASON_CODE_UNKNOWN_ERR  0x0F
 
 #define INFO_TIMER_PERIOD_MS (15 * 1000)
 
@@ -433,15 +434,20 @@ static void wifi_module_stats_event_handler(Wifi* instance, const WifiModuleStat
                 FURI_LOG_T(TAG, "Authentication error");
             }
 
+        } else if(reason_code == REASON_CODE_UNKNOWN_ERR) {
+            if(instance->state != WifiBackendStateDisconnected) {
+                FURI_LOG_W(TAG, "Unknown error while connected/reconnecting");
+            }
+
         } else {
             wifi_log_unhandled_reason_code(state_code, reason_code);
         }
 
         wifi_stop_info_polling(instance);
 
-    } else if(state_code == STATE_CODE_NO_REASON) {
-        if(reason_code == REASON_CODE_NO_REASON) {
-            /* Nothing */
+    } else if(state_code == STATE_CODE_UNSPECIFIED) {
+        if(reason_code == REASON_CODE_UNSPECIFIED) {
+            /* Nothing, occurs under normal operation */
         } else if(reason_code == REASON_CODE_ASSOC_DENIAL) {
             FURI_LOG_W(TAG, "Forcefully disconnected from AP");
 

--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -16,8 +16,8 @@
 #define SCAN_INTERVAL_S         5
 #define BEACON_MISSED_COUNT     40
 
-#define STATE_CODE_MASK  0xF0
-#define REASON_CODE_MASK 0x0F
+#define STATE_CODE_UPPER_MASK 0xF0
+#define REASON_CODE_MSB_MASK  0x7F
 
 #define STATE_CODE_NO_REASON    0x00
 #define STATE_CODE_ASSOCIATED   0x80
@@ -29,6 +29,7 @@
 #define REASON_CODE_AP_NOT_FOUND 0x03
 #define REASON_CODE_DEAUTH_USER  0x06
 #define REASON_CODE_KEY_FAILURE  0x08
+#define REASON_CODE_BEACON_LOSS  0x10
 
 #define INFO_TIMER_PERIOD_MS (15 * 1000)
 
@@ -388,8 +389,8 @@ static void wifi_log_unhandled_reason_code(uint8_t state_code, uint8_t reason_co
 }
 
 static void wifi_module_stats_event_handler(Wifi* instance, const WifiModuleStatsEvent* event) {
-    const uint8_t state_code = event->state_code & STATE_CODE_MASK;
-    const uint8_t reason_code = event->reason_code & REASON_CODE_MASK;
+    const uint8_t state_code = event->state_code & STATE_CODE_UPPER_MASK;
+    const uint8_t reason_code = event->reason_code & REASON_CODE_MSB_MASK;
 
     if(state_code == STATE_CODE_ASSOCIATED) {
         if(instance->state == WifiBackendStateReconnecting) {
@@ -408,7 +409,7 @@ static void wifi_module_stats_event_handler(Wifi* instance, const WifiModuleStat
                 FURI_LOG_W(TAG, "Deassociation by user request while disconnected");
             }
 
-        } else if(reason_code == REASON_CODE_NO_REASON || reason_code == REASON_CODE_NO_RESPONSE) {
+        } else if(reason_code == REASON_CODE_NO_RESPONSE || reason_code == REASON_CODE_BEACON_LOSS) {
             if(instance->state == WifiBackendStateConnected) {
                 wifi_set_state(instance, WifiBackendStateReconnecting);
                 wifi_net_tcpip_netif_down(instance);

--- a/applications/services/wifi/wifi_backend.c
+++ b/applications/services/wifi/wifi_backend.c
@@ -16,18 +16,19 @@
 #define SCAN_INTERVAL_S         5
 #define BEACON_MISSED_COUNT     40
 
-#define STATE_CODE_UPPER_MASK 0xF0
-#define REASON_CODE_MSB_MASK  0x7F
+#define STATE_CODE_MASK  0xF0
+#define REASON_CODE_MASK 0x0F
 
+#define STATE_CODE_NO_REASON    0x00
 #define STATE_CODE_ASSOCIATED   0x80
 #define STATE_CODE_DEASSOCIATED 0x90
 
+#define REASON_CODE_NO_REASON    0x00
 #define REASON_CODE_NO_RESPONSE  0x01
 #define REASON_CODE_ASSOC_DENIAL 0x02
 #define REASON_CODE_AP_NOT_FOUND 0x03
 #define REASON_CODE_DEAUTH_USER  0x06
 #define REASON_CODE_KEY_FAILURE  0x08
-#define REASON_CODE_BEACON_LOSS  0x10
 
 #define INFO_TIMER_PERIOD_MS (15 * 1000)
 
@@ -371,9 +372,24 @@ static void wifi_scan_finished_event_handler(Wifi* instance, const WifiScanFinis
     wifi_send_response(instance, &response);
 }
 
+static void wifi_start_info_polling(Wifi* instance) {
+    furi_event_loop_timer_start(instance->info_timer, INFO_TIMER_PERIOD_MS);
+    furi_event_loop_pend_callback(instance->event_loop, wifi_backend_info_callback, instance);
+}
+
+static void wifi_stop_info_polling(Wifi* instance) {
+    furi_event_loop_timer_stop(instance->info_timer);
+    furi_event_loop_pend_callback(instance->event_loop, wifi_backend_info_callback, instance);
+}
+
+static void wifi_log_unhandled_reason_code(uint8_t state_code, uint8_t reason_code) {
+    FURI_LOG_E(
+        TAG, "BUG: Unhandled module state 0x%hhX | 0x%hhX, please report", state_code, reason_code);
+}
+
 static void wifi_module_stats_event_handler(Wifi* instance, const WifiModuleStatsEvent* event) {
-    const uint8_t state_code = event->state_code & STATE_CODE_UPPER_MASK;
-    const uint8_t reason_code = event->reason_code & REASON_CODE_MSB_MASK;
+    const uint8_t state_code = event->state_code & STATE_CODE_MASK;
+    const uint8_t reason_code = event->reason_code & REASON_CODE_MASK;
 
     if(state_code == STATE_CODE_ASSOCIATED) {
         if(instance->state == WifiBackendStateReconnecting) {
@@ -384,8 +400,7 @@ static void wifi_module_stats_event_handler(Wifi* instance, const WifiModuleStat
             FURI_LOG_W(TAG, "Association while disconnected");
         }
 
-        furi_event_loop_timer_start(instance->info_timer, INFO_TIMER_PERIOD_MS);
-        furi_event_loop_pend_callback(instance->event_loop, wifi_backend_info_callback, instance);
+        wifi_start_info_polling(instance);
 
     } else if(state_code == STATE_CODE_DEASSOCIATED) {
         if(reason_code == REASON_CODE_DEAUTH_USER) {
@@ -393,7 +408,7 @@ static void wifi_module_stats_event_handler(Wifi* instance, const WifiModuleStat
                 FURI_LOG_W(TAG, "Deassociation by user request while disconnected");
             }
 
-        } else if(reason_code == REASON_CODE_NO_RESPONSE || reason_code == REASON_CODE_BEACON_LOSS) {
+        } else if(reason_code == REASON_CODE_NO_REASON || reason_code == REASON_CODE_NO_RESPONSE) {
             if(instance->state == WifiBackendStateConnected) {
                 wifi_set_state(instance, WifiBackendStateReconnecting);
                 wifi_net_tcpip_netif_down(instance);
@@ -418,11 +433,27 @@ static void wifi_module_stats_event_handler(Wifi* instance, const WifiModuleStat
             }
 
         } else {
-            FURI_LOG_E(TAG, "BUG: Unhandled reason code 0x%hhX, please report", reason_code);
+            wifi_log_unhandled_reason_code(state_code, reason_code);
         }
 
-        furi_event_loop_timer_stop(instance->info_timer);
-        furi_event_loop_pend_callback(instance->event_loop, wifi_backend_info_callback, instance);
+        wifi_stop_info_polling(instance);
+
+    } else if(state_code == STATE_CODE_NO_REASON) {
+        if(reason_code == REASON_CODE_NO_REASON) {
+            /* Nothing */
+        } else if(reason_code == REASON_CODE_ASSOC_DENIAL) {
+            FURI_LOG_W(TAG, "Forcefully disconnected from AP");
+
+            if(instance->state == WifiBackendStateConnected) {
+                wifi_set_state(instance, WifiBackendStateReconnecting);
+                wifi_net_tcpip_netif_down(instance);
+
+                wifi_stop_info_polling(instance);
+            }
+
+        } else {
+            wifi_log_unhandled_reason_code(state_code, reason_code);
+        }
 
     } else {
         FURI_LOG_T(TAG, "Module state: 0x%hhX, reason: 0x%hhX", state_code, reason_code);

--- a/applications/services/wifi/wifi_backend_i.h
+++ b/applications/services/wifi/wifi_backend_i.h
@@ -15,6 +15,7 @@
 struct Wifi {
     FuriEventLoop* event_loop;
     FuriMessageQueue* event_queue;
+    FuriMessageQueue* request_queue;
     FuriEventLoopTimer* info_timer;
     FuriPubSub* event_pubsub;
     IntercomChannel* intercom_ch_control;

--- a/targets/f64/config/wifi_config.c
+++ b/targets/f64/config/wifi_config.c
@@ -32,7 +32,8 @@ const sl_wifi_device_configuration_t wifi_config_client = {
             .custom_feature_bit_map =
                 (SL_SI91X_CUSTOM_FEAT_EXTENTION_VALID |
                  SL_SI91X_CUSTOM_FEAT_SOC_CLK_CONFIG_120MHZ |
-                 SL_SI91X_CUSTOM_FEAT_ASYNC_CONNECTION_STATUS),
+                 SL_SI91X_CUSTOM_FEAT_ASYNC_CONNECTION_STATUS |
+                 SL_SI91X_CUSTOM_FEAT_ENABLE_AP_BLACKLIST),
             .ext_custom_feature_bit_map =
                 (SL_SI91X_EXT_FEAT_XTAL_CLK | SL_SI91X_EXT_FEAT_IEEE_80211W | MEMORY_CONFIG |
                  BIT(7)

--- a/targets/f64/config/wifi_config.c
+++ b/targets/f64/config/wifi_config.c
@@ -33,6 +33,7 @@ const sl_wifi_device_configuration_t wifi_config_client = {
                 (SL_SI91X_CUSTOM_FEAT_EXTENTION_VALID |
                  SL_SI91X_CUSTOM_FEAT_SOC_CLK_CONFIG_120MHZ |
                  SL_SI91X_CUSTOM_FEAT_ASYNC_CONNECTION_STATUS |
+                 /* The below feature flag actually DISABLES the blocklist */
                  SL_SI91X_CUSTOM_FEAT_ENABLE_AP_BLACKLIST),
             .ext_custom_feature_bit_map =
                 (SL_SI91X_EXT_FEAT_XTAL_CLK | SL_SI91X_EXT_FEAT_IEEE_80211W | MEMORY_CONFIG |


### PR DESCRIPTION
# What's new

[FW-1060]

- Reconnect to AP after being kicked from it
- Use separate queues for events and request
- Harden assumptions about Wifi backend requests
- Disable AP blocklist to prevent connection to weak/remote APs (yes, despite the define name)

# Verification

1. Flash the firmware bundle.
2. Connect to a multi-AP Wifi network (tested in London office)
3. From the network control panel, forcefully disconnect the device
4. Ensure that device reconnects to the same AP
5. Ensure that there are no regressions

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-1060]: https://flipper.atlassian.net/browse/FW-1060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ