### PR TITLE
Fix Display DELETE Ownership Check for JSON Requests

### DIFF
--- a/applications/services/web_server/http_api/api_display.c
+++ b/applications/services/web_server/http_api/api_display.c
@@ -823,7 +823,7 @@ static void api_display_canvas_clear(struct mg_connection* conn, struct mg_http_
                 if(!all_element_ids_valid) break;
             }
 
-            cJSON* json_app_name = cJSON_GetObjectItem(body, "application_name");
+            json_app_name = cJSON_GetObjectItem(body, "application_name");
             if(json_app_name && !cJSON_IsString(json_app_name)) break;
         }
         char* body_app_name = cJSON_GetStringValue(json_app_name);

--- a/tests/integration/frontend/display/test_api_display_elements.py
+++ b/tests/integration/frontend/display/test_api_display_elements.py
@@ -326,6 +326,36 @@ class TestSelectiveDisplayDeletion:
         with allure.step("Verify status 400 and unchanged canvas"):
             _assert_rejected_without_frame_change(response, before, after)
 
+    @allure.title("DELETE honors application_name from the request body")
+    @pytest.mark.api
+    @pytest.mark.frontend
+    def test_delete_with_wrong_app_name_in_body(
+        self,
+        assets_api: AssetsAPI,
+        streaming_api: StreamingAPI,
+        busy_timer_stopped,
+    ):
+        with allure.step("Draw a stable frame owned by the test application"):
+            before = _draw_and_capture(
+                assets_api,
+                streaming_api,
+                [_solid_rectangle("owned_element", FILL_RED)],
+            )
+            expected = _expected_front_frame([(0, FRONT_DISPLAY_WIDTH, BGR_RED)])
+            assert before == expected, (
+                f"Expected owned frame sha256={_frame_digest(expected)}, "
+                f"got sha256={_frame_digest(before)}"
+            )
+
+        with allure.step("Attempt deletion using another application name in JSON"):
+            response = assets_api.clear_display_raw(
+                {"application_name": _OTHER_APP_NAME}
+            )
+            after = streaming_api.get_screen_bytes(display=0)
+
+        with allure.step("Verify status 400 and unchanged canvas"):
+            _assert_rejected_without_frame_change(response, before, after)
+
     @allure.title("Selective DELETE with a mismatched application_name is rejected")
     @pytest.mark.api
     @pytest.mark.frontend


### PR DESCRIPTION
# What's new

- Fix `DELETE /api/display/draw` so the handler uses `application_name` from the JSON request body.
- Remove the variable redeclaration that left `body_app_name` set to `NULL` and bypassed the canvas ownership check.
- Add an integration test that sends an incorrect `application_name` in the request body. The endpoint must return HTTP 400 and must not change the canvas.

This change overlaps with `api_display_canvas_clear()` changes in #1013. The current #1013 diff does not include this fix.

# Verification

Reproduced on a target 22 device with firmware 1.2.3 and API 27.5.0:

1. Drew a frame owned by `codex_display_delete_repro`.
2. Sent a DELETE request with an incorrect `application_name` in the query. The device returned HTTP 400 and preserved the frame.
3. Sent the same incorrect `application_name` in the JSON body. The device returned HTTP 200 and changed the frame.
4. Cleared the test canvas after the reproduction.

Local checks completed:

- `./fbt format`
- `./fbt TARGET_HW=22`
- `./fbt -s lint TARGET_HW=21`
- `./fbt -s lint TARGET_HW=64`
- Python syntax check for `test_api_display_elements.py`

Built and uploaded commit `7c7f6322` to the same target 22 device with `./fbt flash_usb`. The device reported API 27.7.0 and branch `fix/display-delete-request-parsing` after the reboot.

Repeated the ownership check on the patched firmware:

1. Drew a frame owned by `codex_display_delete_repro`. The device returned HTTP 200.
2. Sent a DELETE request with an incorrect `application_name` in the query. The device returned HTTP 400 and preserved the frame.
3. Sent the same incorrect `application_name` in the JSON body. The device returned HTTP 400 and preserved the frame.
4. Confirmed the frame SHA-256 remained `7629c404c4756a1d8f63bbeccfd0805f4a63e978e567c44d52ad40d1f9294080` throughout both rejected requests.
5. Cleared the test canvas. The device returned HTTP 200.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
