### PR TITLE
[FW-1123] Exit from current JS app

### DIFF
--- a/applications/system/js_app_launcher/js_app_launcher.c
+++ b/applications/system/js_app_launcher/js_app_launcher.c
@@ -129,9 +129,8 @@ static JsAppLauncher* js_app_launcher_alloc(const char* app_id) {
 }
 
 static void js_app_launcher_free(JsAppLauncher* instance) {
-    if(instance->js_app) {
-        js_app_free(instance->js_app);
-    }
+    // TODO [FW-602]: this call MUST be first to avoid use-after-free.
+    scene_manager_free(instance->scene_manager);
 
     furi_event_loop_unsubscribe(instance->event_loop, instance->input_queue);
     furi_event_loop_unsubscribe(instance->event_loop, instance->event_queue);
@@ -140,7 +139,10 @@ static void js_app_launcher_free(JsAppLauncher* instance) {
     furi_message_queue_free(instance->event_queue);
 
     furi_event_loop_free(instance->event_loop);
-    scene_manager_free(instance->scene_manager);
+
+    if(instance->js_app) {
+        js_app_free(instance->js_app);
+    }
 
     with_gui(instance->gui, {
         GuiLayer* layer = gui_get_layer(instance->gui, GuiLayerIdMain);

--- a/applications/system/js_app_launcher/resources/user_assets/app.busy.js_example/scripts/main.js
+++ b/applications/system/js_app_launcher/resources/user_assets/app.busy.js_example/scripts/main.js
@@ -1,1 +1,29 @@
-console.log("Hello from JS App Example!");
+let counter = 0;
+
+function displayText() {
+    const request = new Request(
+        "http://10.0.4.20/api/display/draw",
+        {
+            method: "POST",
+            body: JSON.stringify({
+                "application_name": "app.busy.js_example",
+                "elements": [
+                    {
+                        "id": "0",
+                        "type": "text",
+                        "x": 72 / 2,
+                        "y": 16 / 2,
+                        "align": "center",
+                        "text": "JS Example: " + counter,
+                        "font": "small"
+                    }
+                ]
+            })
+        });
+
+    fetch(request);
+    counter++;
+}
+
+displayText();
+setInterval(displayText, 1000);

--- a/applications/system/js_app_launcher/scenes/js_app_launcher_scene_run.c
+++ b/applications/system/js_app_launcher/scenes/js_app_launcher_scene_run.c
@@ -102,7 +102,12 @@ static void js_app_launcher_scene_run_on_exit(void* context) {
     FuriThread* js_thread = data->js_thread;
 
     if(js_thread != NULL) {
+        // Not checking the return value of js_runner_abort
+        // because it is completely ambiguous here.
         js_runner_abort(data->js_runner, js_thread);
+        // Assuming this will not block forever during normal operation.
+        // The script should have stopped at this point either due to
+        // its internal logic or due to the above abort request.
         furi_thread_join(js_thread);
         furi_thread_free(js_thread);
         data->js_thread = NULL;

--- a/applications/system/js_app_launcher/scenes/js_app_launcher_scene_run.c
+++ b/applications/system/js_app_launcher/scenes/js_app_launcher_scene_run.c
@@ -1,7 +1,7 @@
 #include "../js_app_launcher_i.h"
 #include "js_app_launcher_scenes.h"
 
-#define JS_THREAD_STACK_SIZE (2048)
+#define JS_THREAD_STACK_SIZE (3 * 1024)
 
 typedef struct {
     FuriThread* js_thread;

--- a/applications/system/js_app_launcher/scenes/js_app_launcher_scene_run.c
+++ b/applications/system/js_app_launcher/scenes/js_app_launcher_scene_run.c
@@ -6,6 +6,7 @@
 typedef struct {
     FuriThread* js_thread;
     JsAppInfo js_info;
+    JsRunner* js_runner;
     JsRunnerError js_error;
 } JsAppLauncherSceneRun;
 
@@ -33,16 +34,13 @@ static int32_t js_app_laucher_scene_run_thread_callback(void* arg) {
     JsAppLauncherSceneRun* data = arg;
 
     const JsAppInfo* info = &data->js_info;
-    JsRunner* runner = furi_record_open(RECORD_JS_RUNNER);
 
     const JsRunnerError error = js_runner_run(
-        runner,
+        data->js_runner,
         info->path.entry,
         info->manifest.heap_size,
         js_app_launcher_scene_run_console_out_callback,
         NULL);
-
-    furi_record_close(RECORD_JS_RUNNER);
 
     if(error != JsRunnerErrorNone) {
         FURI_LOG_E(TAG, "JsRunner error: %d", error);
@@ -74,6 +72,8 @@ static void js_app_launcher_scene_run_on_enter(void* context) {
     JsAppLauncherSceneRun* data =
         scene_manager_get_scene_data(instance->scene_manager, JsAppLauncherSceneIdRun);
 
+    data->js_runner = furi_record_open(RECORD_JS_RUNNER);
+
     if(js_app_get_info(instance->js_app, &data->js_info)) {
         FuriThread* js_thread = furi_thread_alloc_ex(
             data->js_info.manifest.name,
@@ -102,11 +102,13 @@ static void js_app_launcher_scene_run_on_exit(void* context) {
     FuriThread* js_thread = data->js_thread;
 
     if(js_thread != NULL) {
-        // TODO: Ask JsRunner to stop the script
+        js_runner_abort(data->js_runner, js_thread);
         furi_thread_join(js_thread);
         furi_thread_free(js_thread);
         data->js_thread = NULL;
     }
+
+    furi_record_close(RECORD_JS_RUNNER);
 }
 
 static bool js_app_launcher_scene_run_on_event(const SceneManagerEvent* event, void* context) {


### PR DESCRIPTION
# What's new

- Implement graceful exit from the currently running JS application (via #962)
- Add a more elaborate JS App example (might not be the most idiomatic JS code)

# Verification 

1. Flash the firmware bundle (with resources)
2. Have the `/ext/apps_data/apps_menu/js_apps_enable` file present and developer mode enabled
3. Navigate to `APPS -> Js App Example -> Start`
4. A text with a one-second counter should appear.
5. Flick the mode selector switch to another position.
6. The JS app should exit (the canvas display might remain because it's a separate service and will require an additional back press)

# Caveats

1. `Back` key behaviour is TBD. There should be some mechanism that will allow apps to process it.
2. Canvas cleanup behaviour is TBD.
3. Loopback fetch requests do not work with USB cable detached for some reason (most likely due to the link being marked as down)

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
