### PR TITLE
ci: authenticate submodule clones + credential hygiene for self-hosted runners

### DIFF
--- a/.github/actions/authenticate-git/action.yml
+++ b/.github/actions/authenticate-git/action.yml
@@ -1,0 +1,28 @@
+name: Authenticate git for the job
+description: >-
+  Reproduce actions/checkout's credential mechanism for every git operation in
+  the calling job (submodule bootstraps, build-artifacts' submodule update, and
+  fbt's own recursive submodule init): write an Authorization extraheader for
+  github.com into a per-job config file and point GIT_CONFIG_GLOBAL at it. This
+  escapes GitHub's throttling of unauthenticated clone traffic from the shared
+  self-hosted runner egress. Uses the GH_TOKEN env var of the calling job; run
+  after actions/checkout.
+author: hedger
+
+runs:
+  using: composite
+  steps:
+    - name: 'Configure git auth for the job'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # base64 must stay single-line: GNU base64 wraps at 76 cols by default,
+        # which would embed newlines in the Authorization header value and make
+        # the server reset the connection ("Failed sending HTTP request").
+        if [[ -n "${GH_TOKEN:-}" ]]; then
+          CFG="${RUNNER_TEMP}/git-credentials.config"
+          AUTH="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+          git config --file "$CFG" http.https://github.com/.extraheader "$AUTH"
+          chmod 600 "$CFG"
+          echo "GIT_CONFIG_GLOBAL=${CFG}" >> "${GITHUB_ENV}"
+        fi

--- a/.github/actions/authenticate-git/action.yml
+++ b/.github/actions/authenticate-git/action.yml
@@ -1,12 +1,8 @@
 name: Authenticate git for the job
 description: >-
-  Reproduce actions/checkout's credential mechanism for every git operation in
-  the calling job (submodule bootstraps, build-artifacts' submodule update, and
-  fbt's own recursive submodule init): write an Authorization extraheader for
-  github.com into a per-job config file and point GIT_CONFIG_GLOBAL at it. This
-  escapes GitHub's throttling of unauthenticated clone traffic from the shared
-  self-hosted runner egress. Uses the GH_TOKEN env var of the calling job; run
-  after actions/checkout.
+  Point GIT_CONFIG_GLOBAL at a per-job config with a github.com Authorization
+  extraheader so all git ops in the job authenticate. Uses GH_TOKEN; run after
+  checkout.
 author: hedger
 
 runs:
@@ -16,9 +12,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        # base64 must stay single-line: GNU base64 wraps at 76 cols by default,
-        # which would embed newlines in the Authorization header value and make
-        # the server reset the connection ("Failed sending HTTP request").
+        # base64 must stay single-line (GNU base64 wraps at 76 cols).
         if [[ -n "${GH_TOKEN:-}" ]]; then
           CFG="${RUNNER_TEMP}/git-credentials.config"
           AUTH="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"

--- a/.github/actions/build-artifacts/action.yml
+++ b/.github/actions/build-artifacts/action.yml
@@ -143,22 +143,10 @@ runs:
         git config --global http.lowSpeedTime 30
 
     - name: Update submodules
-      shell: bash
-      run: |
-        set -euo pipefail
-        # Shared-egress clone throttling comes in waves; retry with backoff.
-        attempt=0
-        until timeout 180 git submodule update --init --depth 1 --filter=blob:none --recursive --jobs="$(nproc)" \
-            scripts/toolchain fbt_layers/fbtng; do
-          attempt=$((attempt + 1))
-          if (( attempt >= 3 )); then
-            git lfs logs last 2>/dev/null || true
-            echo "submodule update failed after ${attempt} attempts"
-            exit 1
-          fi
-          echo "submodule update attempt ${attempt}/3 failed; retrying in $((attempt * 15))s"
-          sleep "$((attempt * 15))"
-        done
+      uses: ./.github/actions/update-submodules
+      with:
+        paths: scripts/toolchain fbt_layers/fbtng
+        recursive: 'true'
 
     - name: Build update package
       shell: bash

--- a/.github/actions/build-artifacts/action.yml
+++ b/.github/actions/build-artifacts/action.yml
@@ -132,10 +132,7 @@ runs:
         set -euo pipefail
         git lfs install --skip-smudge
         if [[ -n "${GH_TOKEN:-}" ]]; then
-          # Keep credentials in the per-job temp dir: the runner cleans
-          # RUNNER_TEMP after each job, while self-hosted runners preserve
-          # $HOME across runs, so ~/.git-credentials would leak a dead token
-          # into later jobs on the same runner.
+          # Self-hosted runners persist $HOME; keep creds in per-job RUNNER_TEMP.
           rm -f "$HOME/.git-credentials"
           echo "https://x-access-token:${GH_TOKEN}@github.com" > "${RUNNER_TEMP}/git-credentials"
           git config credential.helper "store --file ${RUNNER_TEMP}/git-credentials"
@@ -149,9 +146,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        # GitHub intermittently throttles unauthenticated clone traffic from
-        # the shared self-hosted runner egress (HTTP 401/400 in waves when
-        # several CI jobs fire at once). Retry with backoff to ride it out.
+        # Shared-egress clone throttling comes in waves; retry with backoff.
         attempt=0
         until timeout 180 git submodule update --init --depth 1 --filter=blob:none --recursive --jobs="$(nproc)" \
             scripts/toolchain fbt_layers/fbtng; do

--- a/.github/actions/build-artifacts/action.yml
+++ b/.github/actions/build-artifacts/action.yml
@@ -132,8 +132,13 @@ runs:
         set -euo pipefail
         git lfs install --skip-smudge
         if [[ -n "${GH_TOKEN:-}" ]]; then
-          echo "https://x-access-token:${GH_TOKEN}@github.com" > ~/.git-credentials
-          git config credential.helper 'store --file ~/.git-credentials'
+          # Keep credentials in the per-job temp dir: the runner cleans
+          # RUNNER_TEMP after each job, while self-hosted runners preserve
+          # $HOME across runs, so ~/.git-credentials would leak a dead token
+          # into later jobs on the same runner.
+          rm -f "$HOME/.git-credentials"
+          echo "https://x-access-token:${GH_TOKEN}@github.com" > "${RUNNER_TEMP}/git-credentials"
+          git config credential.helper "store --file ${RUNNER_TEMP}/git-credentials"
         fi
         git config lfs.transfer.maxretries 3
         # Fail fast on stalled connections: 30s with no data = abort

--- a/.github/actions/build-artifacts/action.yml
+++ b/.github/actions/build-artifacts/action.yml
@@ -149,10 +149,21 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        timeout 180 git submodule update --init --depth 1 --filter=blob:none --recursive --jobs="$(nproc)" scripts/toolchain fbt_layers/fbtng || {
-          git lfs logs last 2>/dev/null || true
-          exit 1
-        }
+        # GitHub intermittently throttles unauthenticated clone traffic from
+        # the shared self-hosted runner egress (HTTP 401/400 in waves when
+        # several CI jobs fire at once). Retry with backoff to ride it out.
+        attempt=0
+        until timeout 180 git submodule update --init --depth 1 --filter=blob:none --recursive --jobs="$(nproc)" \
+            scripts/toolchain fbt_layers/fbtng; do
+          attempt=$((attempt + 1))
+          if (( attempt >= 3 )); then
+            git lfs logs last 2>/dev/null || true
+            echo "submodule update failed after ${attempt} attempts"
+            exit 1
+          fi
+          echo "submodule update attempt ${attempt}/3 failed; retrying in $((attempt * 15))s"
+          sleep "$((attempt * 15))"
+        done
 
     - name: Build update package
       shell: bash

--- a/.github/actions/build-test-artifacts/action.yml
+++ b/.github/actions/build-test-artifacts/action.yml
@@ -47,7 +47,20 @@ runs:
     - name: 'Bootstrap tooling submodule'
       shell: bash
       run: |
-        git submodule update --init --depth 1 --filter=blob:none fbt_layers/fbtng
+        set -euo pipefail
+        # GitHub intermittently throttles unauthenticated clone traffic from
+        # the shared self-hosted runner egress (HTTP 401/400 in waves when
+        # several CI jobs fire at once). Retry with backoff to ride it out.
+        attempt=0
+        until timeout 180 git submodule update --init --depth 1 --filter=blob:none fbt_layers/fbtng; do
+          attempt=$((attempt + 1))
+          if (( attempt >= 3 )); then
+            echo "submodule bootstrap failed after ${attempt} attempts"
+            exit 1
+          fi
+          echo "submodule bootstrap attempt ${attempt}/3 failed; retrying in $((attempt * 15))s"
+          sleep "$((attempt * 15))"
+        done
 
     - name: 'Get commit details'
       id: get-env

--- a/.github/actions/build-test-artifacts/action.yml
+++ b/.github/actions/build-test-artifacts/action.yml
@@ -48,9 +48,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        # GitHub intermittently throttles unauthenticated clone traffic from
-        # the shared self-hosted runner egress (HTTP 401/400 in waves when
-        # several CI jobs fire at once). Retry with backoff to ride it out.
+        # Shared-egress clone throttling comes in waves; retry with backoff.
         attempt=0
         until timeout 180 git submodule update --init --depth 1 --filter=blob:none fbt_layers/fbtng; do
           attempt=$((attempt + 1))

--- a/.github/actions/build-test-artifacts/action.yml
+++ b/.github/actions/build-test-artifacts/action.yml
@@ -45,20 +45,9 @@ runs:
   using: composite
   steps:
     - name: 'Bootstrap tooling submodule'
-      shell: bash
-      run: |
-        set -euo pipefail
-        # Shared-egress clone throttling comes in waves; retry with backoff.
-        attempt=0
-        until timeout 180 git submodule update --init --depth 1 --filter=blob:none fbt_layers/fbtng; do
-          attempt=$((attempt + 1))
-          if (( attempt >= 3 )); then
-            echo "submodule bootstrap failed after ${attempt} attempts"
-            exit 1
-          fi
-          echo "submodule bootstrap attempt ${attempt}/3 failed; retrying in $((attempt * 15))s"
-          sleep "$((attempt * 15))"
-        done
+      uses: ./.github/actions/update-submodules
+      with:
+        paths: fbt_layers/fbtng
 
     - name: 'Get commit details'
       id: get-env

--- a/.github/actions/update-submodules/action.yml
+++ b/.github/actions/update-submodules/action.yml
@@ -1,0 +1,38 @@
+name: Update submodules
+description: >-
+  Run `git submodule update` on the given paths with the standard shallow/blobless
+  flags and retry with backoff (shared-egress clone throttling comes in waves).
+inputs:
+  paths:
+    description: Space-separated submodule paths to update
+    required: true
+  recursive:
+    description: Recurse into nested submodules (parallel with nproc)
+    required: false
+    default: 'false'
+runs:
+  using: composite
+  steps:
+    - name: 'Update submodules'
+      shell: bash
+      env:
+        SUBMODULE_PATHS: ${{ inputs.paths }}
+        RECURSIVE: ${{ inputs.recursive }}
+      run: |
+        set -euo pipefail
+        read -r -a SUBMODULES <<< "$SUBMODULE_PATHS"
+        ARGS=(--init --depth 1 --filter=blob:none)
+        if [[ "$RECURSIVE" == "true" ]]; then
+          ARGS+=(--recursive --jobs="$(nproc)")
+        fi
+        attempt=0
+        until timeout 180 git submodule update "${ARGS[@]}" "${SUBMODULES[@]}"; do
+          attempt=$((attempt + 1))
+          if (( attempt >= 3 )); then
+            git lfs logs last 2>/dev/null || true
+            echo "submodule update failed after ${attempt} attempts"
+            exit 1
+          fi
+          echo "submodule update attempt ${attempt}/3 failed; retrying in $((attempt * 15))s"
+          sleep "$((attempt * 15))"
+        done

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -69,20 +69,9 @@ jobs:
               uses: ./.github/actions/authenticate-git
 
             - name: "Bootstrap tooling submodule"
-              run: |
-                  set -euo pipefail
-                  # Shared-egress clone throttling comes in waves; retry with
-                  # backoff.
-                  attempt=0
-                  until timeout 180 git submodule update --init --depth 1 --filter=blob:none fbt_layers/fbtng; do
-                      attempt=$((attempt + 1))
-                      if (( attempt >= 3 )); then
-                          echo "submodule bootstrap failed after ${attempt} attempts"
-                          exit 1
-                      fi
-                      echo "submodule bootstrap attempt ${attempt}/3 failed; retrying in $((attempt * 15))s"
-                      sleep "$((attempt * 15))"
-                  done
+              uses: ./.github/actions/update-submodules
+              with:
+                  paths: fbt_layers/fbtng
 
             - name: "Get commit details"
               id: get-env

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -65,6 +65,27 @@ jobs:
                   fetch-depth: 2
                   token: ${{ secrets.GITHUB_TOKEN }}
 
+            - name: "Authenticate git for the job"
+              run: |
+                  set -euo pipefail
+                  # Reproduce actions/checkout's credential mechanism for every
+                  # git operation in this job (submodule bootstraps,
+                  # build-artifacts' submodule update, and fbt's own recursive
+                  # init): an Authorization extraheader applied via the global
+                  # git config. This escapes GitHub's throttling of
+                  # unauthenticated clone traffic from the shared self-hosted
+                  # runner egress (HTTP 401/400 in waves). base64 must stay
+                  # single-line: GNU base64 wraps at 76 cols, which would embed
+                  # newlines in the header and make the server reset the
+                  # connection.
+                  if [[ -n "${GH_TOKEN:-}" ]]; then
+                      CFG="${RUNNER_TEMP}/git-credentials.config"
+                      AUTH="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+                      git config --file "$CFG" http.https://github.com/.extraheader "$AUTH"
+                      chmod 600 "$CFG"
+                      echo "GIT_CONFIG_GLOBAL=${CFG}" >> "${GITHUB_ENV}"
+                  fi
+
             - name: "Bootstrap tooling submodule"
               run: |
                   set -euo pipefail

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -71,10 +71,8 @@ jobs:
             - name: "Bootstrap tooling submodule"
               run: |
                   set -euo pipefail
-                  # GitHub intermittently throttles unauthenticated clone traffic
-                  # from the shared self-hosted runner egress (HTTP 401/400 in
-                  # waves when several CI jobs fire at once). Retry with backoff
-                  # to ride it out.
+                  # Shared-egress clone throttling comes in waves; retry with
+                  # backoff.
                   attempt=0
                   until timeout 180 git submodule update --init --depth 1 --filter=blob:none fbt_layers/fbtng; do
                       attempt=$((attempt + 1))

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -67,7 +67,21 @@ jobs:
 
             - name: "Bootstrap tooling submodule"
               run: |
-                  git submodule update --init --depth 1 --filter=blob:none fbt_layers/fbtng
+                  set -euo pipefail
+                  # GitHub intermittently throttles unauthenticated clone traffic
+                  # from the shared self-hosted runner egress (HTTP 401/400 in
+                  # waves when several CI jobs fire at once). Retry with backoff
+                  # to ride it out.
+                  attempt=0
+                  until timeout 180 git submodule update --init --depth 1 --filter=blob:none fbt_layers/fbtng; do
+                      attempt=$((attempt + 1))
+                      if (( attempt >= 3 )); then
+                          echo "submodule bootstrap failed after ${attempt} attempts"
+                          exit 1
+                      fi
+                      echo "submodule bootstrap attempt ${attempt}/3 failed; retrying in $((attempt * 15))s"
+                      sleep "$((attempt * 15))"
+                  done
 
             - name: "Get commit details"
               id: get-env

--- a/.github/workflows/build-test-artifacts.yml
+++ b/.github/workflows/build-test-artifacts.yml
@@ -66,25 +66,7 @@ jobs:
                   token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: "Authenticate git for the job"
-              run: |
-                  set -euo pipefail
-                  # Reproduce actions/checkout's credential mechanism for every
-                  # git operation in this job (submodule bootstraps,
-                  # build-artifacts' submodule update, and fbt's own recursive
-                  # init): an Authorization extraheader applied via the global
-                  # git config. This escapes GitHub's throttling of
-                  # unauthenticated clone traffic from the shared self-hosted
-                  # runner egress (HTTP 401/400 in waves). base64 must stay
-                  # single-line: GNU base64 wraps at 76 cols, which would embed
-                  # newlines in the header and make the server reset the
-                  # connection.
-                  if [[ -n "${GH_TOKEN:-}" ]]; then
-                      CFG="${RUNNER_TEMP}/git-credentials.config"
-                      AUTH="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
-                      git config --file "$CFG" http.https://github.com/.extraheader "$AUTH"
-                      chmod 600 "$CFG"
-                      echo "GIT_CONFIG_GLOBAL=${CFG}" >> "${GITHUB_ENV}"
-                  fi
+              uses: ./.github/actions/authenticate-git
 
             - name: "Bootstrap tooling submodule"
               run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,9 @@ jobs:
       - name: 'Wipe workspace'
         run: |
           rm -f /home/runner/.gitconfig
+          # Self-hosted runners preserve $HOME across runs; drop any stale
+          # credential file left by earlier jobs on the same runner.
+          rm -f "${HOME}/.git-credentials"
           find ./ -mount -maxdepth 1 -exec rm -rf {} \;
 
       - name: 'Configure Git'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,7 @@ jobs:
       - name: 'Wipe workspace'
         run: |
           rm -f /home/runner/.gitconfig
-          # Self-hosted runners preserve $HOME across runs; drop any stale
-          # credential file left by earlier jobs on the same runner.
+          # Self-hosted runners persist $HOME across jobs.
           rm -f "${HOME}/.git-credentials"
           find ./ -mount -maxdepth 1 -exec rm -rf {} \;
 
@@ -58,9 +57,7 @@ jobs:
       - name: 'Bootstrap tooling submodule'
         run: |
           set -euo pipefail
-          # GitHub intermittently throttles unauthenticated clone traffic from
-          # the shared self-hosted runner egress (HTTP 401/400 in waves when
-          # several CI jobs fire at once). Retry with backoff to ride it out.
+          # Shared-egress clone throttling comes in waves; retry with backoff.
           attempt=0
           until timeout 180 git submodule update --init --depth 1 --filter=blob:none fbt_layers/fbtng; do
             attempt=$((attempt + 1))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,19 +55,9 @@ jobs:
         uses: ./.github/actions/authenticate-git
 
       - name: 'Bootstrap tooling submodule'
-        run: |
-          set -euo pipefail
-          # Shared-egress clone throttling comes in waves; retry with backoff.
-          attempt=0
-          until timeout 180 git submodule update --init --depth 1 --filter=blob:none fbt_layers/fbtng; do
-            attempt=$((attempt + 1))
-            if (( attempt >= 3 )); then
-              echo "submodule bootstrap failed after ${attempt} attempts"
-              exit 1
-            fi
-            echo "submodule bootstrap attempt ${attempt}/3 failed; retrying in $((attempt * 15))s"
-            sleep "$((attempt * 15))"
-          done
+        uses: ./.github/actions/update-submodules
+        with:
+          paths: fbt_layers/fbtng
 
       - name: 'Get commit details'
         id: get-env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,20 @@ jobs:
 
       - name: 'Bootstrap tooling submodule'
         run: |
-          timeout 180 git submodule update --init --depth 1 --filter=blob:none fbt_layers/fbtng
+          set -euo pipefail
+          # GitHub intermittently throttles unauthenticated clone traffic from
+          # the shared self-hosted runner egress (HTTP 401/400 in waves when
+          # several CI jobs fire at once). Retry with backoff to ride it out.
+          attempt=0
+          until timeout 180 git submodule update --init --depth 1 --filter=blob:none fbt_layers/fbtng; do
+            attempt=$((attempt + 1))
+            if (( attempt >= 3 )); then
+              echo "submodule bootstrap failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "submodule bootstrap attempt ${attempt}/3 failed; retrying in $((attempt * 15))s"
+            sleep "$((attempt * 15))"
+          done
 
       - name: 'Get commit details'
         id: get-env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,25 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 'Authenticate git for the job'
+        run: |
+          set -euo pipefail
+          # Reproduce actions/checkout's credential mechanism for every git
+          # operation in this job (submodule bootstraps, build-artifacts'
+          # submodule update, and fbt's own recursive init): an Authorization
+          # extraheader applied via the global git config. This escapes GitHub's
+          # throttling of unauthenticated clone traffic from the shared
+          # self-hosted runner egress (HTTP 401/400 in waves). base64 must stay
+          # single-line: GNU base64 wraps at 76 cols, which would embed newlines
+          # in the header and make the server reset the connection.
+          if [[ -n "${GH_TOKEN:-}" ]]; then
+            CFG="${RUNNER_TEMP}/git-credentials.config"
+            AUTH="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+            git config --file "$CFG" http.https://github.com/.extraheader "$AUTH"
+            chmod 600 "$CFG"
+            echo "GIT_CONFIG_GLOBAL=${CFG}" >> "${GITHUB_ENV}"
+          fi
+
       - name: 'Bootstrap tooling submodule'
         run: |
           set -euo pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,23 +53,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Authenticate git for the job'
-        run: |
-          set -euo pipefail
-          # Reproduce actions/checkout's credential mechanism for every git
-          # operation in this job (submodule bootstraps, build-artifacts'
-          # submodule update, and fbt's own recursive init): an Authorization
-          # extraheader applied via the global git config. This escapes GitHub's
-          # throttling of unauthenticated clone traffic from the shared
-          # self-hosted runner egress (HTTP 401/400 in waves). base64 must stay
-          # single-line: GNU base64 wraps at 76 cols, which would embed newlines
-          # in the header and make the server reset the connection.
-          if [[ -n "${GH_TOKEN:-}" ]]; then
-            CFG="${RUNNER_TEMP}/git-credentials.config"
-            AUTH="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
-            git config --file "$CFG" http.https://github.com/.extraheader "$AUTH"
-            chmod 600 "$CFG"
-            echo "GIT_CONFIG_GLOBAL=${CFG}" >> "${GITHUB_ENV}"
-          fi
+        uses: ./.github/actions/authenticate-git
 
       - name: 'Bootstrap tooling submodule'
         run: |

--- a/.github/workflows/compact-build.yml
+++ b/.github/workflows/compact-build.yml
@@ -29,6 +29,9 @@ jobs:
     steps:
       - name: "Wipe workspace"
         run: |
+          # Self-hosted runners preserve $HOME across runs; drop any stale
+          # credential file left by earlier jobs on the same runner.
+          rm -f "${HOME}/.git-credentials"
           find ./ -mount -maxdepth 1 -exec rm -rf {} \;
 
       - name: "Checkout code"

--- a/.github/workflows/compact-build.yml
+++ b/.github/workflows/compact-build.yml
@@ -41,6 +41,25 @@ jobs:
           fetch-depth: 2
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: "Authenticate git for the job"
+        run: |
+          set -euo pipefail
+          # Reproduce actions/checkout's credential mechanism for every git
+          # operation in this job (build-artifacts' submodule update and fbt's
+          # own recursive init): an Authorization extraheader applied via the
+          # global git config. This escapes GitHub's throttling of
+          # unauthenticated clone traffic from the shared self-hosted runner
+          # egress (HTTP 401/400 in waves). base64 must stay single-line: GNU
+          # base64 wraps at 76 cols, which would embed newlines in the header
+          # and make the server reset the connection.
+          if [[ -n "${GH_TOKEN:-}" ]]; then
+            CFG="${RUNNER_TEMP}/git-credentials.config"
+            AUTH="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+            git config --file "$CFG" http.https://github.com/.extraheader "$AUTH"
+            chmod 600 "$CFG"
+            echo "GIT_CONFIG_GLOBAL=${CFG}" >> "${GITHUB_ENV}"
+          fi
+
       - name: "Build firmware artifacts"
         id: build-fw
         uses: ./.github/actions/build-artifacts

--- a/.github/workflows/compact-build.yml
+++ b/.github/workflows/compact-build.yml
@@ -29,8 +29,7 @@ jobs:
     steps:
       - name: "Wipe workspace"
         run: |
-          # Self-hosted runners preserve $HOME across runs; drop any stale
-          # credential file left by earlier jobs on the same runner.
+          # Self-hosted runners persist $HOME across jobs.
           rm -f "${HOME}/.git-credentials"
           find ./ -mount -maxdepth 1 -exec rm -rf {} \;
 

--- a/.github/workflows/compact-build.yml
+++ b/.github/workflows/compact-build.yml
@@ -42,23 +42,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Authenticate git for the job"
-        run: |
-          set -euo pipefail
-          # Reproduce actions/checkout's credential mechanism for every git
-          # operation in this job (build-artifacts' submodule update and fbt's
-          # own recursive init): an Authorization extraheader applied via the
-          # global git config. This escapes GitHub's throttling of
-          # unauthenticated clone traffic from the shared self-hosted runner
-          # egress (HTTP 401/400 in waves). base64 must stay single-line: GNU
-          # base64 wraps at 76 cols, which would embed newlines in the header
-          # and make the server reset the connection.
-          if [[ -n "${GH_TOKEN:-}" ]]; then
-            CFG="${RUNNER_TEMP}/git-credentials.config"
-            AUTH="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
-            git config --file "$CFG" http.https://github.com/.extraheader "$AUTH"
-            chmod 600 "$CFG"
-            echo "GIT_CONFIG_GLOBAL=${CFG}" >> "${GITHUB_ENV}"
-          fi
+        uses: ./.github/actions/authenticate-git
 
       - name: "Build firmware artifacts"
         id: build-fw

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -82,8 +82,12 @@ jobs:
       - name: 'Configure Git and LFS for submodules'
         run: |
           git lfs install --skip-smudge
-          echo "https://x-access-token:${GH_TOKEN}@github.com" > ~/.git-credentials
-          git config credential.helper 'store --file ~/.git-credentials'
+          # Keep credentials in the per-job temp dir (cleaned by the runner
+          # after the job); self-hosted runners would otherwise keep the token
+          # in ~/.git-credentials across runs.
+          rm -f "$HOME/.git-credentials"
+          echo "https://x-access-token:${GH_TOKEN}@github.com" > "${RUNNER_TEMP}/git-credentials"
+          git config credential.helper "store --file ${RUNNER_TEMP}/git-credentials"
           git config lfs.transfer.maxretries 3
 
       - name: 'Update submodules'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -82,9 +82,7 @@ jobs:
       - name: 'Configure Git and LFS for submodules'
         run: |
           git lfs install --skip-smudge
-          # Keep credentials in the per-job temp dir (cleaned by the runner
-          # after the job); self-hosted runners would otherwise keep the token
-          # in ~/.git-credentials across runs.
+          # Self-hosted runners persist $HOME; keep creds in per-job RUNNER_TEMP.
           rm -f "$HOME/.git-credentials"
           echo "https://x-access-token:${GH_TOKEN}@github.com" > "${RUNNER_TEMP}/git-credentials"
           git config credential.helper "store --file ${RUNNER_TEMP}/git-credentials"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,10 +28,7 @@ jobs:
           # Configure Git LFS
           git lfs install --skip-smudge
           
-          # Set up authentication for GitHub repositories at repo level.
-          # Keep credentials in the per-job temp dir (cleaned by the runner
-          # after the job) rather than ~/.git-credentials, which persists in
-          # $HOME across runs on self-hosted runners.
+          # Auth via per-job RUNNER_TEMP creds (self-hosted runners persist $HOME).
           rm -f "$HOME/.git-credentials"
           echo "https://x-access-token:${GH_TOKEN}@github.com" > "${RUNNER_TEMP}/git-credentials"
           git config credential.helper "store --file ${RUNNER_TEMP}/git-credentials"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,9 +28,13 @@ jobs:
           # Configure Git LFS
           git lfs install --skip-smudge
           
-          # Set up authentication for GitHub repositories at repo level
-          echo "https://x-access-token:${GH_TOKEN}@github.com" > ~/.git-credentials
-          git config credential.helper 'store --file ~/.git-credentials'
+          # Set up authentication for GitHub repositories at repo level.
+          # Keep credentials in the per-job temp dir (cleaned by the runner
+          # after the job) rather than ~/.git-credentials, which persists in
+          # $HOME across runs on self-hosted runners.
+          rm -f "$HOME/.git-credentials"
+          echo "https://x-access-token:${GH_TOKEN}@github.com" > "${RUNNER_TEMP}/git-credentials"
+          git config credential.helper "store --file ${RUNNER_TEMP}/git-credentials"
           
           # Configure LFS settings
           git config lfs.transfer.maxretries 3


### PR DESCRIPTION
# What's new

- Fix CI failures on self-hosted runners (GitHub throttles unauthenticated clones from the shared flipp.dev egress in waves).
- New `.github/actions/authenticate-git`: job-wide github.com Authorization extraheader (single-line base64) via `GIT_CONFIG_GLOBAL`, mirroring actions/checkout.
- New `.github/actions/update-submodules`: retrying (3x backoff) submodule bootstrap, shared across build/compact/test workflows.
- Credential hygiene: tokens in per-job `RUNNER_TEMP`, not `~/.git-credentials`; stale-file cleanup in wipe steps.

# Verification

- CI on this PR: build, compact-build, brick-test-build and unit-test-build all pass.
- On-runner probe: the previously failing `fbtng` submodule clone succeeds with the fix.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
