### PR TITLE
[FW-1086, FW-1087] Fix memory leak, add allocation size checks

### DIFF
--- a/applications/services/js_runner/js_runner.c
+++ b/applications/services/js_runner/js_runner.c
@@ -97,9 +97,13 @@ JsRunnerError js_runner_run(
             break;
         }
         uint64_t file_size = storage_file_size(f);
+        if((file_size == 0) || (file_size > JS_RUNNER_MAX_SCRIPT_SIZE)) {
+            ret = JsRunnerErrorInvalidFileSize;
+            break;
+        }
         char* buf = malloc(file_size);
         if(storage_file_read(f, buf, file_size) != file_size) {
-            ret = JsRunnerErrorCannotOpenFile;
+            ret = JsRunnerErrorCannotReadFile;
             free(buf);
             break;
         }

--- a/applications/services/js_runner/js_runner.h
+++ b/applications/services/js_runner/js_runner.h
@@ -14,6 +14,8 @@ typedef struct JsRunner JsRunner;
 typedef enum JsRunnerError {
     JsRunnerErrorNone = 0,
     JsRunnerErrorCannotOpenFile,
+    JsRunnerErrorInvalidFileSize,
+    JsRunnerErrorCannotReadFile,
     JsRunnerParseException,
 } JsRunnerError;
 

--- a/applications/services/js_runner/js_runner_console.c
+++ b/applications/services/js_runner/js_runner_console.c
@@ -35,14 +35,20 @@ static jerry_value_t console_log(
 
         jerry_size_t size = jerry_string_size(str, JERRY_ENCODING_UTF8);
 
-        char* buf = malloc(size);
-
-        jerry_string_to_buffer(str, JERRY_ENCODING_UTF8, (jerry_char_t*)buf, size);
-
         JsRunnerConsoleSeparator separator =
             i + 1 == args_count ? JsRunnerConsoleSeparatorNewline : JsRunnerConsoleSeparatorSpace;
-        ctx->write(severity, buf, size, separator, ctx->context);
-        free(buf);
+
+        if(size > 0) {
+            char* buf = malloc(size);
+
+            jerry_string_to_buffer(str, JERRY_ENCODING_UTF8, (jerry_char_t*)buf, size);
+            ctx->write(severity, buf, size, separator, ctx->context);
+
+            free(buf);
+
+        } else {
+            ctx->write(severity, "", 0, separator, ctx->context);
+        }
 
         jerry_value_free(str);
     }

--- a/applications/services/js_runner/js_runner_i.h
+++ b/applications/services/js_runner/js_runner_i.h
@@ -18,6 +18,8 @@
 
 #define MIN_INTERVAL_DELAY_MS 10.0f
 
+#define JS_RUNNER_MAX_SCRIPT_SIZE (250 * 1024)
+
 typedef struct IntervalContext {
     bool once;
     FuriEventLoopTimer* timer;

--- a/applications/services/web_server/http_api/api_display.c
+++ b/applications/services/web_server/http_api/api_display.c
@@ -671,10 +671,6 @@ static void api_display_canvas_draw(struct mg_connection* conn, struct mg_http_m
         canvas_show_elements_async(
             canvas, app_name, priority, elements_array, canvas_draw_done_callback, ctx);
         furi_record_close(RECORD_CANVAS);
-
-        CanvasElementsArray_clear(elements_array);
-        free(app_name);
-        return; // response delivered asynchronously via mg_wakeup
     } while(0);
 
     CanvasElementsArray_clear(elements_array);

--- a/applications/services/web_server/http_api/api_display.c
+++ b/applications/services/web_server/http_api/api_display.c
@@ -274,6 +274,8 @@ static bool api_display_draw_parse_anim_player_element(
     bool result = false;
 
     do {
+        canvas_element->type = CanvasElementTypeAnimPlayer;
+
         if(!api_display_draw_parse_image_path(
                &canvas_element->anim_player.file_path,
                app_name,
@@ -305,7 +307,6 @@ static bool api_display_draw_parse_anim_player_element(
         if(opacity < 0 || opacity > 100) break;
         canvas_element->anim_player.opacity = opacity * 255 / 100;
 
-        canvas_element->type = CanvasElementTypeAnimPlayer;
         result = true;
     } while(0);
 
@@ -401,6 +402,8 @@ static bool api_display_draw_parse_rectangle_element(
     bool result = false;
 
     do {
+        canvas_element->type = CanvasElementTypeRectangle;
+
         long width = mg_json_get_long(json_element, "$.width", -1);
         long height = mg_json_get_long(json_element, "$.height", -1);
         if(width <= 0 || height <= 0) {
@@ -417,7 +420,6 @@ static bool api_display_draw_parse_rectangle_element(
             break;
         }
 
-        canvas_element->type = CanvasElementTypeRectangle;
         result = true;
     } while(0);
 

--- a/targets/f21/jerryscript/jerryscript_glue.c
+++ b/targets/f21/jerryscript/jerryscript_glue.c
@@ -107,7 +107,11 @@ jerry_char_t* jerry_port_source_read(const char* file_name_p, jerry_size_t* out_
             break;
         }
         uint64_t file_size = storage_file_size(f);
-        if(file_size >= UINT32_MAX) {
+        if(file_size == 0) {
+            FURI_LOG_E(TAG, "File is empty %s", abs_path_cstr);
+            break;
+        }
+        if(file_size > JS_RUNNER_MAX_SCRIPT_SIZE) {
             FURI_LOG_E(TAG, "File is too large %s", abs_path_cstr);
             break;
         }


### PR DESCRIPTION
# What's new

[FW-1086]
[FW-1087]
[FW-1088]

- Fix memory leak in draw API
- Add allocation size checks in JsRunner
- Fix missing union tag id draw API (by @munzzyy)

# Verification 

1. Flash the firmware bundle.
2. Ensure that there are no regressions in Draw API. JsRunner is still a preview feature.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-1086]: https://flipper.atlassian.net/browse/FW-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FW-1087]: https://flipper.atlassian.net/browse/FW-1087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FW-1088]: https://flipper.atlassian.net/browse/FW-1088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ