### PR TITLE
[http_api] Free the draw error string on the success path

### DIFF
--- a/applications/services/web_server/http_api/api_display.c
+++ b/applications/services/web_server/http_api/api_display.c
@@ -673,6 +673,7 @@ static void api_display_canvas_draw(struct mg_connection* conn, struct mg_http_m
         furi_record_close(RECORD_CANVAS);
 
         CanvasElementsArray_clear(elements_array);
+        furi_string_free(error);
         free(app_name);
         return; // response delivered asynchronously via mg_wakeup
     } while(0);


### PR DESCRIPTION
# What's new

`api_display_canvas_draw` allocates `FuriString* error = furi_string_alloc();` at api_display.c:593
and frees it at :681, after the `do { ... } while(0)`. The failure paths reach that free through
`break`. The success path doesn't — it returns early at :677, because the response goes out
asynchronously via `mg_wakeup`. `error` is a plain local that nothing else owns, so every
successful `POST /api/display/draw` leaks one `FuriString`.

This is the endpoint everything draws through, and a client rendering a clock or ticker posts to it
over and over, so the heap only drifts one way until a reboot. When it finally runs out,
`pvPortMalloc` ends at `furi_check(pvReturn, "out of memory")`, which isn't compiled out in
release. So exhaustion crashes rather than fails softly.

The fix frees it on the success path too, right next to the `CanvasElementsArray_clear` and
`free(app_name)` that are already there.

# Verification

Build and both lint targets are clean:

```
./fbt
./fbt -s lint TARGET_HW=21
./fbt -s lint TARGET_HW=64
```

I don't own a BUSY Bar, so this is compile-verified only — I haven't watched the heap fall across
repeated draws on real hardware. The device tests need your self-hosted runner, so a check there
before it lands would be good.
