### PR TITLE
[js_runner] Fix crash on empty strings and script files

### DIFF
--- a/applications/services/js_runner/js_runner.c
+++ b/applications/services/js_runner/js_runner.c
@@ -97,7 +97,7 @@ JsRunnerError js_runner_run(
             break;
         }
         uint64_t file_size = storage_file_size(f);
-        char* buf = malloc(file_size);
+        char* buf = malloc(file_size ? file_size : 1);
         if(storage_file_read(f, buf, file_size) != file_size) {
             ret = JsRunnerErrorCannotOpenFile;
             free(buf);

--- a/applications/services/js_runner/js_runner_console.c
+++ b/applications/services/js_runner/js_runner_console.c
@@ -35,7 +35,7 @@ static jerry_value_t console_log(
 
         jerry_size_t size = jerry_string_size(str, JERRY_ENCODING_UTF8);
 
-        char* buf = malloc(size);
+        char* buf = malloc(size ? size : 1);
 
         jerry_string_to_buffer(str, JERRY_ENCODING_UTF8, (jerry_char_t*)buf, size);
 

--- a/targets/f21/jerryscript/jerryscript_glue.c
+++ b/targets/f21/jerryscript/jerryscript_glue.c
@@ -111,7 +111,7 @@ jerry_char_t* jerry_port_source_read(const char* file_name_p, jerry_size_t* out_
             FURI_LOG_E(TAG, "File is too large %s", abs_path_cstr);
             break;
         }
-        result = malloc(file_size);
+        result = malloc(file_size ? file_size : 1);
         size_t read_bytes = storage_file_read(f, result, file_size);
         if(read_bytes != file_size) {
             FURI_LOG_E(TAG, "Error reading file %s", abs_path_cstr);


### PR DESCRIPTION
# What's new

`malloc(0)` is a hard crash on this firmware rather than a NULL return. `memmgr_heap.c:512` is
`furi_check(pvReturn, xWantedSize ? "out of memory" : "malloc(0)")`, and `furi_check` is compiled
in on release builds, unlike `furi_assert`.

Three allocations in the JS runner take their size straight from user data, and all three accept
zero:

- `js_runner_console.c:38` sizes the buffer from the UTF-8 length of the stringified argument, so
  `console.log("")` takes the device down.
- `js_runner.c:100` uses the entry point script's file size, so a zero-byte `.js` file does the
  same.
- `jerryscript_glue.c:114` uses an imported module's file size. It already rejects files at the
  top end (`file_size >= UINT32_MAX`), just not at the bottom.

I guarded them the way `fkermit.c:149` already guards the same hazard, allocating one byte rather
than NULL because the console callback's consumers do `memcpy(dst, buf, size)`, and passing NULL
there would be undefined even at size zero. Nothing else changes: the ternary tests `file_size`
before it narrows to `size_t`, so the existing 4 GiB behaviour is untouched.

# Verification

To reproduce on a device, run `js` on a script whose only line is `console.log("")`.
`console.log(String())` and `console.log([].join())` do it too, and so does running `js` on a
zero-byte file.

Empty strings really do reach the allocator with a size of zero. I built the jerryscript this repo
pins (`lib/jerryscript` @ `52cab3dc6c4d`, branch `bsb`) as an amalgam on my machine and ran the
size computation from `console_log` unchanged:

```
argument passed to console.log():
  console.log("")              jerry_string_size = 0  -> malloc(0)   <-- CRASH
  console.log("hi")            jerry_string_size = 2  -> malloc(2)
  console.log(String())        jerry_string_size = 0  -> malloc(0)   <-- CRASH
  console.log([].join())       jerry_string_size = 0  -> malloc(0)   <-- CRASH
  console.log(0)               jerry_string_size = 1  -> malloc(1)
```

Lint and build are clean, all three exiting 0:

```
./fbt -s lint TARGET_HW=21
./fbt -s lint TARGET_HW=64
./fbt
```

`jerryscript_glue.c` sits under `targets/f21/`, and f22 inherits f21, so the default build does
cover it:

```
$ find fbt_layers/fbtng/build -name 'jerryscript_glue*.o'
fbt_layers/fbtng/build/f22-firmware-D/targets/f21/jerryscript/jerryscript_glue.o
fbt_layers/fbtng/build/f22-updater-D/targets/f21/jerryscript/jerryscript_glue.o
```

I don't own a BUSY Bar, so that's compile-verified only. The device tests need your self-hosted
runner, so I'd appreciate a check there before it lands.
