### PR TITLE
[FW-1105] Include Device Info In Log Dump

### DIFF
--- a/applications/services/log_storage/log_storage.c
+++ b/applications/services/log_storage/log_storage.c
@@ -57,6 +57,18 @@ static const LogStorageMessageHandler log_storage_handlers[] = {
 
 static_assert(COUNT_OF(log_storage_handlers) == LogStorageMessageTypesCount);
 
+static bool log_storage_file_write_all(File* file, const void* data, size_t size) {
+    bool is_successful;
+    if(storage_file_write(file, data, size) == size) {
+        is_successful = true;
+    } else {
+        FURI_LOG_E(TAG, "Failed to write log data to file");
+        is_successful = false;
+    }
+
+    return is_successful;
+}
+
 static bool log_storage_dump_base(LogStorageBase* base, File* file) {
     bool is_successful = false;
     do {
@@ -67,9 +79,11 @@ static bool log_storage_dump_base(LogStorageBase* base, File* file) {
         for(size_t i = 0; i < COUNT_OF(snapshot.chunks); i++) {
             const LogStorageBaseSnapshotChunk* chunk = &snapshot.chunks[i];
 
-            if(chunk->length == 0) continue;
-            if(storage_file_write(file, chunk->data, chunk->length) != chunk->length) {
-                FURI_LOG_E(TAG, "Failed to write log data to file");
+            if(chunk->length == 0) {
+                continue;
+            }
+
+            if(!log_storage_file_write_all(file, chunk->data, chunk->length)) {
                 is_successful = false;
                 break;
             }
@@ -86,24 +100,27 @@ static void log_storage_do_dump(LogStorage* instance, const LogStorageMessage* m
     bool is_successful = false;
     if(storage_file_open(file, path, FSAM_WRITE, FSOM_CREATE_ALWAYS)) {
         do {
-            log_storage_local_internal_flush(&instance->local);
-            log_storage_remote_internal_flush(&instance->remote);
+            size_t length;
 
-            size_t length = strlen(LOG_STORAGE_DUMP_U5_SECTION_HEADER);
-            if(storage_file_write(file, LOG_STORAGE_DUMP_U5_SECTION_HEADER, length) != length) {
-                FURI_LOG_E(TAG, "Failed to write log data to file");
+            length = strlen(LOG_STORAGE_DUMP_U5_SECTION_HEADER);
+            if(!log_storage_file_write_all(file, LOG_STORAGE_DUMP_U5_SECTION_HEADER, length)) {
                 break;
             }
 
-            if(!log_storage_dump_base(&instance->local.base, file)) break;
+            log_storage_local_internal_flush(&instance->local);
+            if(!log_storage_dump_base(&instance->local.base, file)) {
+                break;
+            }
 
             length = strlen(LOG_STORAGE_DUMP_917_SECTION_HEADER);
-            if(storage_file_write(file, LOG_STORAGE_DUMP_917_SECTION_HEADER, length) != length) {
-                FURI_LOG_E(TAG, "Failed to write log data to file");
+            if(!log_storage_file_write_all(file, LOG_STORAGE_DUMP_917_SECTION_HEADER, length)) {
                 break;
             }
 
-            if(!log_storage_dump_base(&instance->remote.base, file)) break;
+            log_storage_remote_internal_flush(&instance->remote);
+            if(!log_storage_dump_base(&instance->remote.base, file)) {
+                break;
+            }
 
             FURI_LOG_I(TAG, "Log dump saved to %s", path);
 

--- a/applications/services/log_storage/log_storage.c
+++ b/applications/services/log_storage/log_storage.c
@@ -3,11 +3,14 @@
 #include "log_storage_remote_i.h"
 
 #include <storage/storage.h>
+#include <device_info/device_info.h>
+
 #include <toolbox/api_lock.h>
 
 #define LOG_STORAGE_MESSAGE_QUEUE_SIZE (4u)
 
-#define LOG_STORAGE_DUMP_U5_SECTION_HEADER  "[------ STM32U5 ------]\r\n"
+#define LOG_STORAGE_DUMP_DEVICE_INFO_HEADER "[------ Device Info ------]\r\n"
+#define LOG_STORAGE_DUMP_U5_SECTION_HEADER  "\r\n[------ STM32U5 ------]\r\n"
 #define LOG_STORAGE_DUMP_917_SECTION_HEADER "\r\n[------ SiWG917 ------]\r\n"
 
 struct LogStorage {
@@ -69,6 +72,30 @@ static bool log_storage_file_write_all(File* file, const void* data, size_t size
     return is_successful;
 }
 
+static void
+    log_storage_device_info_callback(const char* key, const char* value, bool last, void* context) {
+    furi_assert(key);
+    furi_assert(value);
+    furi_assert(context);
+
+    UNUSED(last);
+
+    furi_string_cat_printf(context, "%s: %s\r\n", key, value);
+}
+
+static bool log_storage_dump_device_info(File* file) {
+    DeviceInfo* device_info = furi_record_open(RECORD_DEVICE_INFO);
+
+    FuriString* string = furi_string_alloc();
+    device_info_query(device_info, log_storage_device_info_callback, '_', string);
+    bool is_successful =
+        log_storage_file_write_all(file, furi_string_get_cstr(string), furi_string_size(string));
+    furi_string_free(string);
+
+    furi_record_close(RECORD_DEVICE_INFO);
+    return is_successful;
+}
+
 static bool log_storage_dump_base(LogStorageBase* base, File* file) {
     bool is_successful = false;
     do {
@@ -101,6 +128,15 @@ static void log_storage_do_dump(LogStorage* instance, const LogStorageMessage* m
     if(storage_file_open(file, path, FSAM_WRITE, FSOM_CREATE_ALWAYS)) {
         do {
             size_t length;
+
+            length = strlen(LOG_STORAGE_DUMP_DEVICE_INFO_HEADER);
+            if(!log_storage_file_write_all(file, LOG_STORAGE_DUMP_DEVICE_INFO_HEADER, length)) {
+                break;
+            }
+
+            if(!log_storage_dump_device_info(file)) {
+                break;
+            }
 
             length = strlen(LOG_STORAGE_DUMP_U5_SECTION_HEADER);
             if(!log_storage_file_write_all(file, LOG_STORAGE_DUMP_U5_SECTION_HEADER, length)) {


### PR DESCRIPTION
> [!NOTE]
> * [**FW-1105**](https://flipper.atlassian.net/browse/FW-1105)

# What's new

- device info is first member of log dump

# Verification 

- run `/api/log_dump` => created file contains device info as it's first member

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
