### PR TITLE
[FW-1117] Fix "Inactivity timeout" when POSTing to local HTTP API

### DIFF
--- a/applications/system/fetch_cli/fetch_cli.c
+++ b/applications/system/fetch_cli/fetch_cli.c
@@ -91,6 +91,10 @@ static void fetch_callback_error(const char* error, void* context) {
 static int32_t fetch_cli_print_download_progress(const FetchProgress* progress) {
     int32_t print_len = 0;
 
+    if(progress->total_download_size == 0) {
+        return print_len;
+    }
+
     const char* units_str;
     size_t multiplier;
 
@@ -164,7 +168,7 @@ static void fetch_progress_callback(const FetchProgress* progress, void* context
 
     int32_t print_len;
 
-    if(progress->total_download_size != 0) {
+    if(progress->has_total_download_size) {
         print_len = fetch_cli_print_download_progress(progress);
     } else {
         print_len = fetch_cli_print_download_progress_simple(progress);

--- a/lib/fetch/fetch.c
+++ b/lib/fetch/fetch.c
@@ -58,11 +58,14 @@ static bool fetch_is_rx_complete(const Fetch* instance) {
     bool is_complete = false;
 
     const FetchProgress* progress = &instance->progress;
-    const size_t expected_size = progress->total_download_size;
-    const size_t actual_size = progress->received_download_size;
 
-    if((expected_size != 0) && (actual_size >= expected_size)) {
-        is_complete = true;
+    if(progress->has_total_download_size) {
+        const size_t expected_size = progress->total_download_size;
+        const size_t actual_size = progress->received_download_size;
+
+        if(actual_size >= expected_size) {
+            is_complete = true;
+        }
     }
 
     return is_complete;
@@ -83,7 +86,9 @@ static void fetch_switch_to_raw_protocol(
     instance->started_download_ticks = instance->started_raw_ticks;
 
     if(body_length != -1) {
-        instance->progress.total_download_size = body_length;
+        FetchProgress* progress = &instance->progress;
+        progress->total_download_size = body_length;
+        progress->has_total_download_size = true;
     }
 
     fetch_consume_rx_data(conn, msg->head.len);
@@ -339,11 +344,14 @@ static bool fetch_verify_response_body_size(Fetch* instance) {
 
     if(!(instance->is_stop_requested || instance->is_error_occurred)) {
         const FetchProgress* progress = &instance->progress;
-        const size_t expected_size = progress->total_download_size;
-        const size_t actual_size = progress->received_download_size;
 
-        if((expected_size != 0) && (expected_size != actual_size)) {
-            success = false;
+        if(progress->has_total_download_size) {
+            const size_t expected_size = progress->total_download_size;
+            const size_t actual_size = progress->received_download_size;
+
+            if(expected_size != actual_size) {
+                success = false;
+            }
         }
     }
 

--- a/lib/fetch/fetch.c
+++ b/lib/fetch/fetch.c
@@ -54,6 +54,20 @@ static uint32_t fetch_calc_download_speed(size_t size_delta, uint32_t start_time
     return size_delta / delta_s;
 }
 
+static bool fetch_is_rx_complete(const Fetch* instance) {
+    bool is_complete = false;
+
+    const FetchProgress* progress = &instance->progress;
+    const size_t expected_size = progress->total_download_size;
+    const size_t actual_size = progress->received_download_size;
+
+    if((expected_size != 0) && (actual_size >= expected_size)) {
+        is_complete = true;
+    }
+
+    return is_complete;
+}
+
 static void fetch_consume_rx_data(struct mg_connection* conn, size_t length) {
     mg_iobuf_del(&conn->recv, 0, length);
 }
@@ -241,6 +255,10 @@ static FURI_ALWAYS_INLINE void fetch_read_event(Fetch* instance, struct mg_conne
     }
 
     fetch_consume_rx_data(conn, recv_len);
+
+    if(fetch_is_rx_complete(instance)) {
+        conn->is_draining = 1;
+    }
 }
 
 static FURI_ALWAYS_INLINE void fetch_close_event(Fetch* instance, struct mg_connection* conn) {

--- a/lib/fetch/fetch_common.h
+++ b/lib/fetch/fetch_common.h
@@ -14,11 +14,14 @@ extern "C" {
 
 /**
  * @brief Fetch download progress structure.
+ *
+ * @note @p total_download_size is valid ONLY if @p has_total_download_size is @c true.
  */
 typedef struct {
-    size_t total_download_size; /**< Total file size, in bytes (may be 0 if not known) */
+    size_t total_download_size; /**< Total file size, in bytes */
     size_t received_download_size; /**< Number of bytes downloaded so far */
     uint32_t speed_bytes_per_sec; /**< Donwload speed, in bytes per second */
+    bool has_total_download_size; /**< Whether the total download size is known */
 } FetchProgress;
 
 /**

--- a/tests/integration/cli/test_fetch.py
+++ b/tests/integration/cli/test_fetch.py
@@ -64,6 +64,15 @@ class FetchRequestHandler(http.server.BaseHTTPRequestHandler):
 
         if self.path == "/known.bin":
             self._send_payload(200, KNOWN_PAYLOAD)
+        elif self.path == "/known-keep-alive.bin":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(KNOWN_PAYLOAD)))
+            self.send_header("Connection", "keep-alive")
+            self.end_headers()
+            self.wfile.write(KNOWN_PAYLOAD)
+            self.wfile.flush()
+            self.server.release_stall.wait(timeout=15)
         elif self.path == "/truncated.bin":
             self.send_response(200)
             self.send_header("Content-Type", "application/octet-stream")
@@ -113,6 +122,7 @@ class TestCLIFetch:
     """Exercise the real device Fetch path through a local host server."""
 
     DEST = "/ext/fetch_test.bin"
+    KEEP_ALIVE_DEST = "/ext/fetch_keep_alive.bin"
     TRUNCATED_DEST = "/ext/fetch_truncated.bin"
     UNKNOWN_DEST = "/ext/fetch_unknown_length.bin"
     TIMEOUT_DEST = "/ext/fetch_timeout.bin"
@@ -198,6 +208,31 @@ class TestCLIFetch:
             self._assert_saved_payload(cli, self.DEST, KNOWN_PAYLOAD)
         finally:
             cli.execute_command(f"storage remove {self.DEST}")
+
+    @allure.title(
+        "CLI. Fetch completes a known-length response before the connection closes."
+    )
+    def test_fetch_known_length_does_not_wait_for_connection_close(
+        self, persistent_cli_connection, http_server
+    ):
+        cli = persistent_cli_connection
+        cli.execute_command(f"storage remove {self.KEEP_ALIVE_DEST}")
+        try:
+            response = cli.execute_command(
+                f"fetch {http_server.url('/known-keep-alive.bin')} "
+                f"-o {self.KEEP_ALIVE_DEST}",
+                timeout=12,
+                slow_command=True,
+            )
+
+            with allure.step("Verify completion without an inactivity failure"):
+                assert "Downloaded: 100%" in response, response
+                assert "Inactivity timeout" not in response, response
+
+            self._assert_saved_payload(cli, self.KEEP_ALIVE_DEST, KNOWN_PAYLOAD)
+        finally:
+            http_server.release_stall.set()
+            cli.execute_command(f"storage remove {self.KEEP_ALIVE_DEST}")
 
     @allure.title("CLI. Command fetch rejects a truncated known-length response.")
     def test_fetch_truncated_content_length_removes_output(


### PR DESCRIPTION
# What's new

- Fetch: disconnect after having received all of the expected data

# Verification 

1. Flash the firmware bundle.
2. Enter the telnet CLI session.
3. Run the following command:
```
fetch -X POST http://10.0.4.20/api/display/draw -d '{"application_name": "my_app","elements": [{"id": "0","timeout": 10,"type": "text","text": "Hello, World! Long text","font": "normal"}]}'
```
4. Ensure that no "Inactivity timeout" error occurs and the command returns as soon as the response is received.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
