### PR TITLE
[FW-1083] Dialog icon element

### DIFF
--- a/applications/services/gui/modules/dialog.c
+++ b/applications/services/gui/modules/dialog.c
@@ -14,6 +14,7 @@
 
 struct Dialog {
     Widget base;
+    lv_obj_t* icon;
     lv_obj_t* text_cont;
     lv_obj_t* text_main;
     lv_obj_t* text_sub;
@@ -82,12 +83,15 @@ static void dialog_lvgl_constructor(const lv_obj_class_t* class_p, lv_obj_t* obj
     Dialog* instance = (Dialog*)obj;
     lv_obj_set_scrollbar_mode(obj, LV_SCROLLBAR_MODE_OFF);
 
+    instance->icon = lv_image_create(obj);
+    lv_obj_add_flag(instance->icon, LV_OBJ_FLAG_HIDDEN);
+
     instance->text_cont = lv_obj_create(obj);
     lv_obj_set_style_pad_all(instance->text_cont, 0, LV_PART_MAIN);
 
     instance->text_main = lv_obj_class_create_obj(MY_TEXT_CLASS, instance->text_cont);
     lv_obj_class_init_obj(instance->text_main);
-    lv_label_set_long_mode(instance->text_main, LV_LABEL_LONG_MODE_WRAP);
+    lv_label_set_long_mode(instance->text_main, LV_LABEL_LONG_MODE_DOTS);
     lv_label_set_text(instance->text_main, "");
 
     instance->text_sub = lv_obj_class_create_obj(MY_TEXT_SUB_CLASS, instance->text_cont);
@@ -113,10 +117,12 @@ static void dialog_lvgl_constructor(const lv_obj_class_t* class_p, lv_obj_t* obj
 
         lv_obj_set_size(instance->options_cont, LV_PCT(100), LV_SIZE_CONTENT);
     } else {
+        lv_obj_set_style_margin_right(instance->icon, 2, LV_PART_MAIN);
         lv_obj_set_flex_flow(instance->text_cont, LV_FLEX_FLOW_COLUMN);
         lv_obj_set_flex_align(
             instance->text_cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
         lv_obj_set_size(instance->text_cont, LV_PCT(100), LV_PCT(100));
+        lv_obj_set_flex_grow(instance->text_cont, 1);
 
         lv_obj_set_size(instance->options_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
         lv_obj_set_style_pad_row(instance->options_cont, -2, LV_PART_MAIN);
@@ -253,6 +259,16 @@ void dialog_set_callback(Dialog* instance, DialogCallback callback, void* contex
 
     instance->callback = callback;
     instance->context = context;
+}
+
+void dialog_set_icon(Dialog* instance, const char* icon_source) {
+    furi_check(instance);
+    if(icon_source) {
+        lv_image_set_src(instance->icon, icon_source);
+        lv_obj_remove_flag(instance->icon, LV_OBJ_FLAG_HIDDEN);
+    } else {
+        lv_obj_add_flag(instance->icon, LV_OBJ_FLAG_HIDDEN);
+    }
 }
 
 // LVGL class descriptors

--- a/applications/services/gui/modules/dialog.h
+++ b/applications/services/gui/modules/dialog.h
@@ -58,6 +58,14 @@ Widget* dialog_get_base(Dialog* instance);
 void dialog_set_callback(Dialog* instance, DialogCallback callback, void* context);
 
 /**
+ * @brief Set the icon displayed by the Dialog.
+ *
+ * @param[in,out] instance pointer to the Dialog instance to be modified
+ * @param[in] icon_source zero-terminated string containing the icon file path (@c NULL to hide)
+ */
+void dialog_set_icon(Dialog* instance, const char* icon_source);
+
+/**
  * @brief Set a main text label value.
  *
  * @param[in,out] instance pointer to the Dialog instance to be modified

--- a/applications/settings/firmware/scenes/scene_dialog.c
+++ b/applications/settings/firmware/scenes/scene_dialog.c
@@ -3,7 +3,6 @@
 #include <power/power_service/power.h>
 
 #include <gui/modules/dialog.h>
-#include <gui/modules/image.h>
 
 typedef enum {
     FirmwareSettingsDialogSceneEventInstall = FirmwareSettingsEventSceneEventsStart,
@@ -11,9 +10,7 @@ typedef enum {
 } FirmwareSettingsDialogSceneEvent;
 
 typedef struct {
-    FlexLayout* front_layout;
     Dialog* front_dialog;
-
     Dialog* back_dialog;
 } FirmwareSettingsDialogScene;
 
@@ -38,23 +35,10 @@ static void firmware_settings_dialog_scene_on_enter(void* context) {
 
     with_gui(instance->gui, {
         /* front layout setup */
-        scene->front_layout = flex_layout_alloc(instance->front_scene_window, FlexLayoutTypeRow);
-        flex_layout_set_spacing(scene->front_layout, 2);
-        flex_layout_set_align(
-            scene->front_layout,
-            FlexLayoutAlignStart,
-            FlexLayoutAlignCenter,
-            FlexLayoutAlignCenter);
-
-        Image* front_image = image_alloc(flex_layout_get_base(scene->front_layout));
-        image_set_source(front_image, THIS_IMG_PATH("download_front_8x8.image"));
-        widget_set_size_content(image_get_base(front_image));
-
-        scene->front_dialog = dialog_alloc(flex_layout_get_base(scene->front_layout));
-        flex_layout_set_child_widget_grow(
-            scene->front_layout, dialog_get_base(scene->front_dialog), 1);
+        scene->front_dialog = dialog_alloc(instance->front_scene_window);
         dialog_set_callback(
             scene->front_dialog, firmware_settings_dialog_scene_option_callback, instance);
+        dialog_set_icon(scene->front_dialog, THIS_IMG_PATH("download_front_8x8.image"));
         dialog_set_text(scene->front_dialog, "Update available");
         dialog_set_options(scene->front_dialog, "Install", "Cancel");
         dialog_set_option_colors(
@@ -78,8 +62,8 @@ static void firmware_settings_dialog_scene_on_exit(void* context) {
     FirmwareSettingsDialogScene* scene = firmware_settings_dialog_scene_get(instance);
 
     with_gui(instance->gui, {
+        dialog_free(scene->front_dialog);
         dialog_free(scene->back_dialog);
-        flex_layout_free(scene->front_layout);
     });
 }
 

--- a/applications/settings/system_settings/scenes/system_settings_scene_factory_reset_confirm.c
+++ b/applications/settings/system_settings/scenes/system_settings_scene_factory_reset_confirm.c
@@ -3,7 +3,6 @@
 #include <settings_helpers/gui_params.h>
 
 #include <gui/modules/dialog.h>
-#include <gui/modules/image.h>
 
 typedef enum {
     SceneEventConfirm = AppEventSceneEventsStart,
@@ -11,9 +10,7 @@ typedef enum {
 } SceneEvent;
 
 typedef struct {
-    FlexLayout* front_layout;
     Dialog* front_dialog;
-
     Dialog* back_dialog;
 } SceneSystemFactoryResetConfirm;
 
@@ -37,18 +34,8 @@ static void system_settings_scene_factory_reset_confirm_on_enter(void* context) 
 
     with_gui(instance->gui, {
         /* front layout setup */
-        data->front_layout = flex_layout_alloc(instance->front_scene_window, FlexLayoutTypeRow);
-        flex_layout_set_spacing(data->front_layout, 2);
-        flex_layout_set_align(
-            data->front_layout, FlexLayoutAlignStart, FlexLayoutAlignCenter, FlexLayoutAlignCenter);
-
-        Image* front_image = image_alloc(flex_layout_get_base(data->front_layout));
-        image_set_source(front_image, SHARED_IMG_PATH("error_front_8x8.image"));
-        widget_set_size_content(image_get_base(front_image));
-
-        data->front_dialog = dialog_alloc(flex_layout_get_base(data->front_layout));
-        flex_layout_set_child_widget_grow(
-            data->front_layout, dialog_get_base(data->front_dialog), 1);
+        data->front_dialog = dialog_alloc(instance->front_scene_window);
+        dialog_set_icon(data->front_dialog, SHARED_IMG_PATH("error_front_8x8.image"));
         dialog_set_text(data->front_dialog, "Reset\ndevice?");
         dialog_set_option_colors(
             data->front_dialog,
@@ -74,8 +61,8 @@ static void system_settings_scene_factory_reset_confirm_on_exit(void* context) {
         scene_manager_get_scene_data(instance->scene_manager, SceneIdFactoryResetConfirm);
 
     with_gui(instance->gui, {
+        dialog_free(data->front_dialog);
         dialog_free(data->back_dialog);
-        flex_layout_free(data->front_layout);
     });
 }
 

--- a/lib/lvgl_addons/themes/lv_theme_front.c
+++ b/lib/lvgl_addons/themes/lv_theme_front.c
@@ -126,7 +126,7 @@ static void style_init(my_theme_t* theme, FontRegistry* font_registry) {
     lv_style_set_pad_ver(&theme->styles.dialog_text, 0);
     lv_style_set_width(&theme->styles.dialog_text, LV_PCT(100));
     lv_style_set_text_line_space(&theme->styles.dialog_text, -2);
-    lv_style_set_flex_grow(&theme->styles.dialog_text, 1);
+    lv_style_set_max_height(&theme->styles.dialog_text, LV_PCT(100));
 
     lv_style_init(&theme->styles.var_item);
     lv_style_set_margin_top(&theme->styles.var_item, -2);

--- a/lib/lvgl_addons/themes/lv_theme_front.c
+++ b/lib/lvgl_addons/themes/lv_theme_front.c
@@ -124,8 +124,9 @@ static void style_init(my_theme_t* theme, FontRegistry* font_registry) {
 
     lv_style_init(&theme->styles.dialog_text);
     lv_style_set_pad_ver(&theme->styles.dialog_text, 0);
-    lv_style_set_width(&theme->styles.dialog_text, LV_PCT(60));
+    lv_style_set_width(&theme->styles.dialog_text, LV_PCT(100));
     lv_style_set_text_line_space(&theme->styles.dialog_text, -2);
+    lv_style_set_flex_grow(&theme->styles.dialog_text, 1);
 
     lv_style_init(&theme->styles.var_item);
     lv_style_set_margin_top(&theme->styles.var_item, -2);


### PR DESCRIPTION
# What's new

[FW-1083]

- Implement the ability to set an icon for the `Dialog` widget
- Port `Firmware` settings module to use the new method
- Port `Factory Reset` settings module to use the new method

## Caveats:

- The icon is never used on the back display, so this path was not tested (it'll probably look weird if set).

# Verification 

1. Install the firmware bundle
2. Verify that the `Dialog`s look the same as before. Pay attention to [[1](https://www.figma.com/design/CGfSagPcxKchQOTwaV1Uga/-BUSY-Bar--Interfaces?node-id=19204-62777&t=H0ttIv7N5UrVXfio-0)] and [[2](https://www.figma.com/design/CGfSagPcxKchQOTwaV1Uga/-BUSY-Bar--Interfaces?node-id=19096-84991&t=H0ttIv7N5UrVXfio-0)].
3. Ensure that there are no regressions in the UI (there shouldn't be.)

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix


[FW-1083]: https://flipper.atlassian.net/browse/FW-1083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ