### PR TITLE
[FW-1067] Prevent Matter event queue from clogging on failure

### DIFF
--- a/applications/services/matter/matter_f64.cpp
+++ b/applications/services/matter/matter_f64.cpp
@@ -50,12 +50,15 @@ public:
     MatterSrv(void);
     bool init(void);
     void deinit(void);
+    void run(void);
 
     IntercomChannel* m_intercom_ch;
     StatusLights* m_status_lights;
     FuriSemaphore* m_initialization_received;
 
 private:
+    void init_internal(void);
+
     CommonCaseDeviceServerInitParams m_server_init_params;
     BsbFabricTableDelegate m_fabric_delegate;
     ::Identify m_identify;
@@ -340,9 +343,8 @@ MatterSrv::MatterSrv(void)
 }
 
 bool MatterSrv::init(void) {
-    bool is_stack_inited = false;
-
     CHIP_ERROR err;
+    bool success = false;
 
     do {
         err = MemoryInit();
@@ -355,8 +357,22 @@ bool MatterSrv::init(void) {
             break;
         }
 
-        is_stack_inited = true;
+        success = true;
 
+    } while(false);
+
+    if(!success) {
+        FURI_LOG_E(TAG, "Early initialization failed: 0x%lx", err.Format());
+    }
+
+    return success;
+}
+
+void MatterSrv::init_internal(void) {
+    CHIP_ERROR err;
+    bool success = false;
+
+    do {
         StackLock lock;
 
         auto intercom = static_cast<Intercom*>(furi_record_open(RECORD_INTERCOM));
@@ -392,23 +408,30 @@ bool MatterSrv::init(void) {
 
         matter_send_current_state(this);
         matter_send_fabric_count_update(this);
-        MatterIntercomFrame notification = {
+
+        const MatterIntercomFrame notification = {
             .type = MatterIntercomFrameTypeBackendReady,
         };
+
         matter_send_frame(this, &notification);
+
+        success = true;
 
     } while(false);
 
-    if(err != CHIP_NO_ERROR) {
+    if(!success) {
         FURI_LOG_E(TAG, "Initialization failed: 0x%lx", err.Format());
     }
-
-    return is_stack_inited;
 }
 
 void MatterSrv::deinit(void) {
     PlatformMgr().Shutdown();
     furi_thread_suspend(furi_thread_get_current_id());
+}
+
+void MatterSrv::run(void) {
+    init_internal();
+    PlatformMgr().RunEventLoop();
 }
 
 extern "C" {
@@ -421,7 +444,7 @@ int matter_srv(void* arg) {
     matter_global_srv = new MatterSrv;
 
     if(matter_global_srv->init()) {
-        PlatformMgr().RunEventLoop();
+        matter_global_srv->run();
     }
 
     matter_global_srv->deinit();

--- a/applications/services/matter/matter_f64.cpp
+++ b/applications/services/matter/matter_f64.cpp
@@ -422,9 +422,9 @@ int matter_srv(void* arg) {
 
     if(matter_global_srv->init()) {
         PlatformMgr().RunEventLoop();
-    } else {
-        matter_global_srv->deinit();
     }
+
+    matter_global_srv->deinit();
 
     return 0;
 }

--- a/applications/services/matter/matter_f64.cpp
+++ b/applications/services/matter/matter_f64.cpp
@@ -48,7 +48,8 @@ class BsbFabricTableDelegate : public FabricTable::Delegate {
 class MatterSrv {
 public:
     MatterSrv(void);
-    CHIP_ERROR init(void);
+    bool init(void);
+    void deinit(void);
 
     IntercomChannel* m_intercom_ch;
     StatusLights* m_status_lights;
@@ -208,7 +209,7 @@ static void matter_handle_frame(const void* data, size_t data_size, void* contex
 }
 
 /**
- * @brief Notifies u5 about an updated state 
+ * @brief Notifies u5 about an updated state
  */
 static void matter_send_state_update(MatterSrv* matter, bool state) {
     MatterIntercomFrame frame = {
@@ -338,7 +339,9 @@ MatterSrv::MatterSrv(void)
     m_initialization_received = furi_semaphore_alloc(1, 0);
 }
 
-CHIP_ERROR MatterSrv::init(void) {
+bool MatterSrv::init(void) {
+    bool is_stack_inited = false;
+
     CHIP_ERROR err;
 
     do {
@@ -351,6 +354,8 @@ CHIP_ERROR MatterSrv::init(void) {
         if(err != CHIP_NO_ERROR) {
             break;
         }
+
+        is_stack_inited = true;
 
         StackLock lock;
 
@@ -394,7 +399,16 @@ CHIP_ERROR MatterSrv::init(void) {
 
     } while(false);
 
-    return err;
+    if(err != CHIP_NO_ERROR) {
+        FURI_LOG_E(TAG, "Initialization failed: 0x%lx", err.Format());
+    }
+
+    return is_stack_inited;
+}
+
+void MatterSrv::deinit(void) {
+    PlatformMgr().Shutdown();
+    furi_thread_suspend(furi_thread_get_current_id());
 }
 
 extern "C" {
@@ -406,14 +420,10 @@ int matter_srv(void* arg) {
 
     matter_global_srv = new MatterSrv;
 
-    const auto err = matter_global_srv->init();
-
-    if(err == CHIP_NO_ERROR) {
+    if(matter_global_srv->init()) {
         PlatformMgr().RunEventLoop();
-
     } else {
-        FURI_LOG_E(TAG, "Failed to start: 0x%lx", err.Format());
-        furi_thread_suspend(furi_thread_get_current_id());
+        matter_global_srv->deinit();
     }
 
     return 0;

--- a/lib/matter_glue/platform/bsb/ConnectivityManagerImpl.cpp
+++ b/lib/matter_glue/platform/bsb/ConnectivityManagerImpl.cpp
@@ -72,18 +72,32 @@ void ConnectivityManagerImpl::WifiEvent(const void* message, void* context) {
 }
 
 CHIP_ERROR ConnectivityManagerImpl::_Init(void) {
+    if(mIsInitialized) {
+        return CHIP_NO_ERROR;
+    }
+
     auto* network = static_cast<Network*>(furi_record_open(RECORD_NETWORK));
     network_init_current_thread(network);
 
-    mIsConnected = false;
     mWifiPubSub = static_cast<FuriPubSub*>(furi_record_open(RECORD_WIFI));
     mPubSubSub = furi_pubsub_subscribe(mWifiPubSub, ConnectivityManagerImpl::WifiEvent, this);
+
+    mIsConnected = false;
+    mIsInitialized = true;
 
     return CHIP_NO_ERROR;
 }
 
 void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent* event) {
     ChipLogDetail(DeviceLayer, "Platform event of type %hu", event->Type);
+}
+
+void ConnectivityManagerImpl::_Shutdown(void) {
+    if(!mIsInitialized) {
+        return;
+    }
+
+    furi_pubsub_unsubscribe(mWifiPubSub, mPubSubSub);
 }
 
 } // namespace DeviceLayer

--- a/lib/matter_glue/platform/bsb/ConnectivityManagerImpl.cpp
+++ b/lib/matter_glue/platform/bsb/ConnectivityManagerImpl.cpp
@@ -26,8 +26,6 @@
 
 #include <app/server/Server.h>
 
-#include <network/network.h>
-
 #include <wifi/wifi_common_i.h>
 
 namespace chip {
@@ -76,8 +74,8 @@ CHIP_ERROR ConnectivityManagerImpl::_Init(void) {
         return CHIP_NO_ERROR;
     }
 
-    auto* network = static_cast<Network*>(furi_record_open(RECORD_NETWORK));
-    network_init_current_thread(network);
+    mNetwork = static_cast<Network*>(furi_record_open(RECORD_NETWORK));
+    network_init_current_thread(mNetwork);
 
     mWifiPubSub = static_cast<FuriPubSub*>(furi_record_open(RECORD_WIFI));
     mPubSubSub = furi_pubsub_subscribe(mWifiPubSub, ConnectivityManagerImpl::WifiEvent, this);
@@ -98,6 +96,12 @@ void ConnectivityManagerImpl::_Shutdown(void) {
     }
 
     furi_pubsub_unsubscribe(mWifiPubSub, mPubSubSub);
+    furi_record_close(RECORD_WIFI);
+
+    network_deinit_current_thread(mNetwork);
+    furi_record_close(RECORD_NETWORK);
+
+    mIsInitialized = false;
 }
 
 } // namespace DeviceLayer

--- a/lib/matter_glue/platform/bsb/ConnectivityManagerImpl.h
+++ b/lib/matter_glue/platform/bsb/ConnectivityManagerImpl.h
@@ -43,10 +43,12 @@ class ConnectivityManagerImpl final
     // Allow the ConnectivityManager interface class to delegate method calls to
     // the implementation methods provided by this class.
     friend class ConnectivityManager;
+    friend class PlatformManagerImpl;
 
 private:
     // ===== Members that implement the ConnectivityManager abstract interface.
     CHIP_ERROR _Init(void);
+    void _Shutdown(void);
     void _OnPlatformEvent(const ChipDeviceEvent* event);
     bool _IsWiFiStationConnected(void);
 
@@ -59,7 +61,8 @@ private:
     static void WifiEvent(const void* message, void* context);
     FuriPubSub* mWifiPubSub;
     FuriPubSubSubscription* mPubSubSub;
-    bool mIsConnected;
+    bool mIsConnected = false;
+    bool mIsInitialized = false;
 };
 
 /**

--- a/lib/matter_glue/platform/bsb/ConnectivityManagerImpl.h
+++ b/lib/matter_glue/platform/bsb/ConnectivityManagerImpl.h
@@ -27,6 +27,8 @@
 #include <platform/internal/GenericConnectivityManagerImpl_NoThread.h>
 #include <platform/internal/GenericConnectivityManagerImpl_WiFi.h>
 
+#include <network/network.h>
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -59,6 +61,7 @@ private:
     static ConnectivityManagerImpl sInstance;
 
     static void WifiEvent(const void* message, void* context);
+    Network* mNetwork;
     FuriPubSub* mWifiPubSub;
     FuriPubSubSubscription* mPubSubSub;
     bool mIsConnected = false;

--- a/lib/matter_glue/platform/bsb/PlatformManagerImpl.cpp
+++ b/lib/matter_glue/platform/bsb/PlatformManagerImpl.cpp
@@ -102,8 +102,8 @@ void PlatformManagerImpl::UpdateOperationalHours(System::Layer* systemLayer, voi
 }
 
 void PlatformManagerImpl::_Shutdown() {
-    Internal::GenericPlatformManagerImpl_Furi<PlatformManagerImpl>::_Shutdown();
     ConnectivityMgrImpl()._Shutdown();
+    Internal::GenericPlatformManagerImpl_Furi<PlatformManagerImpl>::_Shutdown();
 }
 
 } // namespace DeviceLayer

--- a/lib/matter_glue/platform/bsb/PlatformManagerImpl.cpp
+++ b/lib/matter_glue/platform/bsb/PlatformManagerImpl.cpp
@@ -103,6 +103,7 @@ void PlatformManagerImpl::UpdateOperationalHours(System::Layer* systemLayer, voi
 
 void PlatformManagerImpl::_Shutdown() {
     Internal::GenericPlatformManagerImpl_Furi<PlatformManagerImpl>::_Shutdown();
+    ConnectivityMgrImpl()._Shutdown();
 }
 
 } // namespace DeviceLayer


### PR DESCRIPTION
# What's new

[FW-1067]

- Implement additional failure handling logic that either:
  - Runs Matter event loop when it is safe to do so, or
  - Shuts down Matter stack if it's not safe to run the event loop
- Prevent incoming events from clogging Matter event queue

# Verification 

1. Flash the firmware bundle
2. Have a device with no matter provisioning (it should print `[MatterSrv] Initialization failed` in Si917 logs on startup)
3. Disconnect/reconnect from Wi-fi multiple times (probably up to 50)
4. The device should not display `System Error`.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-1067]: https://flipper.atlassian.net/browse/FW-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ