### PR TITLE
[FW-1145] Allow Recovery At Any Battery % & 917 DFU USART Fix

### DIFF
--- a/applications/services/log_storage/log_storage.h
+++ b/applications/services/log_storage/log_storage.h
@@ -51,7 +51,9 @@ bool log_storage_dump(LogStorage* instance, const char* path);
  * @brief Temporarily release the remote log UART.
  *
  * Releases the serial line used to receive remote logs so that another consumer
- * can acquire it. Reception is paused until log_storage_resume_remote is called.
+ * can acquire it. Suspends are counted: the line is released on the first call
+ * and stays released until every suspend is matched by a
+ * log_storage_resume_remote call.
  *
  * @param[in] instance pointer to the LogStorage instance
  */
@@ -59,6 +61,9 @@ void log_storage_suspend_remote(LogStorage* instance);
 
 /**
  * @brief Resume remote log reception after log_storage_suspend_remote.
+ *
+ * Restores reception only when all outstanding suspends have been resumed;
+ * otherwise the line remains released for its current owner.
  *
  * @param[in] instance pointer to the LogStorage instance
  */

--- a/applications/services/log_storage/log_storage_remote.c
+++ b/applications/services/log_storage/log_storage_remote.c
@@ -44,22 +44,36 @@ static void log_storage_remote_stream_callback(FuriEventLoopObject* object, void
     log_storage_remote_internal_flush(instance);
 }
 
-void log_storage_remote_internal_suspend(LogStorageRemote* instance) {
-    furi_check(instance);
-
+static void log_storage_remote_stop(LogStorageRemote* instance) {
     furi_hal_serial_async_rx_stop(instance->serial);
     furi_hal_serial_set_rx_callback(instance->serial, NULL, NULL);
     furi_hal_serial_control_release(instance->serial);
     instance->serial = NULL;
 }
 
-void log_storage_remote_internal_resume(LogStorageRemote* instance) {
-    furi_check(instance);
-
+static void log_storage_remote_start(LogStorageRemote* instance) {
     instance->serial = furi_hal_serial_control_acquire(FuriHalSerialIdUsart2);
     furi_hal_serial_init(instance->serial, LOG_STORAGE_REMOTE_BAUD_RATE);
     furi_hal_serial_set_rx_callback(instance->serial, log_storage_remote_rx_callback, instance);
     furi_hal_serial_async_rx_start(instance->serial, false);
+}
+
+void log_storage_remote_internal_suspend(LogStorageRemote* instance) {
+    furi_check(instance);
+
+    if(instance->suspend_nesting_count++ == 0) {
+        log_storage_remote_stop(instance);
+    }
+}
+
+void log_storage_remote_internal_resume(LogStorageRemote* instance) {
+    furi_check(instance);
+
+    if(instance->suspend_nesting_count > 0) {
+        if(--instance->suspend_nesting_count == 0) {
+            log_storage_remote_start(instance);
+        }
+    }
 }
 
 void log_storage_remote_internal_flush(LogStorageRemote* instance) {
@@ -84,6 +98,7 @@ void log_storage_remote_internal_init(LogStorageRemote* instance, FuriEventLoop*
 
     log_storage_base_internal_init(&instance->base, LOG_STORAGE_REMOTE_BUFFER_SIZE);
     instance->rx_stream = furi_stream_buffer_alloc(LOG_STORAGE_REMOTE_STREAM_SIZE, 1);
+    instance->suspend_nesting_count = 0;
     instance->did_overrun = false;
 
     furi_event_loop_subscribe_stream_buffer(
@@ -93,5 +108,5 @@ void log_storage_remote_internal_init(LogStorageRemote* instance, FuriEventLoop*
         log_storage_remote_stream_callback,
         instance);
 
-    log_storage_remote_internal_resume(instance);
+    log_storage_remote_start(instance);
 }

--- a/applications/services/log_storage/log_storage_remote_i.h
+++ b/applications/services/log_storage/log_storage_remote_i.h
@@ -15,6 +15,7 @@ typedef struct {
     FuriHalSerialHandle* serial;
     FuriStreamBuffer* rx_stream;
 
+    size_t suspend_nesting_count;
     _Atomic bool did_overrun;
 } LogStorageRemote;
 

--- a/applications/services/supervisor/supervisor.c
+++ b/applications/services/supervisor/supervisor.c
@@ -516,6 +516,7 @@ static void supervisor_handle_intercom_status(Supervisor* instance, IntercomStat
 #ifdef SRV_LOG_STORAGE
     LogStorage* log_storage = furi_record_open(RECORD_LOG_STORAGE);
     log_storage_dump(log_storage, SUPERVISOR_FAILURE_LOG_DUMP_PATH);
+    log_storage_suspend_remote(log_storage);
     furi_record_close(RECORD_LOG_STORAGE);
 #endif
 

--- a/applications/system/updater/updater.c
+++ b/applications/system/updater/updater.c
@@ -91,7 +91,6 @@ bool updater_get_active_security_flags(uint32_t* flags_out) {
 
 #define MESSAGE_QUEUE_ITEMS_COUNT 8
 
-#define UPDATE_START_MIN_BATTERY_CHARGE        40
 #define UPDATE_INSTALLATION_APPLY_REBOOT_DELAY 100
 
 typedef struct {
@@ -288,17 +287,6 @@ FuriState* updater_get_update_state(Updater* instance) {
     furi_check(instance);
 
     return instance->update_state;
-}
-
-UpdaterStatus updater_get_allowance_status(Updater* instance) {
-    PowerInfo power_info;
-    power_get_info(instance->power, &power_info);
-
-    return (power_info.charge >= UPDATE_START_MIN_BATTERY_CHARGE ||
-            (furi_hal_nvm_is_flag_set(FuriHalNvmFlagDebug) &&
-             power_is_usb_connected(instance->power))) ?
-               UpdaterStatusOk :
-               UpdaterStatusBatteryLow;
 }
 
 UpdaterStatus updater_session_start(Updater* instance) {

--- a/applications/system/updater/updater_normal.c
+++ b/applications/system/updater/updater_normal.c
@@ -14,6 +14,8 @@
 #define INSTALL_FROM_URL_THREAD_NAME       "UpdateInstall"
 #define INSTALL_FROM_URL_THREAD_STACK_SIZE (2 * 1024)
 
+#define UPDATE_START_MIN_BATTERY_CHARGE 40
+
 typedef struct {
     bool is_abort_request;
     UpdaterStatus status;
@@ -468,6 +470,17 @@ void updater_get_check_info(Updater* instance, UpdateCheckInfo* info) {
     }
 
     furi_mutex_release(instance->check_info_mutex);
+}
+
+UpdaterStatus updater_get_allowance_status(Updater* instance) {
+    PowerInfo power_info;
+    power_get_info(instance->power, &power_info);
+
+    return (power_info.charge >= UPDATE_START_MIN_BATTERY_CHARGE ||
+            (furi_hal_nvm_is_flag_set(FuriHalNvmFlagDebug) &&
+             power_is_usb_connected(instance->power))) ?
+               UpdaterStatusOk :
+               UpdaterStatusBatteryLow;
 }
 
 UpdaterStatus

--- a/applications/system/updater/updater_recovery.c
+++ b/applications/system/updater/updater_recovery.c
@@ -40,6 +40,12 @@ void updater_get_check_info(Updater* instance, UpdateCheckInfo* info) {
     UNUSED(info);
 }
 
+UpdaterStatus updater_get_allowance_status(Updater* instance) {
+    UNUSED(instance);
+
+    return UpdaterStatusOk;
+}
+
 UpdaterStatus
     updater_download(Updater* instance, const char* url, const char* path, bool do_wait) {
     UNUSED(instance);


### PR DESCRIPTION
> [!NOTE]
> * [**FW-1145**](https://flipper.atlassian.net/browse/FW-1145)

# What's new

- recovery build's updater battry check drop (allow always)
- deinit 917 log USART on intercom error (to fix 917's DFU)
- make `log_storage` remote suspend/resume API count nested calls

# Verification 

- recovery update doesn't fail on low battery
- 917's DFU mode allows manual firmware flashing

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
