### PR TITLE
[QA-329] Retry for the case when dhclient failed to bring device online

### DIFF
--- a/.github/actions/flash-device/action.yml
+++ b/.github/actions/flash-device/action.yml
@@ -1,0 +1,57 @@
+name: Flash device
+description: >-
+  Reboot the BusyBar and make sure it is back online, falling back to an SWD
+  reset when the CLI reboot does not take, then wipe /ext and optionally install
+  a firmware bundle. Shared by the updater, unit, integration and brick test
+  workflows.
+author: qa
+
+inputs:
+  bundle:
+    description: >-
+      Update .tgz to install once the device is up. Leave empty to stop after
+      formatting /ext (the brick test installs its own bundle afterwards).
+    required: false
+    default: ''
+  reboot-timeout:
+    description: Seconds to wait for the device to come back after a reboot
+    required: false
+    default: '20'
+  install-timeout:
+    description: Seconds to wait for the device to come back after installing the bundle
+    required: false
+    default: '320'
+
+runs:
+  using: composite
+  steps:
+    - name: 'Reboot device and install firmware'
+      shell: bash
+      env:
+        BUNDLE: ${{ inputs.bundle }}
+        REBOOT_TIMEOUT: ${{ inputs.reboot-timeout }}
+        INSTALL_TIMEOUT: ${{ inputs.install-timeout }}
+      run: |
+        set -euo pipefail
+        source scripts/toolchain/fbtenv.sh
+
+        # A hung device serves no telnet, so the CLI reboot itself fails; keep
+        # going and let the wait below decide whether the device is actually up.
+        python3 scripts/testops.py power reboot || echo "CLI reboot failed"
+
+        # The device boots in a few seconds, so a timeout here means the CLI
+        # reboot never took effect or the firmware hung — SWD is the only way
+        # left to restart it. bsb-device ships in the runner image.
+        if ! python3 scripts/testops.py wait -t "${REBOOT_TIMEOUT}"; then
+          echo "Device did not come online after the CLI reboot; resetting over SWD"
+          bsb-device reboot
+          python3 scripts/testops.py wait -t "${REBOOT_TIMEOUT}"
+        fi
+
+        python3 scripts/testops.py debug 1
+        python3 scripts/testops.py format --no-confirm
+
+        if [ -n "${BUNDLE}" ]; then
+          python3 scripts/testops.py update-fw "${BUNDLE}" -r 3 --connect-timeout 10
+          python3 scripts/testops.py wait -t "${INSTALL_TIMEOUT}"
+        fi

--- a/.github/workflows/brick-test.yml
+++ b/.github/workflows/brick-test.yml
@@ -118,19 +118,15 @@ jobs:
           echo "Downloading normal firmware: $URL"
           curl --fail -L -o "normal-update.tgz" "$URL"
 
+      - name: 'Reboot device and wipe /ext'
+        id: prepare
+        uses: ./.github/actions/flash-device
+
       - name: 'Flash update with bricked 917 firmware'
         id: flash_brick
         run: |
           set -euo pipefail
           source scripts/toolchain/fbtenv.sh
-          python3 scripts/testops.py power reboot || echo "CLI reboot failed"
-          if ! python3 scripts/testops.py wait -t 20; then
-            echo "Device did not come online after the CLI reboot; resetting over SWD"
-            bsb-device reboot
-            python3 scripts/testops.py wait -t 20
-          fi
-          python3 scripts/testops.py debug 1
-          python3 scripts/testops.py format --no-confirm
 
           # Find the update tar in the extracted brick package
           BRICK_TAR=$(find brick-firmware -name "*.tgz" | head -1)
@@ -211,7 +207,7 @@ jobs:
             echo ""
             echo "| Phase | Status |"
             echo "|-------|--------|"
-            echo "| Flash brick firmware | ${{ steps.flash_brick.outcome }} |"
+            echo "| Flash brick firmware | ${{ steps.prepare.outcome == 'success' && steps.flash_brick.outcome || steps.prepare.outcome }} |"
             echo "| Verify bricked state | ${{ steps.verify_brick.outcome == 'failure' && 'success (expected failure)' || 'unexpected' }} |"
             echo "| Flash recovery firmware | ${{ steps.flash_recovery.outcome }} |"
             echo "| Verify recovery | ${{ steps.verify_recovery.outcome }} |"

--- a/.github/workflows/brick-test.yml
+++ b/.github/workflows/brick-test.yml
@@ -123,8 +123,12 @@ jobs:
         run: |
           set -euo pipefail
           source scripts/toolchain/fbtenv.sh
-          python3 scripts/testops.py power reboot
-          python3 scripts/testops.py wait -t 20
+          python3 scripts/testops.py power reboot || echo "CLI reboot failed"
+          if ! python3 scripts/testops.py wait -t 20; then
+            echo "Device did not come online after the CLI reboot; resetting over SWD"
+            bsb-device reboot
+            python3 scripts/testops.py wait -t 20
+          fi
           python3 scripts/testops.py debug 1
           python3 scripts/testops.py format --no-confirm
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -159,9 +159,16 @@ jobs:
         run: |
           set -euo pipefail
           source scripts/toolchain/fbtenv.sh
+          python3 scripts/testops.py power reboot || echo "CLI reboot failed"
+          if ! python3 scripts/testops.py wait -t 20; then
+            echo "Device did not come online after the CLI reboot; resetting over SWD"
+            bsb-device reboot
+            python3 scripts/testops.py wait -t 20
+          fi
+          python3 scripts/testops.py debug 1
           python3 scripts/testops.py format --no-confirm
           python3 scripts/testops.py update-fw busybar-f${{ env.U5_HW_TARGET }}-update.tgz -r 3 --connect-timeout 10
-          python3 scripts/testops.py wait -t 260
+          python3 scripts/testops.py wait -t 320
 
       - name: 'Sanity check after flashing'
         if: steps.flashing.outcome == 'success'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -156,19 +156,9 @@ jobs:
       - name: 'Flash firmware'
         id: flashing
         timeout-minutes: 20
-        run: |
-          set -euo pipefail
-          source scripts/toolchain/fbtenv.sh
-          python3 scripts/testops.py power reboot || echo "CLI reboot failed"
-          if ! python3 scripts/testops.py wait -t 20; then
-            echo "Device did not come online after the CLI reboot; resetting over SWD"
-            bsb-device reboot
-            python3 scripts/testops.py wait -t 20
-          fi
-          python3 scripts/testops.py debug 1
-          python3 scripts/testops.py format --no-confirm
-          python3 scripts/testops.py update-fw busybar-f${{ env.U5_HW_TARGET }}-update.tgz -r 3 --connect-timeout 10
-          python3 scripts/testops.py wait -t 320
+        uses: ./.github/actions/flash-device
+        with:
+          bundle: busybar-f${{ env.U5_HW_TARGET }}-update.tgz
 
       - name: 'Sanity check after flashing'
         if: steps.flashing.outcome == 'success'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -76,8 +76,12 @@ jobs:
         run: |
           set -euo pipefail
           source scripts/toolchain/fbtenv.sh
-          python3 scripts/testops.py power reboot
-          python3 scripts/testops.py wait -t 20
+          python3 scripts/testops.py power reboot || echo "CLI reboot failed"
+          if ! python3 scripts/testops.py wait -t 20; then
+            echo "Device did not come online after the CLI reboot; resetting over SWD"
+            bsb-device reboot
+            python3 scripts/testops.py wait -t 20
+          fi
           python3 scripts/testops.py debug 1
           python3 scripts/testops.py format --no-confirm
           python3 scripts/testops.py update-fw unittests/busybar-f${{ inputs.target }}-update-unittests.tgz -r 3 --connect-timeout 10

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -73,19 +73,9 @@ jobs:
 
       - name: 'Flash firmware'
         id: flashing
-        run: |
-          set -euo pipefail
-          source scripts/toolchain/fbtenv.sh
-          python3 scripts/testops.py power reboot || echo "CLI reboot failed"
-          if ! python3 scripts/testops.py wait -t 20; then
-            echo "Device did not come online after the CLI reboot; resetting over SWD"
-            bsb-device reboot
-            python3 scripts/testops.py wait -t 20
-          fi
-          python3 scripts/testops.py debug 1
-          python3 scripts/testops.py format --no-confirm
-          python3 scripts/testops.py update-fw unittests/busybar-f${{ inputs.target }}-update-unittests.tgz -r 3 --connect-timeout 10
-          python3 scripts/testops.py wait -t 320
+        uses: ./.github/actions/flash-device
+        with:
+          bundle: unittests/busybar-f${{ inputs.target }}-update-unittests.tgz
 
       - name: 'Check that both cores are available (post-flash)'
         if: steps.flashing.outcome == 'success'

--- a/.github/workflows/updater-test.yml
+++ b/.github/workflows/updater-test.yml
@@ -46,19 +46,9 @@ jobs:
 
       - name: 'Flash firmware'
         id: flashing
-        run: |
-          set -euo pipefail
-          source scripts/toolchain/fbtenv.sh
-          python3 scripts/testops.py power reboot || echo "CLI reboot failed"
-          if ! python3 scripts/testops.py wait -t 20; then
-            echo "Device did not come online after the CLI reboot; resetting over SWD"
-            bsb-device reboot
-            python3 scripts/testops.py wait -t 20
-          fi
-          python3 scripts/testops.py debug 1
-          python3 scripts/testops.py format --no-confirm
-          python3 scripts/testops.py update-fw busybar-f${{ inputs.target }}-update.tgz -r 3 --connect-timeout 10
-          python3 scripts/testops.py wait -t 320
+        uses: ./.github/actions/flash-device
+        with:
+          bundle: busybar-f${{ inputs.target }}-update.tgz
 
       - name: 'Check that both cores are available (post-flash)'
         if: steps.flashing.outcome == 'success'

--- a/.github/workflows/updater-test.yml
+++ b/.github/workflows/updater-test.yml
@@ -49,8 +49,12 @@ jobs:
         run: |
           set -euo pipefail
           source scripts/toolchain/fbtenv.sh
-          python3 scripts/testops.py power reboot
-          python3 scripts/testops.py wait -t 20
+          python3 scripts/testops.py power reboot || echo "CLI reboot failed"
+          if ! python3 scripts/testops.py wait -t 20; then
+            echo "Device did not come online after the CLI reboot; resetting over SWD"
+            bsb-device reboot
+            python3 scripts/testops.py wait -t 20
+          fi
           python3 scripts/testops.py debug 1
           python3 scripts/testops.py format --no-confirm
           python3 scripts/testops.py update-fw busybar-f${{ inputs.target }}-update.tgz -r 3 --connect-timeout 10


### PR DESCRIPTION
…reboot

# What's new

- Retry to reboot before updating device if dhclient didn't get ip after reboot

# Verification 

- Check that jobs now runned successfully more often

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
