### PR TITLE
[FW-1115] JS Application Settings: Parsing, Storage, UI

### DIFF
--- a/applications/debug/unit_tests/js_app_settings_test/js_app_settings_test.c
+++ b/applications/debug/unit_tests/js_app_settings_test/js_app_settings_test.c
@@ -1,0 +1,598 @@
+#include "../unit_tests.h"
+#include <js_app/js_app_settings.h>
+
+#include <limits.h>
+#include <math.h>
+#include <string.h>
+
+static JsAppSettings* js_app_settings_test_parse(const char* manifest) {
+    return js_app_settings_parse(manifest, strlen(manifest));
+}
+
+MU_TEST(js_app_settings_test_root) {
+    /* valid manifest */
+    {
+        JsAppSettings* settings = js_app_settings_test_parse(
+            "{\"format_version\":1,\"version\":7,\"fields\":{"
+            "\"flag\":{\"label\":\"Flag\",\"type\":\"boolean\",\"default\":true}}}");
+
+        mu_assert_not_null(settings);
+        mu_assert_int_eq(7, settings->version);
+        mu_assert_int_eq(1, settings->nodes_count);
+        mu_assert_string_eq("flag", settings->nodes[0].id);
+
+        js_app_settings_free(settings);
+    }
+
+    /* rejected manifests */
+    static const char* const invalid[] = {
+        "{\"format_version\":1,",
+        "[1,2,3]",
+        "{\"version\":1,\"fields\":{\"flag\":{\"label\":\"F\",\"type\":\"boolean\",\"default\":true}}}",
+        "{\"format_version\":2,\"version\":1,\"fields\":{\"flag\":{\"label\":\"F\",\"type\":\"boolean\",\"default\":true}}}",
+        "{\"format_version\":1,\"fields\":{\"flag\":{\"label\":\"F\",\"type\":\"boolean\",\"default\":true}}}",
+        "{\"format_version\":1,\"version\":1}",
+        "{\"format_version\":1,\"version\":1,\"fields\":[{\"label\":\"F\",\"type\":\"boolean\",\"default\":true}]}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{}}",
+    };
+
+    for(size_t i = 0; i < COUNT_OF(invalid); i++) {
+        mu_assert(js_app_settings_test_parse(invalid[i]) == NULL, invalid[i]);
+    }
+}
+
+MU_TEST(js_app_settings_test_node_id) {
+    /* same id in different groups is allowed */
+    {
+        JsAppSettings* settings = js_app_settings_test_parse(
+            "{\"format_version\":1,\"version\":1,\"fields\":{"
+            "\"grp_a\":{\"label\":\"A\",\"type\":\"group\",\"fields\":{"
+            "\"flag\":{\"label\":\"F\",\"type\":\"boolean\",\"default\":true}}},"
+            "\"grp_b\":{\"label\":\"B\",\"type\":\"group\",\"fields\":{"
+            "\"flag\":{\"label\":\"F\",\"type\":\"boolean\",\"default\":false}}}}}");
+
+        mu_assert_not_null(settings);
+        mu_assert_int_eq(2, settings->nodes_count);
+
+        js_app_settings_free(settings);
+    }
+
+    /* duplicate ids on the same level */
+    {
+        mu_assert_null(js_app_settings_test_parse(
+            "{\"format_version\":1,\"version\":1,\"fields\":{"
+            "\"flag\":{\"label\":\"A\",\"type\":\"boolean\",\"default\":true},"
+            "\"flag\":{\"label\":\"B\",\"type\":\"boolean\",\"default\":false}}}"));
+    }
+
+    /* rejected ids */
+    static const char* const invalid[] = {
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"Flag\":{\"label\":\"F\",\"type\":\"boolean\",\"default\":true}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"1flag\":{\"label\":\"F\",\"type\":\"boolean\",\"default\":true}}}",
+    };
+
+    for(size_t i = 0; i < COUNT_OF(invalid); i++) {
+        mu_assert(js_app_settings_test_parse(invalid[i]) == NULL, invalid[i]);
+    }
+}
+
+MU_TEST(js_app_settings_test_node_common) {
+    /* description is optional and owned by the tree */
+    {
+        JsAppSettings* settings = js_app_settings_test_parse(
+            "{\"format_version\":1,\"version\":1,\"fields\":{"
+            "\"flag\":{\"label\":\"Flag\",\"description\":\"description value\","
+            "\"type\":\"boolean\",\"default\":true},"
+            "\"flag2\":{\"label\":\"Flag2\",\"type\":\"boolean\",\"default\":false}}}");
+
+        mu_assert_not_null(settings);
+        mu_assert_string_eq("description value", settings->nodes[0].description);
+        mu_assert_null(settings->nodes[1].description);
+
+        js_app_settings_free(settings);
+    }
+
+    /* rejected nodes */
+    static const char* const invalid[] = {
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"flag\":{\"type\":\"boolean\",\"default\":true}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"flag\":{\"label\":\"F\",\"type\":\"toggle\",\"default\":true}}}",
+    };
+
+    for(size_t i = 0; i < COUNT_OF(invalid); i++) {
+        mu_assert(js_app_settings_test_parse(invalid[i]) == NULL, invalid[i]);
+    }
+}
+
+MU_TEST(js_app_settings_test_boolean) {
+    /* default is captured */
+    {
+        JsAppSettings* settings = js_app_settings_test_parse(
+            "{\"format_version\":1,\"version\":1,\"fields\":{"
+            "\"flag\":{\"label\":\"Flag\",\"type\":\"boolean\",\"default\":true}}}");
+
+        mu_assert_not_null(settings);
+        mu_assert_int_eq(JsAppSettingsNodeTypeBool, settings->nodes[0].type);
+        mu_check(((JsAppSettingsBoolData*)settings->nodes[0].data)->default_value);
+
+        js_app_settings_free(settings);
+    }
+
+    /* rejected defaults */
+    static const char* const invalid[] = {
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"flag\":{\"label\":\"F\",\"type\":\"boolean\"}}}",
+    };
+
+    for(size_t i = 0; i < COUNT_OF(invalid); i++) {
+        mu_assert(js_app_settings_test_parse(invalid[i]) == NULL, invalid[i]);
+    }
+}
+
+MU_TEST(js_app_settings_test_integer) {
+    /* all keys captured */
+    {
+        JsAppSettings* settings =
+            js_app_settings_test_parse("{\"format_version\":1,\"version\":1,\"fields\":{"
+                                       "\"volume\":{\"label\":\"Volume\",\"type\":\"integer\","
+                                       "\"default\":5,\"min\":0,\"max\":10,\"step\":2}}}");
+
+        mu_assert_not_null(settings);
+        mu_assert_int_eq(JsAppSettingsNodeTypeInt, settings->nodes[0].type);
+
+        JsAppSettingsIntData* data = settings->nodes[0].data;
+        mu_assert_int_eq(5, data->default_value);
+        mu_assert_int_eq(0, data->min_value);
+        mu_assert_int_eq(10, data->max_value);
+        mu_assert_int_eq(2, data->value_step);
+
+        js_app_settings_free(settings);
+    }
+
+    /* optional keys default to an unbounded range and a unit step */
+    {
+        JsAppSettings* settings = js_app_settings_test_parse(
+            "{\"format_version\":1,\"version\":1,\"fields\":{"
+            "\"any\":{\"label\":\"Any\",\"type\":\"integer\",\"default\":42}}}");
+
+        mu_assert_not_null(settings);
+
+        JsAppSettingsIntData* data = settings->nodes[0].data;
+        mu_assert_int_eq(INT_MIN, data->min_value);
+        mu_assert_int_eq(INT_MAX, data->max_value);
+        mu_assert_int_eq(1, data->value_step);
+
+        js_app_settings_free(settings);
+    }
+
+    /* rejected integers */
+    static const char* const invalid[] = {
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"any\":{\"label\":\"A\",\"type\":\"integer\",\"min\":0,\"max\":1}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"any\":{\"label\":\"A\",\"type\":\"integer\",\"default\":5,\"min\":10,\"max\":0}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"any\":{\"label\":\"A\",\"type\":\"integer\",\"default\":5,\"step\":0}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"any\":{\"label\":\"A\",\"type\":\"integer\",\"default\":5,\"min\":0,\"max\":10,\"step\":3}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"any\":{\"label\":\"A\",\"type\":\"integer\",\"default\":11,\"min\":0,\"max\":10}}}",
+    };
+
+    for(size_t i = 0; i < COUNT_OF(invalid); i++) {
+        mu_assert(js_app_settings_test_parse(invalid[i]) == NULL, invalid[i]);
+    }
+}
+
+MU_TEST(js_app_settings_test_string) {
+    /* all keys captured */
+    {
+        JsAppSettings* settings = js_app_settings_test_parse(
+            "{\"format_version\":1,\"version\":1,\"fields\":{"
+            "\"name\":{\"label\":\"Name\",\"type\":\"string\","
+            "\"default\":\"admin\",\"sensitive\":true,\"min_length\":2,\"max_length\":16}}}");
+
+        mu_assert_not_null(settings);
+        mu_assert_int_eq(JsAppSettingsNodeTypeString, settings->nodes[0].type);
+
+        JsAppSettingsStringData* data = settings->nodes[0].data;
+        mu_assert_string_eq("admin", data->default_value);
+        mu_check(data->is_sensitive);
+        mu_assert_int_eq(2, data->min_length);
+        mu_assert_int_eq(16, data->max_length);
+
+        js_app_settings_free(settings);
+    }
+
+    /* optional keys default to insensitive and the standard length window */
+    {
+        JsAppSettings* settings = js_app_settings_test_parse(
+            "{\"format_version\":1,\"version\":1,\"fields\":{"
+            "\"name\":{\"label\":\"Name\",\"type\":\"string\",\"default\":\"x\"}}}");
+
+        mu_assert_not_null(settings);
+
+        JsAppSettingsStringData* data = settings->nodes[0].data;
+        mu_check(!data->is_sensitive);
+        mu_assert_int_eq(0, data->min_length);
+        mu_assert_int_eq(64, data->max_length);
+
+        js_app_settings_free(settings);
+    }
+
+    /* rejected strings */
+    static const char* const invalid[] = {
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"name\":{\"label\":\"N\",\"type\":\"string\",\"default\":7}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"name\":{\"label\":\"N\",\"type\":\"string\",\"default\":\"abc\",\"min_length\":8,\"max_length\":4}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"name\":{\"label\":\"N\",\"type\":\"string\",\"default\":\"ab\",\"min_length\":3}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"name\":{\"label\":\"N\",\"type\":\"string\",\"default\":\"x\",\"max_length\":256}}}",
+    };
+
+    for(size_t i = 0; i < COUNT_OF(invalid); i++) {
+        mu_assert(js_app_settings_test_parse(invalid[i]) == NULL, invalid[i]);
+    }
+}
+
+MU_TEST(js_app_settings_test_enum) {
+    /* options, labels and the default index are captured */
+    {
+        JsAppSettings* settings = js_app_settings_test_parse(
+            "{\"format_version\":1,\"version\":1,\"fields\":{"
+            "\"mode\":{\"label\":\"Mode\",\"type\":\"enum\",\"default\":\"fast\","
+            "\"options\":[{\"value\":\"slow\",\"label\":\"Slow\"},"
+            "{\"value\":\"fast\",\"label\":\"Fast\"},{\"value\":\"turbo\",\"label\":\"Turbo\"}]}}}");
+
+        mu_assert_not_null(settings);
+        mu_assert_int_eq(JsAppSettingsNodeTypeEnum, settings->nodes[0].type);
+
+        JsAppSettingsEnumData* data = settings->nodes[0].data;
+        mu_assert_int_eq(3, data->options_count);
+        mu_assert_int_eq(1, data->default_index);
+        mu_assert_string_eq("slow", data->options[0].value);
+        mu_assert_string_eq("Slow", data->options[0].label);
+        mu_assert_string_eq("turbo", data->options[2].value);
+        mu_assert_string_eq("Turbo", data->options[2].label);
+
+        js_app_settings_free(settings);
+    }
+
+    /* rejected enums */
+    static const char* const invalid[] = {
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"mode\":{\"label\":\"M\",\"type\":\"enum\",\"options\":[{\"value\":\"a\",\"label\":\"A\"}]}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"mode\":{\"label\":\"M\",\"type\":\"enum\",\"default\":\"a\",\"options\":[]}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"mode\":{\"label\":\"M\",\"type\":\"enum\",\"default\":\"a\",\"options\":[{\"value\":\"a\"}]}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"mode\":{\"label\":\"M\",\"type\":\"enum\",\"default\":\"a\",\"options\":[{\"value\":\"a\",\"label\":\"A\"},{\"value\":\"a\",\"label\":\"Again\"}]}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"mode\":{\"label\":\"M\",\"type\":\"enum\",\"default\":\"missing\",\"options\":[{\"value\":\"a\",\"label\":\"A\"}]}}}",
+    };
+
+    for(size_t i = 0; i < COUNT_OF(invalid); i++) {
+        mu_assert(js_app_settings_test_parse(invalid[i]) == NULL, invalid[i]);
+    }
+}
+
+MU_TEST(js_app_settings_test_color_codec) {
+    /* both forms parse */
+    {
+        Color value = {0};
+
+        mu_check(js_app_settings_color_parse("#FF8000", &value));
+        mu_assert_int_eq(0xFF, value.r);
+        mu_assert_int_eq(0x80, value.g);
+        mu_assert_int_eq(0x00, value.b);
+        mu_assert_int_eq(0xFF, value.a);
+
+        mu_check(js_app_settings_color_parse("#FF800080", &value));
+        mu_assert_int_eq(0xFF, value.r);
+        mu_assert_int_eq(0x80, value.g);
+        mu_assert_int_eq(0x00, value.b);
+        mu_assert_int_eq(0x80, value.a);
+
+        mu_check(js_app_settings_color_parse("#0B55AA", &value));
+        mu_assert_int_eq(0x0B, value.r);
+    }
+
+    /* rejected colors */
+    static const char* const invalid[] = {
+        "FF8000",
+        "#GG8000",
+        "#0xF800",
+        "#1234567",
+    };
+
+    for(size_t i = 0; i < COUNT_OF(invalid); i++) {
+        Color value = {0};
+        mu_assert(!js_app_settings_color_parse(invalid[i], &value), invalid[i]);
+    }
+
+    /* formatting round-trips */
+    {
+        FuriString* string = furi_string_alloc();
+        Color value = {0};
+
+        value = (Color)COLOR_MAKE_RGBA(0x12, 0x34, 0x56, 0x78);
+        js_app_settings_color_format(&value, string);
+        mu_assert_string_eq("#12345678", furi_string_get_cstr(string));
+
+        value = (Color)COLOR_MAKE_RGB(0xAB, 0xCD, 0xEF);
+        js_app_settings_color_format(&value, string);
+        mu_assert_string_eq("#ABCDEF", furi_string_get_cstr(string));
+        mu_check(js_app_settings_color_parse(furi_string_get_cstr(string), &value));
+        mu_assert_int_eq(0xAB, value.r);
+
+        furi_string_free(string);
+    }
+}
+
+MU_TEST(js_app_settings_test_time_codec) {
+    /* both forms parse, has_seconds follows the form */
+    {
+        JsAppSettingsTimeValue value = {0};
+
+        mu_check(js_app_settings_time_parse("09:30", &value));
+        mu_assert_int_eq(9, value.time.hour);
+        mu_assert_int_eq(30, value.time.minute);
+        mu_assert_int_eq(0, value.time.second);
+        mu_check(!value.has_seconds);
+
+        mu_check(js_app_settings_time_parse("23:59:05", &value));
+        mu_assert_int_eq(23, value.time.hour);
+        mu_assert_int_eq(59, value.time.minute);
+        mu_assert_int_eq(5, value.time.second);
+        mu_check(value.has_seconds);
+    }
+
+    /* rejected times */
+    static const char* const invalid[] = {
+        "9:30",
+        "1:2:3",
+        "09:30x",
+        "24:00",
+    };
+
+    for(size_t i = 0; i < COUNT_OF(invalid); i++) {
+        JsAppSettingsTimeValue value = {0};
+        mu_assert(!js_app_settings_time_parse(invalid[i], &value), invalid[i]);
+    }
+
+    /* formatting round-trips */
+    {
+        FuriString* string = furi_string_alloc();
+        JsAppSettingsTimeValue value = {0};
+
+        mu_check(js_app_settings_time_parse("09:30", &value));
+        js_app_settings_time_format(&value, string);
+        mu_assert_string_eq("09:30", furi_string_get_cstr(string));
+
+        mu_check(js_app_settings_time_parse("23:59:05", &value));
+        js_app_settings_time_format(&value, string);
+        mu_assert_string_eq("23:59:05", furi_string_get_cstr(string));
+
+        furi_string_free(string);
+    }
+}
+
+MU_TEST(js_app_settings_test_complex_field_defaults) {
+    /* color and time defaults go through their codecs */
+    static const char* const invalid[] = {
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"accent\":{\"label\":\"A\",\"type\":\"color\",\"default\":\"red\"}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"alarm\":{\"label\":\"A\",\"type\":\"time\",\"default\":\"9:30\"}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"alarm\":{\"label\":\"A\",\"type\":\"time\"}}}",
+    };
+
+    for(size_t i = 0; i < COUNT_OF(invalid); i++) {
+        mu_assert(js_app_settings_test_parse(invalid[i]) == NULL, invalid[i]);
+    }
+}
+
+MU_TEST(js_app_settings_test_geolocation) {
+    /* auto mode has no coordinates */
+    {
+        JsAppSettings* settings =
+            js_app_settings_test_parse("{\"format_version\":1,\"version\":1,\"fields\":{"
+                                       "\"home\":{\"label\":\"Home\",\"type\":\"geolocation\","
+                                       "\"default\":{\"mode\":\"auto\",\"name\":\"Home\"}}}}");
+
+        mu_assert_not_null(settings);
+        mu_assert_int_eq(JsAppSettingsNodeTypeGeo, settings->nodes[0].type);
+
+        JsAppSettingsGeoValue* value =
+            &((JsAppSettingsGeoData*)settings->nodes[0].data)->default_value;
+        mu_assert_int_eq(JsAppSettingsGeoModeAuto, value->mode);
+        mu_assert_string_eq("Home", value->name);
+        mu_check(isnan(value->latitude));
+        mu_check(isnan(value->longitude));
+
+        js_app_settings_free(settings);
+    }
+
+    /* fixed mode carries the coordinates */
+    {
+        JsAppSettings* settings = js_app_settings_test_parse(
+            "{\"format_version\":1,\"version\":1,\"fields\":{"
+            "\"pin\":{\"label\":\"Pin\",\"type\":\"geolocation\","
+            "\"default\":{\"mode\":\"fixed\",\"name\":\"Pin\",\"lat\":55.75,\"lon\":37.62}}}}");
+
+        mu_assert_not_null(settings);
+
+        JsAppSettingsGeoValue* value =
+            &((JsAppSettingsGeoData*)settings->nodes[0].data)->default_value;
+        mu_assert_int_eq(JsAppSettingsGeoModeFixed, value->mode);
+        mu_assert_string_eq("Pin", value->name);
+        mu_assert_double_eq(55.75, value->latitude);
+        mu_assert_double_eq(37.62f, value->longitude);
+
+        js_app_settings_free(settings);
+    }
+
+    /* rejected geolocations */
+    static const char* const invalid[] = {
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"pin\":{\"label\":\"P\",\"type\":\"geolocation\",\"default\":{\"mode\":\"fixed\",\"name\":\"Pin\"}}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"pin\":{\"label\":\"P\",\"type\":\"geolocation\",\"default\":{\"mode\":\"auto\",\"name\":\"Home\",\"lat\":1.0}}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"pin\":{\"label\":\"P\",\"type\":\"geolocation\",\"default\":{\"mode\":\"fixed\",\"name\":\"Pin\",\"lat\":91.0,\"lon\":0.0}}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"pin\":{\"label\":\"P\",\"type\":\"geolocation\",\"default\":{\"mode\":\"auto\",\"name\":\"\"}}}}",
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"pin\":{\"label\":\"P\",\"type\":\"geolocation\",\"default\":{\"mode\":\"manual\",\"name\":\"Pin\"}}}}",
+    };
+
+    for(size_t i = 0; i < COUNT_OF(invalid); i++) {
+        mu_assert(js_app_settings_test_parse(invalid[i]) == NULL, invalid[i]);
+    }
+}
+
+MU_TEST(js_app_settings_test_groups) {
+    /* nested groups keep their structure */
+    {
+        JsAppSettings* settings = js_app_settings_test_parse(
+            "{\"format_version\":1,\"version\":1,\"fields\":{"
+            "\"network\":{\"label\":\"Network\",\"type\":\"group\",\"fields\":{"
+            "\"proxy\":{\"label\":\"Proxy\",\"type\":\"group\",\"fields\":{"
+            "\"port\":{\"label\":\"Port\",\"type\":\"integer\",\"default\":8080,"
+            "\"min\":1,\"max\":65535}}}}}}}");
+
+        mu_assert_not_null(settings);
+        mu_assert_int_eq(JsAppSettingsNodeTypeGroup, settings->nodes[0].type);
+
+        JsAppSettingsGroupData* data = settings->nodes[0].data;
+        mu_assert_int_eq(1, data->nodes_count);
+        mu_assert_string_eq("proxy", data->nodes[0].id);
+
+        JsAppSettingsGroupData* inner = data->nodes[0].data;
+        mu_assert_int_eq(1, inner->nodes_count);
+        mu_assert_string_eq("port", inner->nodes[0].id);
+        mu_assert_int_eq(8080, ((JsAppSettingsIntData*)inner->nodes[0].data)->default_value);
+
+        js_app_settings_free(settings);
+    }
+
+    /* rejected groups */
+    static const char* const invalid[] = {
+        "{\"format_version\":1,\"version\":1,\"fields\":{\"grp\":{\"label\":\"G\",\"type\":\"group\",\"fields\":{}}}}",
+    };
+
+    for(size_t i = 0; i < COUNT_OF(invalid); i++) {
+        mu_assert(js_app_settings_test_parse(invalid[i]) == NULL, invalid[i]);
+    }
+}
+
+MU_TEST(js_app_settings_test_validate_value) {
+    JsAppSettings* settings = js_app_settings_test_parse(
+        "{\"format_version\":1,\"version\":1,\"fields\":{"
+        "\"flag\":{\"label\":\"F\",\"type\":\"boolean\",\"default\":true},"
+        "\"num\":{\"label\":\"N\",\"type\":\"integer\",\"default\":5,\"min\":0,\"max\":10},"
+        "\"name\":{\"label\":\"N\",\"type\":\"string\",\"default\":\"abc\",\"min_length\":2},"
+        "\"mode\":{\"label\":\"M\",\"type\":\"enum\",\"default\":\"a\","
+        "\"options\":[{\"value\":\"a\",\"label\":\"A\"},{\"value\":\"b\",\"label\":\"B\"}]},"
+        "\"alarm\":{\"label\":\"A\",\"type\":\"time\",\"default\":\"09:30\"},"
+        "\"pin\":{\"label\":\"P\",\"type\":\"geolocation\","
+        "\"default\":{\"mode\":\"auto\",\"name\":\"Pin\"}}}}");
+
+    mu_assert_not_null(settings);
+
+    /* boolean accepts anything */
+    {
+        bool value = true;
+        mu_check(js_app_settings_validate_value(&settings->nodes[0], &value));
+        value = false;
+        mu_check(js_app_settings_validate_value(&settings->nodes[0], &value));
+    }
+
+    /* integer is bounded by min and max */
+    {
+        int in_bounds = 7;
+        int out_of_bounds = 10 + 1;
+        mu_check(js_app_settings_validate_value(&settings->nodes[1], &in_bounds));
+        mu_check(!js_app_settings_validate_value(&settings->nodes[1], &out_of_bounds));
+    }
+
+    /* string is bounded by its length window */
+    {
+        mu_check(js_app_settings_validate_value(&settings->nodes[2], "ab"));
+        mu_check(!js_app_settings_validate_value(&settings->nodes[2], "a"));
+    }
+
+    /* enum is an index within the options */
+    {
+        int in_bounds = 1;
+        int out_of_bounds = 2;
+        mu_check(js_app_settings_validate_value(&settings->nodes[3], &in_bounds));
+        mu_check(!js_app_settings_validate_value(&settings->nodes[3], &out_of_bounds));
+    }
+
+    /* time must be a real time of day */
+    {
+        JsAppSettingsTimeValue value = {0};
+        mu_check(js_app_settings_time_parse("10:15", &value));
+        mu_check(js_app_settings_validate_value(&settings->nodes[4], &value));
+
+        value.time.hour = 24;
+        mu_check(!js_app_settings_validate_value(&settings->nodes[4], &value));
+    }
+
+    /* geolocation must be well-formed */
+    {
+        JsAppSettingsGeoValue valid_fixed = {
+            .mode = JsAppSettingsGeoModeFixed,
+            .name = "Pin",
+            .latitude = 1.0f,
+            .longitude = 2.0f,
+        };
+        mu_check(js_app_settings_validate_value(&settings->nodes[5], &valid_fixed));
+
+        JsAppSettingsGeoValue no_coordinates = valid_fixed;
+        no_coordinates.latitude = NAN;
+        no_coordinates.longitude = NAN;
+        mu_check(!js_app_settings_validate_value(&settings->nodes[5], &no_coordinates));
+
+        JsAppSettingsGeoValue out_of_range = valid_fixed;
+        out_of_range.latitude = 91.0f;
+        mu_check(!js_app_settings_validate_value(&settings->nodes[5], &out_of_range));
+
+        JsAppSettingsGeoValue garbage_mode = valid_fixed;
+        garbage_mode.mode = (JsAppSettingsGeoMode)42;
+        garbage_mode.latitude = NAN;
+        garbage_mode.longitude = NAN;
+        mu_check(!js_app_settings_validate_value(&settings->nodes[5], &garbage_mode));
+    }
+
+    js_app_settings_free(settings);
+}
+
+MU_TEST(js_app_settings_test_integration) {
+    JsAppSettings* settings = js_app_settings_test_parse(
+        "{\"format_version\":1,\"version\":3,\"fields\":{"
+        "\"flag\":{\"label\":\"Flag\",\"description\":\"description value\","
+        "\"type\":\"boolean\",\"default\":false},"
+        "\"volume\":{\"label\":\"Volume\",\"type\":\"integer\","
+        "\"default\":7,\"min\":0,\"max\":11,\"step\":1},"
+        "\"name\":{\"label\":\"Name\",\"type\":\"string\",\"default\":\"guest\"},"
+        "\"mode\":{\"label\":\"Mode\",\"type\":\"enum\",\"default\":\"b\","
+        "\"options\":[{\"value\":\"a\",\"label\":\"A\"},{\"value\":\"b\",\"label\":\"B\"}]},"
+        "\"accent\":{\"label\":\"Accent\",\"type\":\"color\",\"default\":\"#00FF00\"},"
+        "\"alarm\":{\"label\":\"Alarm\",\"type\":\"time\",\"default\":\"07:45:30\"},"
+        "\"pin\":{\"label\":\"Pin\",\"type\":\"geolocation\","
+        "\"default\":{\"mode\":\"fixed\",\"name\":\"Spot\",\"lat\":10.5,\"lon\":-20.25}},"
+        "\"extra\":{\"label\":\"Extra\",\"type\":\"group\",\"fields\":{"
+        "\"nested\":{\"label\":\"Nested\",\"type\":\"boolean\",\"default\":true}}}}}");
+
+    mu_assert_not_null(settings);
+    mu_assert_int_eq(3, settings->version);
+    mu_assert_int_eq(8, settings->nodes_count);
+    mu_assert_string_eq("description value", settings->nodes[0].description);
+    mu_assert_int_eq(JsAppSettingsNodeTypeGroup, settings->nodes[7].type);
+
+    js_app_settings_free(settings);
+}
+
+MU_TEST_SUITE(js_app_settings_test_suite) {
+    MU_RUN_TEST(js_app_settings_test_root);
+    MU_RUN_TEST(js_app_settings_test_node_id);
+    MU_RUN_TEST(js_app_settings_test_node_common);
+    MU_RUN_TEST(js_app_settings_test_boolean);
+    MU_RUN_TEST(js_app_settings_test_integer);
+    MU_RUN_TEST(js_app_settings_test_string);
+    MU_RUN_TEST(js_app_settings_test_enum);
+    MU_RUN_TEST(js_app_settings_test_color_codec);
+    MU_RUN_TEST(js_app_settings_test_time_codec);
+    MU_RUN_TEST(js_app_settings_test_complex_field_defaults);
+    MU_RUN_TEST(js_app_settings_test_geolocation);
+    MU_RUN_TEST(js_app_settings_test_groups);
+    MU_RUN_TEST(js_app_settings_test_validate_value);
+    MU_RUN_TEST(js_app_settings_test_integration);
+}
+
+int run_minunit_js_app_settings_test(void) {
+    MU_RUN_SUITE(js_app_settings_test_suite);
+    return MU_EXIT_CODE;
+}

--- a/applications/debug/unit_tests/js_app_settings_test/js_app_settings_test.c
+++ b/applications/debug/unit_tests/js_app_settings_test/js_app_settings_test.c
@@ -340,6 +340,9 @@ MU_TEST(js_app_settings_test_time_codec) {
         "1:2:3",
         "09:30x",
         "24:00",
+        " 9:30",
+        "+9:30",
+        "09:+1",
     };
 
     for(size_t i = 0; i < COUNT_OF(invalid); i++) {

--- a/applications/debug/unit_tests/js_app_settings_test/js_app_settings_test.h
+++ b/applications/debug/unit_tests/js_app_settings_test/js_app_settings_test.h
@@ -1,0 +1,7 @@
+#ifdef TEST_FUNCTION_DECLS
+extern int run_minunit_js_app_settings_test(void);
+#endif
+
+#ifdef TEST_FUNCTION_REFS
+run_minunit_js_app_settings_test,
+#endif

--- a/applications/debug/unit_tests/test_list.h
+++ b/applications/debug/unit_tests/test_list.h
@@ -31,6 +31,7 @@ extern "C" {
 #include "argparse_test/argparse_test.h"
 #include "js_test/js_test.h"
 #include "xpm_test/xpm_test.h"
+#include "js_app_settings_test/js_app_settings_test.h"
 #undef TEST_FUNCTION_DECLS
 
 typedef int (*TestCallback)(void);
@@ -56,6 +57,7 @@ static TestCallback unit_test_callbacks[] = {
 #include "argparse_test/argparse_test.h"
 #include "js_test/js_test.h"
 #include "xpm_test/xpm_test.h"
+#include "js_app_settings_test/js_app_settings_test.h"
 #undef TEST_FUNCTION_REFS
 };
 

--- a/applications/services/gui/modules/var_item_list.c
+++ b/applications/services/gui/modules/var_item_list.c
@@ -15,10 +15,12 @@
 #define SYM_EDIT_ARROW_LEFT  "‹" // U+2039
 #define SYM_EDIT_ARROW_RIGHT "›" // U+203A
 
-#define CHECK_RANGE_AND_STEP(min, max, step)                                               \
-    do {                                                                                   \
-        furi_check(max >= min, "Range error: min > max");                                  \
-        furi_check((max - min) % step == 0, "Step error: range must be evenly divisible"); \
+#define CHECK_RANGE_AND_STEP(min, max, step)                                                 \
+    do {                                                                                     \
+        furi_check(max >= min, "Range error: min > max");                                    \
+        furi_check(step != 0, "Step error: step must be non-zero");                          \
+        furi_check(                                                                          \
+            ((int64_t)max - min) % step == 0, "Step error: range must be evenly divisible"); \
     } while(0)
 
 typedef enum {
@@ -41,7 +43,7 @@ typedef struct {
     lv_obj_t* arrow_right;
     int32_t min;
     int32_t max;
-    int32_t step;
+    uint32_t step;
     int32_t value;
     uint32_t flags;
     char* suffix;
@@ -166,7 +168,7 @@ static void var_item_editor_set_range_and_step(
     VarItemEditor* instance,
     int32_t min,
     int32_t max,
-    int32_t step) {
+    uint32_t step) {
     instance->min = min;
     instance->max = max;
     instance->step = step;
@@ -298,7 +300,8 @@ static void var_item_editor_update(VarItemEditor* instance) {
 
 static void var_item_editor_increment(VarItemEditor* instance) {
     if(instance->value < instance->max) {
-        instance->value += instance->step - (instance->value % instance->step);
+        const int64_t step_index = ((int64_t)instance->value - instance->min) / instance->step + 1;
+        instance->value = instance->min + step_index * instance->step;
 
         if(instance->callback) {
             instance->callback(var_item_editor_get_item(instance), instance->context);
@@ -310,7 +313,8 @@ static void var_item_editor_increment(VarItemEditor* instance) {
 
 static void var_item_editor_decrement(VarItemEditor* instance) {
     if(instance->value > instance->min) {
-        instance->value -= instance->step + (instance->value % instance->step);
+        const int64_t step_index = ((int64_t)instance->value - instance->min - 1) / instance->step;
+        instance->value = instance->min + step_index * instance->step;
 
         if(instance->callback) {
             instance->callback(var_item_editor_get_item(instance), instance->context);
@@ -445,7 +449,7 @@ VarItem* var_item_list_add_timebox(
     const char* label,
     int32_t min_mn,
     int32_t max_mn,
-    int32_t step_mn,
+    uint32_t step_mn,
     VarItemChangeCallback callback,
     void* context) {
     furi_check(instance);
@@ -467,7 +471,7 @@ VarItem* var_item_list_add_spinbox(
     const char* suffix,
     int32_t min,
     int32_t max,
-    int32_t step,
+    uint32_t step,
     VarItemChangeCallback callback,
     void* context) {
     furi_check(instance);
@@ -554,6 +558,9 @@ void var_item_set_value(VarItem* item, int32_t value) {
 
     VarItemEditor* editor = item->editor;
     value = CLAMP(value, editor->max, editor->min);
+
+    const int64_t offset = (int64_t)value - editor->min;
+    value = editor->min + offset / editor->step * editor->step;
 
     if(editor->value != value) {
         editor->value = value;

--- a/applications/services/gui/modules/var_item_list.h
+++ b/applications/services/gui/modules/var_item_list.h
@@ -74,7 +74,7 @@ VarItem* var_item_list_add_timebox(
     const char* label,
     int32_t min_mn,
     int32_t max_mn,
-    int32_t step_mn,
+    uint32_t step_mn,
     VarItemChangeCallback callback,
     void* context);
 
@@ -97,7 +97,7 @@ VarItem* var_item_list_add_spinbox(
     const char* suffix,
     int32_t min,
     int32_t max,
-    int32_t step,
+    uint32_t step,
     VarItemChangeCallback callback,
     void* context);
 

--- a/applications/system/js_app_launcher/application.fam
+++ b/applications/system/js_app_launcher/application.fam
@@ -3,7 +3,7 @@ App(
     name="JsAppLauncher",
     apptype=FlipperAppType.SYSTEM,
     entry_point="js_app_launcher_app",
-    requires=["gui", "apps_menu"],
-    stack_size=2 * 1024,
+    requires=["gui", "apps_menu", "storage"],
+    stack_size=4 * 1024,
     targets=["f20", "f21", "f22"],
 )

--- a/applications/system/js_app_launcher/js_app_launcher.c
+++ b/applications/system/js_app_launcher/js_app_launcher.c
@@ -119,6 +119,7 @@ static JsAppLauncher* js_app_launcher_alloc(const char* app_id) {
         instance);
 
     if(instance->js_app) {
+        instance->settings_storage = js_app_settings_storage_alloc(app_id);
         scene_manager_next_scene(instance->scene_manager, JsAppLauncherSceneIdStart);
     } else {
         instance->error = JsAppLauncherErrorLoadFailed;
@@ -139,6 +140,10 @@ static void js_app_launcher_free(JsAppLauncher* instance) {
     furi_message_queue_free(instance->event_queue);
 
     furi_event_loop_free(instance->event_loop);
+
+    if(instance->settings_storage) {
+        js_app_settings_storage_free(instance->settings_storage);
+    }
 
     if(instance->js_app) {
         js_app_free(instance->js_app);

--- a/applications/system/js_app_launcher/js_app_launcher.c
+++ b/applications/system/js_app_launcher/js_app_launcher.c
@@ -7,8 +7,9 @@
 
 #include "scenes/js_app_launcher_scenes.h"
 
-#define INPUT_QUEUE_SIZE (8)
-#define EVENT_QUEUE_SIZE (8)
+#define INPUT_QUEUE_SIZE       (8)
+#define EVENT_QUEUE_SIZE       (8)
+#define EVENT_QUEUE_TIMEOUT_MS (3000)
 
 #define NAV_BAR_HEIGHT (14)
 
@@ -174,6 +175,11 @@ int32_t js_app_launcher_app(void* arg) {
 
 void js_app_launcher_send_custom_event(JsAppLauncher* instance, uint32_t event) {
     furi_assert(instance);
-    furi_check(
-        furi_message_queue_put(instance->event_queue, &event, FuriWaitForever) == FuriStatusOk);
+
+    FuriStatus queue_status =
+        furi_message_queue_put(instance->event_queue, &event, EVENT_QUEUE_TIMEOUT_MS);
+
+    if(queue_status != FuriStatusOk) {
+        FURI_LOG_E(TAG, "Failed to put an item into event queue.");
+    }
 }

--- a/applications/system/js_app_launcher/js_app_launcher_error.c
+++ b/applications/system/js_app_launcher/js_app_launcher_error.c
@@ -18,6 +18,30 @@ static const JsAppLauncherErrorDesc js_app_launcher_error_descs[JsAppLauncherErr
                     .back = "Try to restart or reinstall it",
                 },
         },
+    [JsAppLauncherErrorSettingsMissing] =
+        {
+            .primary =
+                {
+                    .front = "This app has\nno settings.",
+                    .back = "No settings",
+                },
+            .auxiliary =
+                {
+                    .back = "Add settings file to the app",
+                },
+        },
+    [JsAppLauncherErrorSettingsLoadFailed] =
+        {
+            .primary =
+                {
+                    .front = "Settings loading\nfailed.",
+                    .back = "Settings loading failed",
+                },
+            .auxiliary =
+                {
+                    .back = "Check the app settings file",
+                },
+        },
     [JsAppLauncherErrorSyntaxError] =
         {
             .primary =

--- a/applications/system/js_app_launcher/js_app_launcher_i.h
+++ b/applications/system/js_app_launcher/js_app_launcher_i.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "js_app_settings_storage.h"
+
 #include <furi.h>
 
 #include <gui/gui.h>
@@ -44,6 +46,7 @@ typedef struct {
     NavBar* nav_bar;
 
     JsApp* js_app;
+    JsAppSettingsStorage* settings_storage;
     JsAppLauncherError error;
 } JsAppLauncher;
 

--- a/applications/system/js_app_launcher/js_app_launcher_i.h
+++ b/applications/system/js_app_launcher/js_app_launcher_i.h
@@ -18,6 +18,8 @@
 typedef enum {
     JsAppLauncherErrorNone,
     JsAppLauncherErrorLoadFailed,
+    JsAppLauncherErrorSettingsMissing,
+    JsAppLauncherErrorSettingsLoadFailed,
     JsAppLauncherErrorSyntaxError,
     JsAppLauncherErrorProgramCrashed,
     JsAppLauncherErrorMax,
@@ -53,6 +55,7 @@ typedef struct {
 typedef enum {
     JsAppLauncherCustomEventIndexMax = 0x7F,
     JsAppLauncherCustomEventScriptFinished,
+    JsAppLauncherCustomEventSettingsChanged,
 } JsAppLauncherCustomEvent;
 
 void js_app_launcher_send_custom_event(JsAppLauncher* instance, uint32_t event);

--- a/applications/system/js_app_launcher/js_app_settings_storage.c
+++ b/applications/system/js_app_launcher/js_app_settings_storage.c
@@ -1,0 +1,548 @@
+#include "js_app_settings_storage.h"
+
+#include <storage/storage.h>
+
+#define TAG "JsAppSettingsStorage"
+
+#define JS_APP_SETTINGS_STORAGE_SCHEMA_PATH_FORMAT \
+    (EXT_PATH("user_assets") "/%s/appmeta/settings.json")
+#define JS_APP_SETTINGS_STORAGE_DATA_PATH_FORMAT \
+    (EXT_PATH("apps_data/jsrunner") "/%s.settings.json")
+
+#define JS_APP_SETTINGS_STORAGE_ALIGN(value) \
+    (((value) + (_Alignof(max_align_t) - 1)) & ~(_Alignof(max_align_t) - 1))
+
+struct JsAppSettingsStorage {
+    JsAppSettings* settings;
+    SettingProvider* provider;
+
+    SettingProviderSetting root;
+    SettingProviderStructInterface root_interface;
+    SettingProviderSetting* root_fields;
+
+    void* values;
+};
+
+typedef struct {
+    const JsAppSettingsNode* node;
+    void* value;
+} JsAppSettingsStorageSettingContext;
+
+typedef struct {
+    void* (*build)(const JsAppSettingsNode* node);
+    SettingProviderSettingType setting_type;
+} JsAppSettingsStorageInterfaceBuilder;
+
+static const JsAppSettingsStorageInterfaceBuilder js_app_settings_storage_interface_builders[];
+static const size_t js_app_settings_storage_sizes[];
+
+/* Layout */
+
+static size_t
+    js_app_settings_storage_compute_size(const JsAppSettingsNode* nodes, size_t nodes_count);
+
+static size_t js_app_settings_storage_compute_node_size(const JsAppSettingsNode* node) {
+    size_t node_size;
+
+    if(node->type == JsAppSettingsNodeTypeString) {
+        const JsAppSettingsStringData* node_data = node->data;
+        node_size = node_data->max_length + 1;
+    } else if(node->type == JsAppSettingsNodeTypeGroup) {
+        const JsAppSettingsGroupData* node_data = node->data;
+        node_size = js_app_settings_storage_compute_size(node_data->nodes, node_data->nodes_count);
+    } else {
+        node_size = js_app_settings_storage_sizes[node->type];
+    }
+
+    return node_size;
+}
+
+static size_t
+    js_app_settings_storage_compute_size(const JsAppSettingsNode* nodes, size_t nodes_count) {
+    size_t nodes_total_size = 0;
+
+    for(; nodes_count > 0; nodes_count--, nodes++) {
+        nodes_total_size +=
+            JS_APP_SETTINGS_STORAGE_ALIGN(js_app_settings_storage_compute_node_size(nodes));
+    }
+
+    return nodes_total_size;
+}
+
+/* Validation */
+
+static bool
+    js_app_settings_storage_is_valid_int(const SettingProviderSetting* setting, int value) {
+    const JsAppSettingsStorageSettingContext* context = setting->context;
+
+    return js_app_settings_validate_value(context->node, &value);
+}
+
+static bool js_app_settings_storage_is_valid_string(
+    const SettingProviderSetting* setting,
+    const char* value) {
+    const JsAppSettingsStorageSettingContext* context = setting->context;
+
+    return js_app_settings_validate_value(context->node, value);
+}
+
+/* Serialization */
+
+static bool js_app_settings_storage_color_serialize(
+    const SettingProviderSetting* setting,
+    const void* value,
+    FuriString* string) {
+    UNUSED(setting);
+
+    js_app_settings_color_format(value, string);
+
+    return true;
+}
+
+static bool js_app_settings_storage_color_deserialize(
+    const SettingProviderSetting* setting,
+    const char* string,
+    void* value) {
+    UNUSED(setting);
+
+    return js_app_settings_color_parse(string, value);
+}
+
+static bool js_app_settings_storage_time_serialize(
+    const SettingProviderSetting* setting,
+    const void* value,
+    FuriString* string) {
+    UNUSED(setting);
+
+    js_app_settings_time_format(value, string);
+
+    return true;
+}
+
+static bool js_app_settings_storage_time_deserialize(
+    const SettingProviderSetting* setting,
+    const char* string,
+    void* value) {
+    UNUSED(setting);
+
+    return js_app_settings_time_parse(string, value);
+}
+
+static bool js_app_settings_storage_geo_serialize(
+    const SettingProviderSetting* setting,
+    const void* value,
+    cJSON* json) {
+    UNUSED(setting);
+
+    const JsAppSettingsGeoValue* geo = value;
+    bool is_valid = geo->mode < JsAppSettingsGeoModesCount;
+
+    if(is_valid) {
+        cJSON_AddStringToObject(json, "mode", js_app_settings_geo_mode_format(geo->mode));
+        cJSON_AddStringToObject(json, "name", geo->name);
+
+        if(geo->mode == JsAppSettingsGeoModeFixed) {
+            cJSON_AddNumberToObject(json, "lat", geo->latitude);
+            cJSON_AddNumberToObject(json, "lon", geo->longitude);
+        }
+    }
+
+    return is_valid;
+}
+
+static bool js_app_settings_storage_geo_deserialize(
+    const SettingProviderSetting* setting,
+    const cJSON* json,
+    void* value) {
+    const JsAppSettingsStorageSettingContext* context = setting->context;
+    JsAppSettingsGeoValue* geo = value;
+
+    bool is_successful = false;
+
+    do {
+        cJSON* mode_json = cJSON_GetObjectItem(json, "mode");
+        if(!cJSON_IsString(mode_json)) {
+            break;
+        }
+
+        if(!js_app_settings_geo_mode_parse(mode_json->valuestring, &geo->mode)) {
+            break;
+        }
+
+        cJSON* name_json = cJSON_GetObjectItem(json, "name");
+        if(!cJSON_IsString(name_json)) {
+            break;
+        }
+
+        const char* name = name_json->valuestring;
+        if(strlen(name) > sizeof(geo->name) - 1) {
+            break;
+        }
+
+        strcpy(geo->name, name);
+
+        cJSON* lat_json = cJSON_GetObjectItem(json, "lat");
+        geo->latitude = cJSON_GetNumberValue(lat_json);
+
+        cJSON* lon_json = cJSON_GetObjectItem(json, "lon");
+        geo->longitude = cJSON_GetNumberValue(lon_json);
+
+        is_successful = js_app_settings_validate_value(context->node, geo);
+    } while(false);
+
+    return is_successful;
+}
+
+/* Construction */
+
+static void* js_app_settings_storage_build_interface_bool(const JsAppSettingsNode* node) {
+    const JsAppSettingsBoolData* node_data = node->data;
+
+    SettingProviderBoolInterface* interface = malloc(sizeof(*interface));
+    interface->default_value_callback = NULL;
+    interface->default_value = node_data->default_value;
+
+    return interface;
+}
+
+static void* js_app_settings_storage_build_interface_int(const JsAppSettingsNode* node) {
+    const JsAppSettingsIntData* node_data = node->data;
+
+    SettingProviderIntInterface* interface = malloc(sizeof(*interface));
+    interface->is_valid_callback = js_app_settings_storage_is_valid_int;
+    interface->default_value = node_data->default_value;
+
+    return interface;
+}
+
+static void* js_app_settings_storage_build_interface_string(const JsAppSettingsNode* node) {
+    const JsAppSettingsStringData* node_data = node->data;
+
+    SettingProviderStringInterface* interface = malloc(sizeof(*interface));
+    interface->is_valid_callback = js_app_settings_storage_is_valid_string;
+    interface->default_value = node_data->default_value;
+    interface->max_size = node_data->max_length + 1;
+
+    return interface;
+}
+
+static void* js_app_settings_storage_build_interface_enum(const JsAppSettingsNode* node) {
+    const JsAppSettingsEnumData* node_data = node->data;
+
+    const char** enum_string_map = calloc(node_data->options_count, sizeof(const char*));
+    for(size_t i = 0; i < node_data->options_count; i++) {
+        enum_string_map[i] = node_data->options[i].value;
+    }
+
+    SettingProviderEnumInterface* interface = malloc(sizeof(*interface));
+    interface->string_map = enum_string_map;
+    interface->string_map_length = node_data->options_count;
+    interface->type_size = sizeof(node_data->default_index);
+    interface->default_value = &node_data->default_index;
+
+    return interface;
+}
+
+static void* js_app_settings_storage_build_interface_color(const JsAppSettingsNode* node) {
+    const JsAppSettingsColorData* node_data = node->data;
+
+    SettingProviderCustomInterface* interface = malloc(sizeof(*interface));
+    interface->is_valid_callback = NULL;
+    interface->serialize_callback = js_app_settings_storage_color_serialize;
+    interface->deserialize_callback = js_app_settings_storage_color_deserialize;
+    interface->default_value_callback = NULL;
+    interface->default_value = &node_data->default_value;
+    interface->default_value_size = sizeof(node_data->default_value);
+
+    return interface;
+}
+
+static void* js_app_settings_storage_build_interface_time(const JsAppSettingsNode* node) {
+    const JsAppSettingsTimeData* node_data = node->data;
+
+    SettingProviderCustomInterface* interface = malloc(sizeof(*interface));
+    interface->is_valid_callback = NULL;
+    interface->serialize_callback = js_app_settings_storage_time_serialize;
+    interface->deserialize_callback = js_app_settings_storage_time_deserialize;
+    interface->default_value_callback = NULL;
+    interface->default_value = &node_data->default_value;
+    interface->default_value_size = sizeof(node_data->default_value);
+
+    return interface;
+}
+
+static void* js_app_settings_storage_build_interface_geo(const JsAppSettingsNode* node) {
+    const JsAppSettingsGeoData* node_data = node->data;
+
+    SettingProviderRawInterface* interface = malloc(sizeof(*interface));
+    interface->is_valid_callback = NULL;
+    interface->serialize_callback = js_app_settings_storage_geo_serialize;
+    interface->deserialize_callback = js_app_settings_storage_geo_deserialize;
+    interface->default_value = &node_data->default_value;
+    interface->default_value_size = sizeof(node_data->default_value);
+
+    return interface;
+}
+
+static void js_app_settings_storage_build_group(
+    JsAppSettingsStorage* instance,
+    const JsAppSettingsNode* nodes,
+    size_t nodes_count,
+    SettingProviderSetting* settings,
+    size_t initial_offset) {
+    for(size_t cursor = initial_offset; nodes_count > 0; nodes++, settings++, nodes_count--) {
+        JsAppSettingsStorageSettingContext* context = malloc(sizeof(*context));
+        context->node = nodes;
+        context->value = instance->values + cursor;
+
+        const JsAppSettingsStorageInterfaceBuilder* builder =
+            &js_app_settings_storage_interface_builders[nodes->type];
+
+        settings->name = nodes->id;
+        settings->context = context;
+        settings->field_offset = cursor - initial_offset;
+        settings->type = builder->setting_type;
+
+        if(nodes->type == JsAppSettingsNodeTypeGroup) {
+            const JsAppSettingsGroupData* node_data = nodes->data;
+            size_t inner_nodes_count = node_data->nodes_count;
+
+            SettingProviderStructInterface* interface = malloc(sizeof(*interface));
+            SettingProviderSetting* inner_settings =
+                calloc(inner_nodes_count, sizeof(*inner_settings));
+
+            interface->is_valid_callback = NULL;
+            interface->inner_settings = inner_settings;
+            interface->inner_settings_count = inner_nodes_count;
+
+            js_app_settings_storage_build_group(
+                instance, node_data->nodes, inner_nodes_count, inner_settings, cursor);
+
+            settings->interface = interface;
+        } else {
+            settings->interface = builder->build(nodes);
+        }
+
+        cursor += JS_APP_SETTINGS_STORAGE_ALIGN(js_app_settings_storage_compute_node_size(nodes));
+    }
+}
+
+/* Destruction */
+
+static void
+    js_app_settings_storage_free_group(const SettingProviderSetting* settings, size_t count) {
+    for(; count > 0; settings++, count--) {
+        SettingProviderSettingType type = settings->type;
+
+        if(type == SettingProviderSettingTypeStruct) {
+            const SettingProviderStructInterface* interface = settings->interface;
+            js_app_settings_storage_free_group(
+                interface->inner_settings, interface->inner_settings_count);
+            free((void*)interface->inner_settings);
+        } else if(type == SettingProviderSettingTypeEnum) {
+            const SettingProviderEnumInterface* interface = settings->interface;
+            free((void*)interface->string_map);
+        }
+
+        free((void*)settings->context);
+        free((void*)settings->interface);
+    }
+}
+
+/* Schema Parsing */
+
+static JsAppSettings* js_app_settings_storage_parse_schema(const char* app_id) {
+    FuriString* schema_path_builder =
+        furi_string_alloc_printf(JS_APP_SETTINGS_STORAGE_SCHEMA_PATH_FORMAT, app_id);
+
+    JsAppSettings* settings = NULL;
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    File* file = storage_file_alloc(storage);
+
+    do {
+        const char* schema_path = furi_string_get_cstr(schema_path_builder);
+        if(!storage_file_open(file, schema_path, FSAM_READ, FSOM_OPEN_EXISTING)) {
+            if(storage_file_get_error(file) != FSE_NOT_EXIST) {
+                FURI_LOG_E(TAG, "Failed to open schema file %s", schema_path);
+            }
+
+            break;
+        }
+
+        uint64_t file_size = storage_file_size(file);
+        if(file_size == 0) {
+            FURI_LOG_E(TAG, "Schema file %s is empty", schema_path);
+            break;
+        }
+
+        char* file_buffer = malloc(file_size);
+        if(storage_file_read(file, file_buffer, file_size) == file_size) {
+            settings = js_app_settings_parse(file_buffer, file_size);
+        } else {
+            FURI_LOG_E(TAG, "Failed to read schema file %s", schema_path);
+        }
+
+        free(file_buffer);
+    } while(false);
+
+    storage_file_free(file);
+    furi_record_close(RECORD_STORAGE);
+    furi_string_free(schema_path_builder);
+
+    return settings;
+}
+
+/* Public API Implementation */
+
+JsAppSettingsStorage* js_app_settings_storage_alloc(const char* app_id) {
+    furi_check(app_id);
+
+    JsAppSettingsStorage* instance = NULL;
+
+    do {
+        JsAppSettings* settings = js_app_settings_storage_parse_schema(app_id);
+        if(!settings) {
+            break;
+        }
+
+        JsAppSettingsNode* nodes = settings->nodes;
+        size_t nodes_count = settings->nodes_count;
+
+        instance = malloc(sizeof(*instance));
+        instance->settings = settings;
+        instance->values = malloc(js_app_settings_storage_compute_size(nodes, nodes_count));
+
+        instance->root_fields = calloc(nodes_count, sizeof(*instance->root_fields));
+
+        instance->root_interface = (SettingProviderStructInterface){
+            .inner_settings = instance->root_fields,
+            .inner_settings_count = nodes_count,
+        };
+
+        instance->root = (SettingProviderSetting){
+            .interface = &instance->root_interface,
+            .type = SettingProviderSettingTypeStruct,
+        };
+
+        js_app_settings_storage_build_group(
+            instance, nodes, nodes_count, instance->root_fields, 0);
+
+        FuriString* data_path =
+            furi_string_alloc_printf(JS_APP_SETTINGS_STORAGE_DATA_PATH_FORMAT, app_id);
+        instance->provider =
+            setting_provider_alloc(furi_string_get_cstr(data_path), settings->version, NULL, 0);
+        furi_string_free(data_path);
+    } while(false);
+
+    return instance;
+}
+
+void js_app_settings_storage_free(JsAppSettingsStorage* instance) {
+    furi_check(instance);
+
+    setting_provider_free(instance->provider);
+
+    js_app_settings_storage_free_group(instance->root_fields, instance->settings->nodes_count);
+
+    free(instance->root_fields);
+    free(instance->values);
+
+    js_app_settings_free(instance->settings);
+    free(instance);
+}
+
+bool js_app_settings_storage_load(JsAppSettingsStorage* instance) {
+    furi_check(instance);
+
+    return setting_provider_load(instance->provider, &instance->root, instance->values);
+}
+
+bool js_app_settings_storage_save(JsAppSettingsStorage* instance) {
+    furi_check(instance);
+
+    return setting_provider_save(instance->provider, &instance->root, instance->values);
+}
+
+const SettingProviderSetting* js_app_settings_storage_get_root(JsAppSettingsStorage* instance) {
+    furi_check(instance);
+
+    return &instance->root;
+}
+
+const JsAppSettingsNode* js_app_settings_storage_get_node(const SettingProviderSetting* instance) {
+    furi_check(instance);
+    furi_check(instance->context);
+
+    const JsAppSettingsStorageSettingContext* context = instance->context;
+
+    return context->node;
+}
+
+void* js_app_settings_storage_get_value(const SettingProviderSetting* instance) {
+    furi_check(instance);
+    furi_check(instance->context);
+
+    const JsAppSettingsStorageSettingContext* context = instance->context;
+
+    return context->value;
+}
+
+/* Tables */
+
+static const JsAppSettingsStorageInterfaceBuilder js_app_settings_storage_interface_builders[] = {
+    [JsAppSettingsNodeTypeBool] =
+        {
+            .build = js_app_settings_storage_build_interface_bool,
+            .setting_type = SettingProviderSettingTypeBool,
+        },
+    [JsAppSettingsNodeTypeInt] =
+        {
+            .build = js_app_settings_storage_build_interface_int,
+            .setting_type = SettingProviderSettingTypeInt,
+        },
+    [JsAppSettingsNodeTypeString] =
+        {
+            .build = js_app_settings_storage_build_interface_string,
+            .setting_type = SettingProviderSettingTypeString,
+        },
+    [JsAppSettingsNodeTypeEnum] =
+        {
+            .build = js_app_settings_storage_build_interface_enum,
+            .setting_type = SettingProviderSettingTypeEnum,
+        },
+    [JsAppSettingsNodeTypeColor] =
+        {
+            .build = js_app_settings_storage_build_interface_color,
+            .setting_type = SettingProviderSettingTypeCustom,
+        },
+    [JsAppSettingsNodeTypeTime] =
+        {
+            .build = js_app_settings_storage_build_interface_time,
+            .setting_type = SettingProviderSettingTypeCustom,
+        },
+    [JsAppSettingsNodeTypeGeo] =
+        {
+            .build = js_app_settings_storage_build_interface_geo,
+            .setting_type = SettingProviderSettingTypeRaw,
+        },
+    [JsAppSettingsNodeTypeGroup] =
+        {
+            .build = NULL,
+            .setting_type = SettingProviderSettingTypeStruct,
+        },
+};
+
+static_assert(COUNT_OF(js_app_settings_storage_interface_builders) == JsAppSettingsNodeTypesCount);
+
+static const size_t js_app_settings_storage_sizes[] = {
+    [JsAppSettingsNodeTypeBool] = sizeof(bool),
+    [JsAppSettingsNodeTypeInt] = sizeof(int),
+    [JsAppSettingsNodeTypeString] = 0,
+    [JsAppSettingsNodeTypeEnum] = sizeof(int),
+    [JsAppSettingsNodeTypeColor] = sizeof(Color),
+    [JsAppSettingsNodeTypeTime] = sizeof(JsAppSettingsTimeValue),
+    [JsAppSettingsNodeTypeGeo] = sizeof(JsAppSettingsGeoValue),
+    [JsAppSettingsNodeTypeGroup] = 0,
+};
+
+static_assert(COUNT_OF(js_app_settings_storage_sizes) == JsAppSettingsNodeTypesCount);

--- a/applications/system/js_app_launcher/js_app_settings_storage.c
+++ b/applications/system/js_app_launcher/js_app_settings_storage.c
@@ -86,6 +86,14 @@ static bool js_app_settings_storage_is_valid_string(
     return js_app_settings_validate_value(context->node, value);
 }
 
+static bool js_app_settings_storage_is_valid_value(
+    const SettingProviderSetting* setting,
+    const void* value) {
+    const JsAppSettingsStorageSettingContext* context = setting->context;
+
+    return js_app_settings_validate_value(context->node, value);
+}
+
 /* Serialization */
 
 static bool js_app_settings_storage_color_serialize(
@@ -112,11 +120,15 @@ static bool js_app_settings_storage_time_serialize(
     const SettingProviderSetting* setting,
     const void* value,
     FuriString* string) {
-    UNUSED(setting);
+    const JsAppSettingsStorageSettingContext* context = setting->context;
 
-    js_app_settings_time_format(value, string);
+    bool is_valid = false;
+    if(js_app_settings_validate_value(context->node, value)) {
+        js_app_settings_time_format(value, string);
+        is_valid = true;
+    }
 
-    return true;
+    return is_valid;
 }
 
 static bool js_app_settings_storage_time_deserialize(
@@ -132,12 +144,11 @@ static bool js_app_settings_storage_geo_serialize(
     const SettingProviderSetting* setting,
     const void* value,
     cJSON* json) {
-    UNUSED(setting);
-
+    const JsAppSettingsStorageSettingContext* context = setting->context;
     const JsAppSettingsGeoValue* geo = value;
-    bool is_valid = geo->mode < JsAppSettingsGeoModesCount;
 
-    if(is_valid) {
+    bool is_valid = false;
+    if(js_app_settings_validate_value(context->node, geo)) {
         cJSON_AddStringToObject(json, "mode", js_app_settings_geo_mode_format(geo->mode));
         cJSON_AddStringToObject(json, "name", geo->name);
 
@@ -145,6 +156,8 @@ static bool js_app_settings_storage_geo_serialize(
             cJSON_AddNumberToObject(json, "lat", geo->latitude);
             cJSON_AddNumberToObject(json, "lon", geo->longitude);
         }
+
+        is_valid = true;
     }
 
     return is_valid;
@@ -261,7 +274,7 @@ static void* js_app_settings_storage_build_interface_time(const JsAppSettingsNod
     const JsAppSettingsTimeData* node_data = node->data;
 
     SettingProviderCustomInterface* interface = malloc(sizeof(*interface));
-    interface->is_valid_callback = NULL;
+    interface->is_valid_callback = js_app_settings_storage_is_valid_value;
     interface->serialize_callback = js_app_settings_storage_time_serialize;
     interface->deserialize_callback = js_app_settings_storage_time_deserialize;
     interface->default_value_callback = NULL;
@@ -275,7 +288,7 @@ static void* js_app_settings_storage_build_interface_geo(const JsAppSettingsNode
     const JsAppSettingsGeoData* node_data = node->data;
 
     SettingProviderRawInterface* interface = malloc(sizeof(*interface));
-    interface->is_valid_callback = NULL;
+    interface->is_valid_callback = js_app_settings_storage_is_valid_value;
     interface->serialize_callback = js_app_settings_storage_geo_serialize;
     interface->deserialize_callback = js_app_settings_storage_geo_deserialize;
     interface->default_value = &node_data->default_value;

--- a/applications/system/js_app_launcher/js_app_settings_storage.h
+++ b/applications/system/js_app_launcher/js_app_settings_storage.h
@@ -1,0 +1,90 @@
+/**
+ * @file js_app_settings_storage.h
+ * @brief Settings storage bridge for JavaScript applications.
+ *
+ * Composes a parsed settings schema into a setting provider descriptor tree
+ * with a single POD value block, backed by an application data file.
+ */
+
+#pragma once
+
+#include <js_app/js_app_settings.h>
+#include <setting_provider.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct JsAppSettingsStorage JsAppSettingsStorage;
+
+/**
+ * @brief Build a settings storage for an application.
+ *
+ * Parses the application's settings schema, composes the provider descriptor
+ * tree and allocates the value block. Does not load any values; call
+ * js_app_settings_storage_load() before reading any.
+ *
+ * @param[in] app_id Application identifier.
+ * @return Allocated storage, or NULL when the application has no settings
+ *         schema; failures are logged.
+ */
+JsAppSettingsStorage* js_app_settings_storage_alloc(const char* app_id);
+
+/**
+ * @brief Release a settings storage.
+ *
+ * Releases the storage with the schema tree, the descriptor tree and the
+ * value block.
+ *
+ * @param[in] instance Storage returned by js_app_settings_storage_alloc().
+ */
+void js_app_settings_storage_free(JsAppSettingsStorage* instance);
+
+/**
+ * @brief Load values from the application's data file.
+ *
+ * Missing and invalid fields fall back to the schema defaults; an absent or
+ * unparsable file still loads every default.
+ *
+ * @param[in] instance Storage.
+ * @return true when the values are usable, false only on storage errors.
+ */
+bool js_app_settings_storage_load(JsAppSettingsStorage* instance);
+
+/**
+ * @brief Write every value to the application's data file.
+ *
+ * The file is rebuilt as a whole; a single invalid field discards the save.
+ *
+ * @param[in] instance Storage.
+ * @return true on success, false on a write or validation failure.
+ */
+bool js_app_settings_storage_save(JsAppSettingsStorage* instance);
+
+/**
+ * @brief Get the root setting of the descriptor tree.
+ *
+ * @param[in] instance Storage.
+ * @return Anonymous struct setting covering the whole value block.
+ */
+const SettingProviderSetting* js_app_settings_storage_get_root(JsAppSettingsStorage* instance);
+
+/**
+ * @brief Get the schema node a setting was built from.
+ *
+ * @param[in] instance Setting from the descriptor tree, not the root.
+ * @return Node that produced the setting.
+ */
+const JsAppSettingsNode* js_app_settings_storage_get_node(const SettingProviderSetting* instance);
+
+/**
+ * @brief Get the value behind a setting.
+ *
+ * @param[in] instance Setting from the descriptor tree, not the root.
+ * @return Pointer into the storage's value block, valid until free.
+ */
+void* js_app_settings_storage_get_value(const SettingProviderSetting* instance);
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications/system/js_app_launcher/scenes/js_app_launcher_scene_setup.c
+++ b/applications/system/js_app_launcher/scenes/js_app_launcher_scene_setup.c
@@ -1,12 +1,241 @@
 #include "../js_app_launcher_i.h"
 #include "js_app_launcher_scenes.h"
 
-#include <gui/modules/label.h>
+#include <gui/modules/var_item_list.h>
 
 typedef struct {
-    Label* front_label;
-    Label* back_label;
+    JsAppLauncher* instance;
+    const SettingProviderSetting* setting;
+    const JsAppSettingsNode* node;
+} JsAppLauncherSceneSetupItemContext;
+
+typedef struct {
+    VarItemList* front_list;
+    VarItemList* back_list;
+    JsAppLauncherSceneSetupItemContext* contexts;
+    FuriMutex* settings_mutex;
 } JsAppLauncherSceneSetup;
+
+typedef struct {
+    VarItem* (*build)(
+        VarItemList* list,
+        JsAppLauncherSceneSetupItemContext* context,
+        VarItemChangeCallback callback);
+    void (*store)(void* value, int32_t item_value);
+} JsAppLauncherSceneSetupItemEntry;
+
+static const JsAppLauncherSceneSetupItemEntry js_app_launcher_scene_setup_items[];
+
+static VarItem* js_app_launcher_scene_setup_build_bool(
+    VarItemList* list,
+    JsAppLauncherSceneSetupItemContext* context,
+    VarItemChangeCallback callback) {
+    const JsAppSettingsNode* node = context->node;
+    const bool* value = js_app_settings_storage_get_value(context->setting);
+
+    VarItem* item = var_item_list_add_switch(list, node->label, callback, context);
+    var_item_set_value(item, *value);
+
+    return item;
+}
+
+static VarItem* js_app_launcher_scene_setup_build_integer(
+    VarItemList* list,
+    JsAppLauncherSceneSetupItemContext* context,
+    VarItemChangeCallback callback) {
+    const JsAppSettingsNode* node = context->node;
+    const JsAppSettingsIntData* node_data = node->data;
+    const int* value = js_app_settings_storage_get_value(context->setting);
+
+    VarItem* item = var_item_list_add_spinbox(
+        list,
+        node->label,
+        NULL,
+        node_data->min_value,
+        node_data->max_value,
+        node_data->value_step,
+        callback,
+        context);
+    var_item_set_value(item, *value);
+
+    return item;
+}
+
+static VarItem* js_app_launcher_scene_setup_build_string(
+    VarItemList* list,
+    JsAppLauncherSceneSetupItemContext* context,
+    VarItemChangeCallback callback) {
+    const JsAppSettingsNode* node = context->node;
+    const JsAppSettingsStringData* node_data = node->data;
+    const char* value =
+        node_data->is_sensitive ? "***" : js_app_settings_storage_get_value(context->setting);
+
+    return var_item_list_add_selector(
+        list, node->label, NULL, (const char*[]){value}, 1, callback, context);
+}
+
+static VarItem* js_app_launcher_scene_setup_build_enum(
+    VarItemList* list,
+    JsAppLauncherSceneSetupItemContext* context,
+    VarItemChangeCallback callback) {
+    const JsAppSettingsNode* node = context->node;
+    const JsAppSettingsEnumData* node_data = node->data;
+
+    const char** labels = calloc(node_data->options_count, sizeof(*labels));
+    for(size_t i = 0; i < node_data->options_count; i++) {
+        labels[i] = node_data->options[i].label;
+    }
+
+    VarItem* item = var_item_list_add_selector(
+        list, node->label, NULL, labels, node_data->options_count, callback, context);
+
+    free(labels);
+
+    const int* index_value = js_app_settings_storage_get_value(context->setting);
+    var_item_set_value(item, *index_value);
+
+    return item;
+}
+
+static VarItem* js_app_launcher_scene_setup_build_color(
+    VarItemList* list,
+    JsAppLauncherSceneSetupItemContext* context,
+    VarItemChangeCallback callback) {
+    const JsAppSettingsNode* node = context->node;
+    FuriString* string = furi_string_alloc();
+
+    js_app_settings_color_format(js_app_settings_storage_get_value(context->setting), string);
+    VarItem* item = var_item_list_add_selector(
+        list,
+        node->label,
+        NULL,
+        (const char*[]){furi_string_get_cstr(string)},
+        1,
+        callback,
+        context);
+
+    furi_string_free(string);
+
+    return item;
+}
+
+static VarItem* js_app_launcher_scene_setup_build_time(
+    VarItemList* list,
+    JsAppLauncherSceneSetupItemContext* context,
+    VarItemChangeCallback callback) {
+    const JsAppSettingsNode* node = context->node;
+    FuriString* string = furi_string_alloc();
+
+    js_app_settings_time_format(js_app_settings_storage_get_value(context->setting), string);
+    VarItem* item = var_item_list_add_selector(
+        list,
+        node->label,
+        NULL,
+        (const char*[]){furi_string_get_cstr(string)},
+        1,
+        callback,
+        context);
+
+    furi_string_free(string);
+
+    return item;
+}
+
+static VarItem* js_app_launcher_scene_setup_build_geo(
+    VarItemList* list,
+    JsAppLauncherSceneSetupItemContext* context,
+    VarItemChangeCallback callback) {
+    const JsAppSettingsNode* node = context->node;
+
+    const JsAppSettingsGeoValue* geo = js_app_settings_storage_get_value(context->setting);
+    const char* value = (*geo->name != '\0') ? geo->name :
+                                               js_app_settings_geo_mode_format(geo->mode);
+
+    return var_item_list_add_selector(
+        list, node->label, NULL, (const char*[]){value}, 1, callback, context);
+}
+
+static void js_app_launcher_scene_setup_store_bool(void* value, int32_t item_value) {
+    *(bool*)value = item_value;
+}
+
+static void js_app_launcher_scene_setup_store_integer(void* value, int32_t item_value) {
+    *(int*)value = item_value;
+}
+
+static void js_app_launcher_scene_setup_store_enum(void* value, int32_t item_value) {
+    *(int*)value = item_value;
+}
+
+static size_t js_app_launcher_scene_setup_count_items(
+    const SettingProviderSetting* settings,
+    size_t settings_count) {
+    size_t items_count = 0;
+
+    for(size_t i = 0; i < settings_count; i++) {
+        const SettingProviderSetting* setting = &settings[i];
+
+        if(setting->type == SettingProviderSettingTypeStruct) {
+            const SettingProviderStructInterface* interface = setting->interface;
+            items_count += js_app_launcher_scene_setup_count_items(
+                interface->inner_settings, interface->inner_settings_count);
+        } else {
+            items_count++;
+        }
+    }
+
+    return items_count;
+}
+
+static void js_app_launcher_scene_setup_add_items(
+    JsAppLauncher* instance,
+    VarItemList* list,
+    const SettingProviderSetting* settings,
+    size_t settings_count,
+    JsAppLauncherSceneSetupItemContext** contexts,
+    VarItemChangeCallback callback) {
+    for(size_t i = 0; i < settings_count; i++) {
+        const SettingProviderSetting* setting = &settings[i];
+
+        if(setting->type == SettingProviderSettingTypeStruct) {
+            const SettingProviderStructInterface* interface = setting->interface;
+            js_app_launcher_scene_setup_add_items(
+                instance,
+                list,
+                interface->inner_settings,
+                interface->inner_settings_count,
+                contexts,
+                callback);
+        } else {
+            const JsAppSettingsNode* node = js_app_settings_storage_get_node(setting);
+            const JsAppLauncherSceneSetupItemEntry* entry =
+                &js_app_launcher_scene_setup_items[node->type];
+
+            JsAppLauncherSceneSetupItemContext* item_context = (*contexts)++;
+            item_context->instance = instance;
+            item_context->setting = setting;
+            item_context->node = node;
+
+            entry->build(list, item_context, entry->store ? callback : NULL);
+        }
+    }
+}
+
+static void js_app_launcher_scene_setup_value_changed(VarItem* item, void* context) {
+    const JsAppLauncherSceneSetupItemContext* item_context = context;
+
+    JsAppLauncher* instance = item_context->instance;
+    JsAppLauncherSceneSetup* data =
+        scene_manager_get_scene_data(instance->scene_manager, JsAppLauncherSceneIdSetup);
+
+    furi_mutex_acquire(data->settings_mutex, FuriWaitForever);
+    js_app_launcher_scene_setup_items[item_context->node->type].store(
+        js_app_settings_storage_get_value(item_context->setting), var_item_get_value(item));
+    furi_mutex_release(data->settings_mutex);
+
+    uint32_t event = JsAppLauncherCustomEventSettingsChanged;
+    furi_message_queue_put(instance->event_queue, &event, 0);
+}
 
 static void js_app_launcher_scene_setup_on_enter(void* context) {
     furi_assert(context);
@@ -15,17 +244,59 @@ static void js_app_launcher_scene_setup_on_enter(void* context) {
     JsAppLauncherSceneSetup* data =
         scene_manager_get_scene_data(instance->scene_manager, JsAppLauncherSceneIdSetup);
 
-    with_gui(instance->gui, {
-        nav_bar_push_location(instance->nav_bar, "SETUP");
+    data->front_list = NULL;
+    data->back_list = NULL;
+    data->contexts = NULL;
+    data->settings_mutex = furi_mutex_alloc(FuriMutexTypeNormal);
 
-        data->front_label = label_alloc(instance->front_window);
-        label_set_text(data->front_label, "Not implemented");
-        widget_set_align(label_get_base(data->front_label), AlignCenter);
+    do {
+        if(!instance->settings_storage) {
+            instance->error = JsAppLauncherErrorSettingsMissing;
+            scene_manager_replace_current_scene(
+                instance->scene_manager, JsAppLauncherSceneIdError);
+            break;
+        };
 
-        data->back_label = label_alloc(instance->back_window);
-        label_set_text(data->back_label, "Not implemented");
-        widget_set_align(label_get_base(data->back_label), AlignCenter);
-    });
+        if(!js_app_settings_storage_load(instance->settings_storage)) {
+            instance->error = JsAppLauncherErrorSettingsLoadFailed;
+            scene_manager_replace_current_scene(
+                instance->scene_manager, JsAppLauncherSceneIdError);
+            break;
+        };
+
+        with_gui(instance->gui, {
+            const SettingProviderSetting* root =
+                js_app_settings_storage_get_root(instance->settings_storage);
+            const SettingProviderStructInterface* interface = root->interface;
+
+            data->front_list = var_item_list_alloc(instance->front_window);
+            data->back_list = var_item_list_alloc(instance->back_window);
+
+            data->contexts = calloc(
+                js_app_launcher_scene_setup_count_items(
+                    interface->inner_settings, interface->inner_settings_count),
+                sizeof(*data->contexts));
+
+            js_app_launcher_scene_setup_add_items(
+                instance,
+                data->front_list,
+                interface->inner_settings,
+                interface->inner_settings_count,
+                &(JsAppLauncherSceneSetupItemContext*){data->contexts},
+                js_app_launcher_scene_setup_value_changed);
+
+            js_app_launcher_scene_setup_add_items(
+                instance,
+                data->back_list,
+                interface->inner_settings,
+                interface->inner_settings_count,
+                &(JsAppLauncherSceneSetupItemContext*){data->contexts},
+                NULL);
+
+            widget_set_scrollbar_enabled(var_item_list_get_base(data->front_list), true);
+            widget_set_scrollbar_enabled(var_item_list_get_base(data->back_list), true);
+        });
+    } while(false);
 }
 
 static void js_app_launcher_scene_setup_on_exit(void* context) {
@@ -38,9 +309,18 @@ static void js_app_launcher_scene_setup_on_exit(void* context) {
     with_gui(instance->gui, {
         nav_bar_pop_location(instance->nav_bar);
 
-        label_free(data->front_label);
-        label_free(data->back_label);
+        if(data->front_list) {
+            var_item_list_free(data->front_list);
+        }
+
+        if(data->back_list) {
+            var_item_list_free(data->back_list);
+        }
     });
+
+    free(data->contexts);
+
+    furi_mutex_free(data->settings_mutex);
 }
 
 static bool js_app_launcher_scene_setup_on_event(const SceneManagerEvent* event, void* context) {
@@ -50,7 +330,19 @@ static bool js_app_launcher_scene_setup_on_event(const SceneManagerEvent* event,
     bool consumed = false;
 
     JsAppLauncher* instance = context;
-    UNUSED(instance);
+
+    if(event->type == SceneManagerEventTypeCustom) {
+        if(event->event == JsAppLauncherCustomEventSettingsChanged) {
+            JsAppLauncherSceneSetup* data =
+                scene_manager_get_scene_data(instance->scene_manager, JsAppLauncherSceneIdSetup);
+
+            furi_mutex_acquire(data->settings_mutex, FuriWaitForever);
+            js_app_settings_storage_save(instance->settings_storage);
+            furi_mutex_release(data->settings_mutex);
+
+            consumed = true;
+        }
+    }
 
     return consumed;
 }
@@ -61,3 +353,48 @@ const Scene js_app_launcher_scene_setup = {
     .exit_callback = js_app_launcher_scene_setup_on_exit,
     .event_callback = js_app_launcher_scene_setup_on_event,
 };
+
+static const JsAppLauncherSceneSetupItemEntry js_app_launcher_scene_setup_items[] = {
+    [JsAppSettingsNodeTypeBool] =
+        {
+            .build = js_app_launcher_scene_setup_build_bool,
+            .store = js_app_launcher_scene_setup_store_bool,
+        },
+    [JsAppSettingsNodeTypeInt] =
+        {
+            .build = js_app_launcher_scene_setup_build_integer,
+            .store = js_app_launcher_scene_setup_store_integer,
+        },
+    [JsAppSettingsNodeTypeString] =
+        {
+            .build = js_app_launcher_scene_setup_build_string,
+            .store = NULL,
+        },
+    [JsAppSettingsNodeTypeEnum] =
+        {
+            .build = js_app_launcher_scene_setup_build_enum,
+            .store = js_app_launcher_scene_setup_store_enum,
+        },
+    [JsAppSettingsNodeTypeColor] =
+        {
+            .build = js_app_launcher_scene_setup_build_color,
+            .store = NULL,
+        },
+    [JsAppSettingsNodeTypeTime] =
+        {
+            .build = js_app_launcher_scene_setup_build_time,
+            .store = NULL,
+        },
+    [JsAppSettingsNodeTypeGeo] =
+        {
+            .build = js_app_launcher_scene_setup_build_geo,
+            .store = NULL,
+        },
+    [JsAppSettingsNodeTypeGroup] =
+        {
+            .build = NULL,
+            .store = NULL,
+        },
+};
+
+static_assert(COUNT_OF(js_app_launcher_scene_setup_items) == JsAppSettingsNodeTypesCount);

--- a/applications/system/js_app_launcher/scenes/js_app_launcher_scene_setup.c
+++ b/applications/system/js_app_launcher/scenes/js_app_launcher_scene_setup.c
@@ -233,8 +233,7 @@ static void js_app_launcher_scene_setup_value_changed(VarItem* item, void* conte
         js_app_settings_storage_get_value(item_context->setting), var_item_get_value(item));
     furi_mutex_release(data->settings_mutex);
 
-    uint32_t event = JsAppLauncherCustomEventSettingsChanged;
-    furi_message_queue_put(instance->event_queue, &event, 0);
+    js_app_launcher_send_custom_event(instance, JsAppLauncherCustomEventSettingsChanged);
 }
 
 static void js_app_launcher_scene_setup_on_enter(void* context) {

--- a/applications/system/js_app_launcher/scenes/js_app_launcher_scene_start.c
+++ b/applications/system/js_app_launcher/scenes/js_app_launcher_scene_start.c
@@ -80,6 +80,7 @@ static bool js_app_launcher_scene_start_on_event(const SceneManagerEvent* event,
         if(event->event == JsAppLauncherSceneStartMenuIdxStart) {
             scene_manager_next_scene(instance->scene_manager, JsAppLauncherSceneIdRun);
         } else if(event->event == JsAppLauncherSceneStartMenuIdxSetup) {
+            with_gui(instance->gui, { nav_bar_push_location(instance->nav_bar, "SETUP"); });
             scene_manager_next_scene(instance->scene_manager, JsAppLauncherSceneIdSetup);
         }
 

--- a/lib/js_app/SConscript
+++ b/lib/js_app/SConscript
@@ -10,7 +10,11 @@ env.Append(
     SDK_HEADERS=[
         File("js_app.h"),
         File("js_app_manifest.h"),
+        File("js_app_settings.h"),
         File("js_app_registry.h"),
+        File("setting_types/js_app_settings_color.h"),
+        File("setting_types/js_app_settings_geo.h"),
+        File("setting_types/js_app_settings_time.h"),
     ],
 )
 
@@ -20,7 +24,11 @@ libenv.ApplyLibFlags()
 sources = [
     "js_app.c",
     "js_app_manifest.c",
+    "js_app_settings.c",
     "js_app_registry.c",
+    "setting_types/js_app_settings_color.c",
+    "setting_types/js_app_settings_geo.c",
+    "setting_types/js_app_settings_time.c",
 ]
 
 lib = libenv.StaticLibrary("${FW_LIB_NAME}", sources)

--- a/lib/js_app/js_app_settings.c
+++ b/lib/js_app/js_app_settings.c
@@ -1,0 +1,990 @@
+#include "js_app_settings.h"
+
+#include <cjson/cJSON.h>
+
+#define TAG "JsAppSettings"
+
+#define JS_APP_SETTINGS_FORMAT_VERSION (1)
+
+#define JS_APP_SETTINGS_MAX_DEPTH (4u)
+
+#define JS_APP_SETTINGS_INT_DEFAULT_MIN  INT_MIN
+#define JS_APP_SETTINGS_INT_DEFAULT_MAX  INT_MAX
+#define JS_APP_SETTINGS_INT_DEFAULT_STEP (1)
+
+#define JS_APP_SETTINGS_STRING_ABSOLUTE_MAX_LENGTH (255u)
+#define JS_APP_SETTINGS_STRING_DEFAULT_MIN_LENGTH  (0u)
+#define JS_APP_SETTINGS_STRING_DEFAULT_MAX_LENGTH  (64u)
+
+#define JS_APP_SETTINGS_ENUM_MAX_OPTIONS (32u)
+
+typedef struct JsAppSettingsCursor JsAppSettingsCursor;
+
+struct JsAppSettingsCursor {
+    const JsAppSettingsCursor* parent;
+    const char* id;
+    cJSON* json;
+};
+
+typedef struct {
+    const char* key;
+    bool (*parse)(const JsAppSettingsCursor* cursor, JsAppSettingsNode* node);
+    bool (*is_valid)(const JsAppSettingsNode* node, const void* value);
+    void (*free)(JsAppSettingsNode* node);
+} JsAppSettingsNodeTypeEntry;
+
+typedef enum {
+    JsAppSettingsJsonTypeBool,
+    JsAppSettingsJsonTypeNumber,
+    JsAppSettingsJsonTypeString,
+    JsAppSettingsJsonTypeArray,
+    JsAppSettingsJsonTypeObject,
+    JsAppSettingsJsonTypeNull,
+
+    JsAppSettingsJsonTypesCount,
+} JsAppSettingsJsonType;
+
+typedef struct {
+    const char* name;
+    cJSON_bool (*is_type)(const cJSON* item);
+} JsAppSettingsJsonTypeInfo;
+
+static const JsAppSettingsNodeTypeEntry js_app_settings_node_types[];
+static const JsAppSettingsJsonTypeInfo js_app_settings_json_types[];
+
+/* JSON Logging */
+
+static size_t js_app_settings_cursor_depth(const JsAppSettingsCursor* cursor) {
+    size_t depth = 0;
+
+    for(; cursor->parent; cursor = cursor->parent) {
+        depth++;
+    }
+
+    return depth;
+}
+
+static void
+    js_app_settings_json_cat_cursor_path(const JsAppSettingsCursor* cursor, FuriString* path) {
+    if(cursor->parent) {
+        js_app_settings_json_cat_cursor_path(cursor->parent, path);
+        furi_string_cat(path, ".");
+    }
+
+    furi_string_cat(path, cursor->id);
+}
+
+static void
+    js_app_settings_json_log_error(const JsAppSettingsCursor* cursor, const char* format, ...) {
+    FuriString* message = furi_string_alloc();
+
+    furi_string_cat(message, "Field '");
+    js_app_settings_json_cat_cursor_path(cursor, message);
+    furi_string_cat(message, "': ");
+
+    va_list arguments;
+    va_start(arguments, format);
+    furi_string_cat_vprintf(message, format, arguments);
+    va_end(arguments);
+
+    FURI_LOG_E(TAG, "%s", furi_string_get_cstr(message));
+
+    furi_string_free(message);
+}
+
+static const char* js_app_settings_json_type_name(cJSON* json) {
+    const char* name = "unknown";
+
+    for(JsAppSettingsJsonType type = 0; type < JsAppSettingsJsonTypesCount; type++) {
+        const JsAppSettingsJsonTypeInfo* type_info = &js_app_settings_json_types[type];
+
+        if(type_info->is_type(json)) {
+            name = type_info->name;
+            break;
+        }
+    }
+
+    return name;
+}
+
+/* JSON Reading */
+
+static char* js_app_settings_string_steal(char** string) {
+    char* value = *string;
+    *string = NULL;
+
+    return value;
+}
+
+static bool js_app_settings_json_get(
+    const JsAppSettingsCursor* cursor,
+    const char* key,
+    bool is_optional,
+    JsAppSettingsJsonType type,
+    cJSON** json_out) {
+    cJSON* json = cJSON_GetObjectItem(cursor->json, key);
+
+    bool is_successful = true;
+    do {
+        if(json) {
+            const JsAppSettingsJsonTypeInfo* type_info = &js_app_settings_json_types[type];
+
+            if(!type_info->is_type(json)) {
+                js_app_settings_json_log_error(
+                    cursor,
+                    "key '%s' has type %s (%s was expected)",
+                    key,
+                    js_app_settings_json_type_name(json),
+                    type_info->name);
+                is_successful = false;
+            } else {
+                *json_out = json;
+            }
+
+            break;
+        }
+
+        if(is_optional) {
+            *json_out = NULL;
+            break;
+        }
+
+        js_app_settings_json_log_error(cursor, "key '%s' is missing", key);
+        is_successful = false;
+    } while(false);
+
+    return is_successful;
+}
+
+static bool js_app_settings_json_read_bool(
+    const JsAppSettingsCursor* cursor,
+    const char* key,
+    bool is_optional,
+    bool* value_out) {
+    cJSON* json;
+    bool is_successful =
+        js_app_settings_json_get(cursor, key, is_optional, JsAppSettingsJsonTypeBool, &json);
+
+    if(is_successful && json) {
+        *value_out = cJSON_IsTrue(json);
+    }
+
+    return is_successful;
+}
+
+static bool js_app_settings_json_read_float(
+    const JsAppSettingsCursor* cursor,
+    const char* key,
+    bool is_optional,
+    float* value_out) {
+    cJSON* json;
+    bool is_successful =
+        js_app_settings_json_get(cursor, key, is_optional, JsAppSettingsJsonTypeNumber, &json);
+
+    if(is_successful && json) {
+        *value_out = cJSON_GetNumberValue(json);
+    }
+
+    return is_successful;
+}
+
+static bool js_app_settings_json_read_int(
+    const JsAppSettingsCursor* cursor,
+    const char* key,
+    bool is_optional,
+    int* value_out) {
+    cJSON* json;
+    bool is_successful =
+        js_app_settings_json_get(cursor, key, is_optional, JsAppSettingsJsonTypeNumber, &json);
+
+    if(is_successful && json) {
+        *value_out = json->valueint;
+    }
+
+    return is_successful;
+}
+
+static bool js_app_settings_json_read_uint(
+    const JsAppSettingsCursor* cursor,
+    const char* key,
+    bool is_optional,
+    unsigned int* value_out) {
+    cJSON* json;
+    bool is_successful =
+        js_app_settings_json_get(cursor, key, is_optional, JsAppSettingsJsonTypeNumber, &json);
+
+    if(is_successful && json) {
+        int value = json->valueint;
+
+        if(value >= 0) {
+            *value_out = value;
+        } else {
+            js_app_settings_json_log_error(cursor, "key '%s' must be a non-negative integer", key);
+            is_successful = false;
+        }
+    }
+
+    return is_successful;
+}
+
+static bool js_app_settings_json_read_string(
+    const JsAppSettingsCursor* cursor,
+    const char* key,
+    bool is_optional,
+    const char** value_out) {
+    cJSON* json;
+    bool is_successful =
+        js_app_settings_json_get(cursor, key, is_optional, JsAppSettingsJsonTypeString, &json);
+
+    if(is_successful && json) {
+        *value_out = json->valuestring;
+    }
+
+    return is_successful;
+}
+
+static bool js_app_settings_json_steal_string(
+    const JsAppSettingsCursor* cursor,
+    const char* key,
+    bool is_optional,
+    char** value_out) {
+    cJSON* json;
+    bool is_successful =
+        js_app_settings_json_get(cursor, key, is_optional, JsAppSettingsJsonTypeString, &json);
+
+    if(is_successful && json) {
+        *value_out = js_app_settings_string_steal(&json->valuestring);
+    }
+
+    return is_successful;
+}
+
+/* Node Value Validation */
+
+static bool js_app_settings_is_id_valid(const char* id) {
+    bool is_id_valid = islower((unsigned char)*id);
+
+    for(unsigned char character; is_id_valid && (character = *++id) != '\0';) {
+        is_id_valid = islower(character) || isdigit(character) || character == '_';
+    }
+
+    return is_id_valid;
+}
+
+static bool js_app_settings_is_id_unique(
+    const JsAppSettingsNode* nodes,
+    size_t nodes_count,
+    const char* id) {
+    bool is_id_unique = true;
+
+    for(; nodes_count > 0; nodes_count--, nodes++) {
+        if(strcmp(nodes->id, id) == 0) {
+            is_id_unique = false;
+            break;
+        }
+    }
+
+    return is_id_unique;
+}
+
+static bool js_app_settings_is_int_valid(const JsAppSettingsNode* node, const void* value) {
+    const JsAppSettingsIntData* data = node->data;
+    int integer = *(const int*)value;
+
+    return integer >= data->min_value && integer <= data->max_value;
+}
+
+static bool js_app_settings_is_string_valid(const JsAppSettingsNode* node, const void* value) {
+    const JsAppSettingsStringData* data = node->data;
+    size_t length = strlen(value);
+
+    return length >= data->min_length && length <= data->max_length;
+}
+
+static bool js_app_settings_is_enum_valid(const JsAppSettingsNode* node, const void* value) {
+    const JsAppSettingsEnumData* data = node->data;
+    int index = *(const int*)value;
+
+    return index >= 0 && (size_t)index < data->options_count;
+}
+
+static bool js_app_settings_is_time_valid(const JsAppSettingsNode* node, const void* value) {
+    UNUSED(node);
+
+    const JsAppSettingsTimeValue* time_value = value;
+
+    return utz_time_init_checked(
+        time_value->time.hour, time_value->time.minute, time_value->time.second, &(utz_time_t){});
+}
+
+static inline bool js_app_settings_is_geo_auto_valid(const JsAppSettingsGeoValue* geo) {
+    return isnan(geo->latitude) && isnan(geo->longitude);
+}
+
+static inline bool js_app_settings_is_geo_fixed_valid(const JsAppSettingsGeoValue* geo) {
+    return !isnan(geo->latitude) && !isnan(geo->longitude) && geo->latitude >= -90.0f &&
+           geo->latitude <= 90.0f && geo->longitude >= -180.0f && geo->longitude <= 180.0f;
+}
+
+static bool js_app_settings_is_geo_valid(const JsAppSettingsNode* node, const void* value) {
+    UNUSED(node);
+
+    const JsAppSettingsGeoValue* geo = value;
+    return (geo->mode < JsAppSettingsGeoModesCount) && *geo->name != '\0' &&
+           ((geo->mode == JsAppSettingsGeoModeAuto) ? js_app_settings_is_geo_auto_valid(geo) :
+                                                      js_app_settings_is_geo_fixed_valid(geo));
+}
+
+/* Node Parsing */
+
+static bool
+    js_app_settings_parse_bool(const JsAppSettingsCursor* cursor, JsAppSettingsNode* node) {
+    JsAppSettingsBoolData* data = malloc(sizeof(*data));
+    node->data = data;
+
+    return js_app_settings_json_read_bool(cursor, "default", false, &data->default_value);
+}
+
+static bool js_app_settings_parse_int(const JsAppSettingsCursor* cursor, JsAppSettingsNode* node) {
+    JsAppSettingsIntData* data = malloc(sizeof(*data));
+    node->data = data;
+
+    data->min_value = JS_APP_SETTINGS_INT_DEFAULT_MIN;
+    data->max_value = JS_APP_SETTINGS_INT_DEFAULT_MAX;
+    data->value_step = JS_APP_SETTINGS_INT_DEFAULT_STEP;
+
+    bool is_successful = false;
+    do {
+        if(!js_app_settings_json_read_int(cursor, "default", false, &data->default_value)) {
+            break;
+        }
+
+        if(!js_app_settings_json_read_int(cursor, "min", true, &data->min_value)) {
+            break;
+        }
+
+        if(!js_app_settings_json_read_int(cursor, "max", true, &data->max_value)) {
+            break;
+        }
+
+        if(!js_app_settings_json_read_uint(cursor, "step", true, &data->value_step)) {
+            break;
+        }
+
+        if(data->min_value > data->max_value) {
+            js_app_settings_json_log_error(cursor, "'min' is greater than 'max'");
+            break;
+        }
+
+        if(data->value_step == 0) {
+            js_app_settings_json_log_error(cursor, "key 'step' must be a non-zero integer");
+            break;
+        }
+
+        unsigned int range = (unsigned int)data->max_value - (unsigned int)data->min_value;
+        if(range % data->value_step != 0) {
+            js_app_settings_json_log_error(
+                cursor, "'max' - 'min' must be evenly divisible by 'step'");
+            break;
+        }
+
+        if(!js_app_settings_is_int_valid(node, &data->default_value)) {
+            js_app_settings_json_log_error(cursor, "default is out of bounds");
+            break;
+        }
+
+        is_successful = true;
+    } while(false);
+
+    return is_successful;
+}
+
+static bool
+    js_app_settings_parse_string(const JsAppSettingsCursor* cursor, JsAppSettingsNode* node) {
+    JsAppSettingsStringData* data = malloc(sizeof(*data));
+    node->data = data;
+
+    data->default_value = NULL;
+    data->min_length = JS_APP_SETTINGS_STRING_DEFAULT_MIN_LENGTH;
+    data->max_length = JS_APP_SETTINGS_STRING_DEFAULT_MAX_LENGTH;
+    data->is_sensitive = false;
+
+    bool is_successful = false;
+    do {
+        if(!js_app_settings_json_steal_string(cursor, "default", false, &data->default_value)) {
+            break;
+        }
+
+        if(!js_app_settings_json_read_bool(cursor, "sensitive", true, &data->is_sensitive)) {
+            break;
+        }
+
+        if(!js_app_settings_json_read_uint(cursor, "min_length", true, &data->min_length)) {
+            break;
+        }
+
+        if(!js_app_settings_json_read_uint(cursor, "max_length", true, &data->max_length)) {
+            break;
+        }
+
+        if(data->min_length > data->max_length) {
+            js_app_settings_json_log_error(cursor, "'min_length' is greater than 'max_length'");
+            break;
+        }
+
+        if(data->max_length > JS_APP_SETTINGS_STRING_ABSOLUTE_MAX_LENGTH) {
+            js_app_settings_json_log_error(
+                cursor,
+                "'max_length' is greater than %u",
+                JS_APP_SETTINGS_STRING_ABSOLUTE_MAX_LENGTH);
+            break;
+        }
+
+        if(!js_app_settings_is_string_valid(node, data->default_value)) {
+            js_app_settings_json_log_error(cursor, "default length is out of bounds");
+            break;
+        }
+
+        is_successful = true;
+    } while(false);
+
+    return is_successful;
+}
+
+static bool js_app_settings_enum_find_index(
+    const JsAppSettingsEnumData* data,
+    const char* value,
+    int* index) {
+    bool is_found = false;
+
+    for(size_t i = 0; i < data->options_count; i++) {
+        if(strcmp(data->options[i].value, value) == 0) {
+            *index = i;
+            is_found = true;
+            break;
+        }
+    }
+
+    return is_found;
+}
+
+static bool js_app_settings_parse_enum_options(
+    const JsAppSettingsCursor* cursor,
+    cJSON* options_json,
+    JsAppSettingsEnumData* data) {
+    bool is_successful = false;
+
+    do {
+        size_t options_count = cJSON_GetArraySize(options_json);
+        if(options_count == 0 || options_count > JS_APP_SETTINGS_ENUM_MAX_OPTIONS) {
+            js_app_settings_json_log_error(
+                cursor,
+                "key 'options' must contain between 1 and %u items",
+                JS_APP_SETTINGS_ENUM_MAX_OPTIONS);
+            break;
+        }
+
+        data->options = calloc(options_count, sizeof(*data->options));
+        data->options_count = options_count;
+
+        is_successful = true;
+        size_t index = 0;
+        for(cJSON* json = options_json->child; json && is_successful; json = json->next, index++) {
+            JsAppSettingsEnumOption* option = &data->options[index];
+            JsAppSettingsCursor option_cursor = *cursor;
+            option_cursor.json = json;
+
+            is_successful =
+                js_app_settings_json_steal_string(
+                    &option_cursor, "value", false, &option->value) &&
+                js_app_settings_json_steal_string(&option_cursor, "label", false, &option->label);
+
+            for(size_t i = 0; is_successful && i < index; i++) {
+                if(strcmp(option->value, data->options[i].value) == 0) {
+                    js_app_settings_json_log_error(
+                        cursor, "duplicate enum option value '%s'", option->value);
+                    is_successful = false;
+                }
+            }
+        }
+    } while(false);
+
+    return is_successful;
+}
+
+static bool
+    js_app_settings_parse_enum(const JsAppSettingsCursor* cursor, JsAppSettingsNode* node) {
+    JsAppSettingsEnumData* data = malloc(sizeof(*data));
+    node->data = data;
+
+    data->default_index = 0;
+    data->options = NULL;
+    data->options_count = 0;
+
+    bool is_successful = false;
+    do {
+        const char* default_value;
+        if(!js_app_settings_json_read_string(cursor, "default", false, &default_value)) {
+            break;
+        }
+
+        cJSON* options_json;
+        if(!js_app_settings_json_get(
+               cursor, "options", false, JsAppSettingsJsonTypeArray, &options_json)) {
+            break;
+        }
+
+        if(!js_app_settings_parse_enum_options(cursor, options_json, data)) {
+            break;
+        }
+
+        if(!js_app_settings_enum_find_index(data, default_value, &data->default_index)) {
+            js_app_settings_json_log_error(
+                cursor, "default '%s' is not among the options", default_value);
+            break;
+        }
+
+        is_successful = true;
+    } while(false);
+
+    return is_successful;
+}
+
+static bool
+    js_app_settings_parse_color(const JsAppSettingsCursor* cursor, JsAppSettingsNode* node) {
+    JsAppSettingsColorData* data = malloc(sizeof(*data));
+    node->data = data;
+
+    bool is_successful = false;
+    do {
+        const char* default_value;
+        if(!js_app_settings_json_read_string(cursor, "default", false, &default_value)) {
+            break;
+        }
+
+        if(!js_app_settings_color_parse(default_value, &data->default_value)) {
+            js_app_settings_json_log_error(
+                cursor, "default must be a '#RRGGBB' or '#RRGGBBAA' color");
+            break;
+        }
+
+        is_successful = true;
+    } while(false);
+
+    return is_successful;
+}
+
+static bool
+    js_app_settings_parse_time(const JsAppSettingsCursor* cursor, JsAppSettingsNode* node) {
+    JsAppSettingsTimeData* data = malloc(sizeof(*data));
+    node->data = data;
+
+    bool is_successful = false;
+    do {
+        const char* default_value;
+        if(!js_app_settings_json_read_string(cursor, "default", false, &default_value)) {
+            break;
+        }
+
+        if(!js_app_settings_time_parse(default_value, &data->default_value)) {
+            js_app_settings_json_log_error(cursor, "default must be a 'HH:MM' or 'HH:MM:SS' time");
+            break;
+        }
+
+        is_successful = true;
+    } while(false);
+
+    return is_successful;
+}
+
+static bool js_app_settings_parse_geo(const JsAppSettingsCursor* cursor, JsAppSettingsNode* node) {
+    JsAppSettingsGeoData* data = malloc(sizeof(*data));
+    node->data = data;
+    JsAppSettingsGeoValue* value = &data->default_value;
+
+    value->mode = JsAppSettingsGeoModeAuto;
+    *value->name = '\0';
+    value->latitude = NAN;
+    value->longitude = NAN;
+
+    bool is_successful = false;
+    do {
+        cJSON* default_json;
+        if(!js_app_settings_json_get(
+               cursor, "default", false, JsAppSettingsJsonTypeObject, &default_json)) {
+            break;
+        }
+
+        JsAppSettingsCursor default_cursor = *cursor;
+        default_cursor.json = default_json;
+
+        const char* mode;
+        if(!js_app_settings_json_read_string(&default_cursor, "mode", false, &mode)) {
+            break;
+        }
+
+        if(!js_app_settings_geo_mode_parse(mode, &value->mode)) {
+            js_app_settings_json_log_error(
+                &default_cursor, "key 'mode' must be 'auto' or 'fixed', got '%s'", mode);
+            break;
+        }
+
+        const char* name;
+        if(!js_app_settings_json_read_string(&default_cursor, "name", false, &name)) {
+            break;
+        }
+
+        size_t name_length = strlen(name);
+        if(name_length == 0 || name_length > JS_APP_SETTINGS_GEO_NAME_MAX_LENGTH) {
+            js_app_settings_json_log_error(
+                &default_cursor,
+                "key 'name' must be between 1 and %u characters",
+                JS_APP_SETTINGS_GEO_NAME_MAX_LENGTH);
+            break;
+        }
+
+        strcpy(value->name, name);
+        if(!js_app_settings_json_read_float(&default_cursor, "lat", true, &value->latitude)) {
+            break;
+        }
+
+        if(!js_app_settings_json_read_float(&default_cursor, "lon", true, &value->longitude)) {
+            break;
+        }
+
+        if(!js_app_settings_is_geo_valid(node, value)) {
+            js_app_settings_json_log_error(&default_cursor, "invalid default value");
+            break;
+        }
+
+        is_successful = true;
+    } while(false);
+
+    return is_successful;
+}
+
+static bool js_app_settings_parse_nodes(
+    cJSON* fields_json,
+    const JsAppSettingsCursor* parent,
+    JsAppSettingsNode* nodes);
+
+static bool
+    js_app_settings_parse_group(const JsAppSettingsCursor* cursor, JsAppSettingsNode* node) {
+    JsAppSettingsGroupData* data = malloc(sizeof(*data));
+    node->data = data;
+
+    data->nodes = NULL;
+    data->nodes_count = 0;
+
+    bool is_successful = false;
+    do {
+        cJSON* fields_json;
+        if(!js_app_settings_json_get(
+               cursor, "fields", false, JsAppSettingsJsonTypeObject, &fields_json)) {
+            break;
+        }
+
+        size_t nodes_count = cJSON_GetArraySize(fields_json);
+        if(nodes_count == 0) {
+            js_app_settings_json_log_error(cursor, "group has no fields");
+            break;
+        }
+
+        if(js_app_settings_cursor_depth(cursor) >= JS_APP_SETTINGS_MAX_DEPTH) {
+            js_app_settings_json_log_error(
+                cursor, "maximum group nesting depth (%u) reached", JS_APP_SETTINGS_MAX_DEPTH);
+            break;
+        }
+
+        data->nodes_count = nodes_count;
+        data->nodes = calloc(nodes_count, sizeof(*data->nodes));
+
+        is_successful = js_app_settings_parse_nodes(fields_json, cursor, data->nodes);
+    } while(false);
+
+    return is_successful;
+}
+
+static bool js_app_settings_parse_node_type(const char* string, JsAppSettingsNodeType* node_type) {
+    bool is_successful = false;
+
+    for(JsAppSettingsNodeType type = 0; type < JsAppSettingsNodeTypesCount; type++) {
+        const JsAppSettingsNodeTypeEntry* type_entry = &js_app_settings_node_types[type];
+
+        if(strcmp(type_entry->key, string) == 0) {
+            *node_type = type;
+            is_successful = true;
+            break;
+        }
+    }
+
+    return is_successful;
+}
+
+static bool
+    js_app_settings_parse_node(const JsAppSettingsCursor* cursor, JsAppSettingsNode* node) {
+    bool is_successful = false;
+
+    do {
+        if(!js_app_settings_json_steal_string(cursor, "label", false, &node->label)) {
+            break;
+        }
+
+        if(!js_app_settings_json_steal_string(cursor, "description", true, &node->description)) {
+            break;
+        }
+
+        const char* type_key;
+        if(!js_app_settings_json_read_string(cursor, "type", false, &type_key)) {
+            break;
+        }
+
+        if(!js_app_settings_parse_node_type(type_key, &node->type)) {
+            js_app_settings_json_log_error(cursor, "unknown type '%s'", type_key);
+            break;
+        }
+
+        is_successful = js_app_settings_node_types[node->type].parse(cursor, node);
+    } while(false);
+
+    return is_successful;
+}
+
+static bool js_app_settings_parse_nodes(
+    cJSON* fields_json,
+    const JsAppSettingsCursor* parent,
+    JsAppSettingsNode* nodes) {
+    bool is_successful = true;
+
+    size_t index = 0;
+    for(cJSON* json = fields_json->child; json; json = json->next, index++) {
+        JsAppSettingsNode* node = &nodes[index];
+
+        node->id = js_app_settings_string_steal(&json->string);
+        JsAppSettingsCursor cursor = {.parent = parent, .json = json, .id = node->id};
+        if(!js_app_settings_is_id_valid(cursor.id)) {
+            js_app_settings_json_log_error(&cursor, "invalid id format");
+            is_successful = false;
+            break;
+        }
+
+        if(!js_app_settings_is_id_unique(nodes, index, cursor.id)) {
+            js_app_settings_json_log_error(&cursor, "duplicate id on the same level");
+            is_successful = false;
+            break;
+        }
+
+        if(!js_app_settings_parse_node(&cursor, node)) {
+            is_successful = false;
+            break;
+        }
+    }
+
+    return is_successful;
+}
+
+/* Node Destruction */
+
+static void js_app_settings_free_nodes(JsAppSettingsNode* nodes, size_t nodes_count) {
+    for(JsAppSettingsNode* node = nodes; nodes_count > 0; nodes_count--, node++) {
+        const JsAppSettingsNodeTypeEntry* type_entry = &js_app_settings_node_types[node->type];
+
+        if(type_entry->free) {
+            type_entry->free(node);
+        }
+
+        free(node->data);
+
+        cJSON_free(node->id);
+        cJSON_free(node->label);
+        cJSON_free(node->description);
+    }
+
+    free(nodes);
+}
+
+static void js_app_settings_free_string(JsAppSettingsNode* node) {
+    JsAppSettingsStringData* data = node->data;
+
+    cJSON_free(data->default_value);
+}
+
+static void js_app_settings_free_enum(JsAppSettingsNode* node) {
+    JsAppSettingsEnumData* data = node->data;
+
+    for(size_t i = 0; i < data->options_count; i++) {
+        JsAppSettingsEnumOption* option = &data->options[i];
+
+        cJSON_free(option->value);
+        cJSON_free(option->label);
+    }
+
+    free(data->options);
+}
+
+static void js_app_settings_free_group(JsAppSettingsNode* node) {
+    JsAppSettingsGroupData* data = node->data;
+
+    js_app_settings_free_nodes(data->nodes, data->nodes_count);
+}
+
+/* Public API Implementation */
+
+bool js_app_settings_validate_value(const JsAppSettingsNode* node, const void* value) {
+    furi_check(node);
+    furi_check(value);
+
+    const JsAppSettingsNodeTypeEntry* type_entry = &js_app_settings_node_types[node->type];
+    return type_entry->is_valid ? type_entry->is_valid(node, value) : true;
+}
+
+JsAppSettings* js_app_settings_parse(const char* data, uint32_t length) {
+    furi_check(data);
+
+    cJSON* root_json;
+    JsAppSettings* settings = NULL;
+
+    do {
+        root_json = cJSON_ParseWithLength(data, length);
+        if(!cJSON_IsObject(root_json)) {
+            FURI_LOG_E(TAG, "Malformed JSON or root item is not an object");
+            break;
+        }
+
+        cJSON* format_version_json = cJSON_GetObjectItem(root_json, "format_version");
+        if(!cJSON_IsNumber(format_version_json)) {
+            FURI_LOG_E(TAG, "Root key 'format_version' is missing or is not a number");
+            break;
+        }
+
+        int format_version = format_version_json->valueint;
+        if(format_version != JS_APP_SETTINGS_FORMAT_VERSION) {
+            FURI_LOG_E(
+                TAG,
+                "Unsupported format version: expected %u, got %d",
+                JS_APP_SETTINGS_FORMAT_VERSION,
+                format_version);
+            break;
+        }
+
+        cJSON* version_json = cJSON_GetObjectItem(root_json, "version");
+        if(!cJSON_IsNumber(version_json)) {
+            FURI_LOG_E(TAG, "Root key 'version' is missing or is not a number");
+            break;
+        }
+
+        int version = version_json->valueint;
+        if(version <= 0) {
+            FURI_LOG_E(TAG, "Root key 'version' must be a positive number");
+            break;
+        }
+
+        cJSON* fields_json = cJSON_GetObjectItem(root_json, "fields");
+        if(!cJSON_IsObject(fields_json)) {
+            FURI_LOG_E(TAG, "Root key 'fields' is missing or is not an object");
+            break;
+        }
+
+        size_t nodes_count = cJSON_GetArraySize(fields_json);
+        if(nodes_count == 0) {
+            FURI_LOG_E(TAG, "Root key 'fields' must not be empty");
+            break;
+        }
+
+        settings = malloc(sizeof(*settings));
+        settings->version = version;
+        settings->nodes_count = nodes_count;
+        settings->nodes = calloc(nodes_count, sizeof(*settings->nodes));
+
+        if(!js_app_settings_parse_nodes(fields_json, NULL, settings->nodes)) {
+            js_app_settings_free(settings);
+            settings = NULL;
+        }
+    } while(false);
+
+    cJSON_Delete(root_json);
+
+    return settings;
+}
+
+void js_app_settings_free(JsAppSettings* settings) {
+    furi_check(settings);
+
+    js_app_settings_free_nodes(settings->nodes, settings->nodes_count);
+
+    free(settings);
+}
+
+/* Tables */
+
+static const JsAppSettingsNodeTypeEntry js_app_settings_node_types[] = {
+    [JsAppSettingsNodeTypeBool] =
+        {
+            .key = "boolean",
+            .parse = js_app_settings_parse_bool,
+            .is_valid = NULL,
+            .free = NULL,
+        },
+    [JsAppSettingsNodeTypeInt] =
+        {
+            .key = "integer",
+            .parse = js_app_settings_parse_int,
+            .is_valid = js_app_settings_is_int_valid,
+            .free = NULL,
+        },
+    [JsAppSettingsNodeTypeString] =
+        {
+            .key = "string",
+            .parse = js_app_settings_parse_string,
+            .is_valid = js_app_settings_is_string_valid,
+            .free = js_app_settings_free_string,
+        },
+    [JsAppSettingsNodeTypeEnum] =
+        {
+            .key = "enum",
+            .parse = js_app_settings_parse_enum,
+            .is_valid = js_app_settings_is_enum_valid,
+            .free = js_app_settings_free_enum,
+        },
+    [JsAppSettingsNodeTypeColor] =
+        {
+            .key = "color",
+            .parse = js_app_settings_parse_color,
+            .is_valid = NULL,
+            .free = NULL,
+        },
+    [JsAppSettingsNodeTypeTime] =
+        {
+            .key = "time",
+            .parse = js_app_settings_parse_time,
+            .is_valid = js_app_settings_is_time_valid,
+            .free = NULL,
+        },
+    [JsAppSettingsNodeTypeGeo] =
+        {
+            .key = "geolocation",
+            .parse = js_app_settings_parse_geo,
+            .is_valid = js_app_settings_is_geo_valid,
+            .free = NULL,
+        },
+    [JsAppSettingsNodeTypeGroup] =
+        {
+            .key = "group",
+            .parse = js_app_settings_parse_group,
+            .is_valid = NULL,
+            .free = js_app_settings_free_group,
+        },
+};
+
+static_assert(COUNT_OF(js_app_settings_node_types) == JsAppSettingsNodeTypesCount);
+
+static const JsAppSettingsJsonTypeInfo js_app_settings_json_types[] = {
+    [JsAppSettingsJsonTypeBool] = {.name = "boolean", .is_type = cJSON_IsBool},
+    [JsAppSettingsJsonTypeNumber] = {.name = "number", .is_type = cJSON_IsNumber},
+    [JsAppSettingsJsonTypeString] = {.name = "string", .is_type = cJSON_IsString},
+    [JsAppSettingsJsonTypeArray] = {.name = "array", .is_type = cJSON_IsArray},
+    [JsAppSettingsJsonTypeObject] = {.name = "object", .is_type = cJSON_IsObject},
+    [JsAppSettingsJsonTypeNull] = {.name = "null", .is_type = cJSON_IsNull},
+};
+
+static_assert(COUNT_OF(js_app_settings_json_types) == JsAppSettingsJsonTypesCount);

--- a/lib/js_app/js_app_settings.h
+++ b/lib/js_app/js_app_settings.h
@@ -1,0 +1,176 @@
+/**
+ * @file js_app_settings.h
+ * @brief Settings manifest parser for JavaScript applications.
+ *
+ * Parses & validates application's settings manifest (settings.json) 
+ * into a tree of typed nodes.
+ */
+
+#pragma once
+
+#include "setting_types/js_app_settings_color.h"
+#include "setting_types/js_app_settings_geo.h"
+#include "setting_types/js_app_settings_time.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct JsAppSettingsNode JsAppSettingsNode;
+
+/**
+ * @brief Settings node type.
+ *
+ * Each value corresponds to a "type" key of a manifest entry.
+ */
+typedef enum {
+    JsAppSettingsNodeTypeBool, ///< "boolean" toggle.
+    JsAppSettingsNodeTypeInt, ///< "integer" input.
+    JsAppSettingsNodeTypeString, ///< "string" input.
+    JsAppSettingsNodeTypeEnum, ///< "enum" selector.
+    JsAppSettingsNodeTypeColor, ///< "color" picker.
+    JsAppSettingsNodeTypeTime, ///< "time" value.
+    JsAppSettingsNodeTypeGeo, ///< "geolocation" value.
+
+    JsAppSettingsNodeTypeGroup, ///< "group" container.
+
+    JsAppSettingsNodeTypesCount,
+} JsAppSettingsNodeType;
+
+/**
+ * @brief Boolean node data.
+ */
+typedef struct {
+    bool default_value; ///< Default state.
+} JsAppSettingsBoolData;
+
+/**
+ * @brief Integer node data.
+ */
+typedef struct {
+    int default_value; ///< Default value, always within [min_value, max_value].
+    int min_value; ///< Lower bound, INT_MIN when unspecified.
+    int max_value; ///< Upper bound, INT_MAX when unspecified.
+    unsigned int value_step; ///< Adjustment step, 1 when unspecified.
+} JsAppSettingsIntData;
+
+/**
+ * @brief String node data.
+ */
+typedef struct {
+    char* default_value; ///< Default text, owned by the tree.
+    unsigned int min_length; ///< Minimum length in bytes, 0 when unspecified.
+    unsigned int max_length; ///< Maximum length in bytes, 64 when unspecified.
+    bool is_sensitive; ///< Hide the text while editing.
+} JsAppSettingsStringData;
+
+/**
+ * @brief Enumeration option.
+ */
+typedef struct {
+    char* value; ///< Machine-readable value, owned by the tree.
+    char* label; ///< User-visible label, owned by the tree.
+} JsAppSettingsEnumOption;
+
+/**
+ * @brief Enumeration node data.
+ */
+typedef struct {
+    int default_index; ///< Index of the default option within options.
+    JsAppSettingsEnumOption* options; ///< Option array, owned by the tree.
+    size_t options_count; ///< Number of options, between 1 and 32.
+} JsAppSettingsEnumData;
+
+/**
+ * @brief Color node data.
+ */
+typedef struct {
+    Color default_value; ///< Default color.
+} JsAppSettingsColorData;
+
+/**
+ * @brief Time node data.
+ */
+typedef struct {
+    JsAppSettingsTimeValue default_value; ///< Default time.
+} JsAppSettingsTimeData;
+
+/**
+ * @brief Geolocation node data.
+ */
+typedef struct {
+    JsAppSettingsGeoValue default_value; ///< Default position.
+} JsAppSettingsGeoData;
+
+/**
+ * @brief Group node data.
+ */
+typedef struct {
+    JsAppSettingsNode* nodes; ///< Child nodes, owned by the tree.
+    size_t nodes_count; ///< Number of child nodes.
+} JsAppSettingsGroupData;
+
+/**
+ * @brief Settings node.
+ *
+ * A single field or a recursive group of fields. The type member selects the
+ * type of the data payload; all strings and the payload itself are owned by
+ * the tree and released by js_app_settings_free().
+ */
+struct JsAppSettingsNode {
+    char* id; ///< Identifier, unique among siblings.
+    char* label; ///< User-visible name.
+    char* description; ///< Optional details, NULL when absent.
+
+    JsAppSettingsNodeType type; ///< Node kind, selects the data payload.
+    void* data; ///< Per-type payload.
+};
+
+/**
+ * @brief Parsed settings tree.
+ */
+typedef struct {
+    int version; ///< Application-defined manifest version.
+
+    JsAppSettingsNode* nodes; ///< Root-level nodes.
+    size_t nodes_count; ///< Number of root-level nodes.
+} JsAppSettings;
+
+/**
+ * @brief Validate a value against a node's constraints.
+ *
+ * The value pointer is type-specific:
+ * bool* for boolean, int* for integer, char* for string,
+ * int* for enum (option index), Color* for color,
+ * const JsAppSettingsTimeValue* for time,
+ * const JsAppSettingsGeoValue* for geolocation.
+ * Boolean and color nodes accept any value.
+ *
+ * @param[in] node Settings node.
+ * @param[in] value Value matching the node's type.
+ * @return true if the value satisfies the node's bounds, false otherwise.
+ */
+bool js_app_settings_validate_value(const JsAppSettingsNode* node, const void* value);
+
+/**
+ * @brief Parse a settings manifest.
+ *
+ * @param[in] data Manifest buffer, need not be NUL-terminated.
+ * @param[in] length Manifest length in bytes.
+ * @return Allocated settings tree, or NULL if the manifest is invalid;
+ *         failures are logged with the offending field's path.
+ */
+JsAppSettings* js_app_settings_parse(const char* data, uint32_t length);
+
+/**
+ * @brief Free a settings tree.
+ *
+ * Releases the tree and every string and node array it owns.
+ *
+ * @param[in] settings Tree returned by js_app_settings_parse().
+ */
+void js_app_settings_free(JsAppSettings* settings);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/js_app/setting_types/js_app_settings_color.c
+++ b/lib/js_app/setting_types/js_app_settings_color.c
@@ -1,0 +1,22 @@
+#include "js_app_settings_color.h"
+
+bool js_app_settings_color_parse(const char* string, Color* value) {
+    furi_check(string);
+    furi_check(value);
+
+    return color_parse_hex_string(string, value) || color_parse_hexa_string(string, value);
+}
+
+void js_app_settings_color_format(const Color* value, FuriString* string) {
+    furi_check(value);
+    furi_check(string);
+
+    uint8_t alpha = value->a;
+    furi_string_printf(
+        string,
+        (alpha == 0xFF) ? "#%02X%02X%02X" : "#%02X%02X%02X%02X",
+        value->r,
+        value->g,
+        value->b,
+        alpha);
+}

--- a/lib/js_app/setting_types/js_app_settings_color.h
+++ b/lib/js_app/setting_types/js_app_settings_color.h
@@ -1,0 +1,33 @@
+/**
+ * @file js_app_settings_color.h
+ * @brief Color type for application settings.
+ */
+#pragma once
+
+#include <furi.h>
+#include <color.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Parse a color string.
+ *
+ * @param[in] string "#RRGGBB" or "#RRGGBBAA"; the short form is opaque.
+ * @param[out] value Parsed color.
+ * @return true if the string is a valid color, false otherwise.
+ */
+bool js_app_settings_color_parse(const char* string, Color* value);
+
+/**
+ * @brief Format a color as a string.
+ *
+ * @param[in] value Color.
+ * @param[out] string Output, "#RRGGBB" when opaque, "#RRGGBBAA" otherwise.
+ */
+void js_app_settings_color_format(const Color* value, FuriString* string);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/js_app/setting_types/js_app_settings_geo.c
+++ b/lib/js_app/setting_types/js_app_settings_geo.c
@@ -1,0 +1,32 @@
+#include "js_app_settings_geo.h"
+
+#include <furi.h>
+
+#include <string.h>
+
+static const char* const js_app_settings_geo_mode_map[] = {
+    [JsAppSettingsGeoModeAuto] = "auto",
+    [JsAppSettingsGeoModeFixed] = "fixed",
+};
+
+static_assert(COUNT_OF(js_app_settings_geo_mode_map) == JsAppSettingsGeoModesCount);
+
+bool js_app_settings_geo_mode_parse(const char* string, JsAppSettingsGeoMode* mode) {
+    furi_check(string);
+    furi_check(mode);
+
+    bool is_mode_valid = false;
+    for(JsAppSettingsGeoMode i = 0; i < JsAppSettingsGeoModesCount; i++) {
+        if(strcmp(js_app_settings_geo_mode_map[i], string) == 0) {
+            *mode = i;
+            is_mode_valid = true;
+            break;
+        }
+    }
+
+    return is_mode_valid;
+}
+
+const char* js_app_settings_geo_mode_format(JsAppSettingsGeoMode mode) {
+    return (mode < JsAppSettingsGeoModesCount) ? js_app_settings_geo_mode_map[mode] : "unknown";
+}

--- a/lib/js_app/setting_types/js_app_settings_geo.h
+++ b/lib/js_app/setting_types/js_app_settings_geo.h
@@ -1,0 +1,54 @@
+/**
+ * @file js_app_settings_geo.h
+ * @brief Geolocation type for application settings.
+ */
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define JS_APP_SETTINGS_GEO_NAME_MAX_LENGTH (128u)
+
+/**
+ * @brief Geolocation mode.
+ */
+typedef enum {
+    JsAppSettingsGeoModeAuto, ///< Derive coordinates from the device.
+    JsAppSettingsGeoModeFixed, ///< Use the given coordinates.
+
+    JsAppSettingsGeoModesCount,
+} JsAppSettingsGeoMode;
+
+/**
+ * @brief Geolocation value.
+ */
+typedef struct {
+    JsAppSettingsGeoMode mode; ///< Coordinate source.
+    char name[JS_APP_SETTINGS_GEO_NAME_MAX_LENGTH + 1]; ///< Location name.
+    float latitude; ///< Degrees within [-90, 90], NAN in auto mode.
+    float longitude; ///< Degrees within [-180, 180], NAN in auto mode.
+} JsAppSettingsGeoValue;
+
+/**
+ * @brief Parse a geolocation mode string.
+ *
+ * @param[in] string "auto" or "fixed".
+ * @param[out] mode Parsed mode.
+ * @return true if the string names a mode, false otherwise.
+ */
+bool js_app_settings_geo_mode_parse(const char* string, JsAppSettingsGeoMode* mode);
+
+/**
+ * @brief Format a geolocation mode as a string.
+ *
+ * @param[in] mode Mode.
+ * @return Mode name, "auto" or "fixed".
+ */
+const char* js_app_settings_geo_mode_format(JsAppSettingsGeoMode mode);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/js_app/setting_types/js_app_settings_time.c
+++ b/lib/js_app/setting_types/js_app_settings_time.c
@@ -2,6 +2,39 @@
 
 #include <inttypes.h>
 
+static bool js_app_settings_time_parse_digits(const char* digits, unsigned int* value) {
+    unsigned char high_digit = digits[0];
+    unsigned char low_digit = digits[1];
+
+    bool is_valid;
+    if((is_valid = isdigit(high_digit) && isdigit(low_digit))) {
+        *value = (high_digit - '0') * 10 + (low_digit - '0');
+    }
+
+    return is_valid;
+}
+
+static bool js_app_settings_time_parse_fields(const char* string, unsigned int* fields) {
+    bool is_valid = false;
+    for(;; fields++, string += strlen(":")) {
+        if(!js_app_settings_time_parse_digits(string, fields)) {
+            break;
+        }
+
+        string += strlen("XX");
+        if(*string == '\0') {
+            is_valid = true;
+            break;
+        }
+
+        if(*string != ':') {
+            break;
+        }
+    }
+
+    return is_valid;
+}
+
 bool js_app_settings_time_parse(const char* string, JsAppSettingsTimeValue* value) {
     furi_check(string);
     furi_check(value);
@@ -15,22 +48,15 @@ bool js_app_settings_time_parse(const char* string, JsAppSettingsTimeValue* valu
             break;
         }
 
-        unsigned int hours = 0;
-        unsigned int minutes = 0;
-        unsigned int seconds = 0;
-
-        int parsed_length = 0;
-        if(has_seconds) {
-            sscanf(string, "%2u:%2u:%2u%n", &hours, &minutes, &seconds, &parsed_length);
-        } else {
-            sscanf(string, "%2u:%2u%n", &hours, &minutes, &parsed_length);
+        /* hours, minutes, seconds */
+        unsigned int fields[3] = {0};
+        if(!js_app_settings_time_parse_fields(string, fields)) {
+            break;
         }
 
-        if((size_t)parsed_length == length) {
-            if(utz_time_init_checked(hours, minutes, seconds, &value->time)) {
-                value->has_seconds = has_seconds;
-                is_format_valid = true;
-            }
+        if(utz_time_init_checked(fields[0], fields[1], fields[2], &value->time)) {
+            value->has_seconds = has_seconds;
+            is_format_valid = true;
         }
     } while(false);
 

--- a/lib/js_app/setting_types/js_app_settings_time.c
+++ b/lib/js_app/setting_types/js_app_settings_time.c
@@ -1,0 +1,50 @@
+#include "js_app_settings_time.h"
+
+#include <inttypes.h>
+
+bool js_app_settings_time_parse(const char* string, JsAppSettingsTimeValue* value) {
+    furi_check(string);
+    furi_check(value);
+
+    bool is_format_valid = false;
+
+    do {
+        size_t length = strlen(string);
+        bool has_seconds = length == strlen("HH:MM:SS");
+        if(!has_seconds && length != strlen("HH:MM")) {
+            break;
+        }
+
+        unsigned int hours = 0;
+        unsigned int minutes = 0;
+        unsigned int seconds = 0;
+
+        int parsed_length = 0;
+        if(has_seconds) {
+            sscanf(string, "%2u:%2u:%2u%n", &hours, &minutes, &seconds, &parsed_length);
+        } else {
+            sscanf(string, "%2u:%2u%n", &hours, &minutes, &parsed_length);
+        }
+
+        if((size_t)parsed_length == length) {
+            if(utz_time_init_checked(hours, minutes, seconds, &value->time)) {
+                value->has_seconds = has_seconds;
+                is_format_valid = true;
+            }
+        }
+    } while(false);
+
+    return is_format_valid;
+}
+
+void js_app_settings_time_format(const JsAppSettingsTimeValue* value, FuriString* string) {
+    furi_check(string);
+    furi_check(value);
+
+    furi_string_printf(
+        string,
+        value->has_seconds ? "%02" PRIu8 ":%02" PRIu8 ":%02" PRIu8 : "%02" PRIu8 ":%02" PRIu8,
+        value->time.hour,
+        value->time.minute,
+        value->time.second);
+}

--- a/lib/js_app/setting_types/js_app_settings_time.h
+++ b/lib/js_app/setting_types/js_app_settings_time.h
@@ -1,0 +1,41 @@
+/**
+ * @file js_app_settings_time.h
+ * @brief Time of day type for application settings.
+ */
+#pragma once
+
+#include <furi.h>
+#include <utz/utz.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Time of day value.
+ */
+typedef struct {
+    utz_time_t time; ///< Time of day.
+    bool has_seconds; ///< Whether seconds are part of the value.
+} JsAppSettingsTimeValue;
+
+/**
+ * @brief Parse a time of day string.
+ *
+ * @param[in] string "HH:MM" or "HH:MM:SS".
+ * @param[out] value Parsed time of day; has_seconds is set for the long form.
+ * @return true if the string is a valid time, false otherwise.
+ */
+bool js_app_settings_time_parse(const char* string, JsAppSettingsTimeValue* value);
+
+/**
+ * @brief Format a time of day as a string.
+ *
+ * @param[in] value Time of day.
+ * @param[out] string Output, zero-padded "HH:MM" or "HH:MM:SS".
+ */
+void js_app_settings_time_format(const JsAppSettingsTimeValue* value, FuriString* string);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/toolbox/color.c
+++ b/lib/toolbox/color.c
@@ -90,6 +90,17 @@ Color color_hexa_to_rgb(uint32_t hexa) {
     return rgb;
 }
 
+bool color_parse_hex_string(const char* hex, Color* color_out) {
+    if(strlen(hex) != strlen("#RRGGBB")) return false;
+    hex++;
+
+    uint32_t hex_int;
+    if(strint_to_uint32(hex, NULL, &hex_int, 16) != StrintParseNoError) return false;
+
+    *color_out = color_hex_to_rgb(hex_int);
+    return true;
+}
+
 bool color_parse_hexa_string(const char* hexa, Color* color_out) {
     if(strlen(hexa) != strlen("#RRGGBBAA")) return false;
     hexa++;

--- a/lib/toolbox/color.c
+++ b/lib/toolbox/color.c
@@ -2,7 +2,8 @@
 
 #include <core/check.h>
 #include <limits.h>
-#include "strint.h"
+
+#include "hex.h"
 
 // https://stackoverflow.com/questions/24152553/hsv-to-rgb-and-back-without-floating-point-math-in-python
 Color color_hsv_to_rgb(ColorHsv hsv) {
@@ -91,24 +92,22 @@ Color color_hexa_to_rgb(uint32_t hexa) {
 }
 
 bool color_parse_hex_string(const char* hex, Color* color_out) {
-    if(strlen(hex) != strlen("#RRGGBB")) return false;
-    hex++;
+    if(strlen(hex) != strlen("#RRGGBB") || *hex != '#') return false;
 
-    uint32_t hex_int;
-    if(strint_to_uint32(hex, NULL, &hex_int, 16) != StrintParseNoError) return false;
+    uint8_t rgb[3];
+    if(!hex_chars_to_uint8(hex + 1, rgb)) return false;
 
-    *color_out = color_hex_to_rgb(hex_int);
+    *color_out = (Color)COLOR_MAKE_RGB(rgb[0], rgb[1], rgb[2]);
     return true;
 }
 
 bool color_parse_hexa_string(const char* hexa, Color* color_out) {
-    if(strlen(hexa) != strlen("#RRGGBBAA")) return false;
-    hexa++;
+    if(strlen(hexa) != strlen("#RRGGBBAA") || *hexa != '#') return false;
 
-    uint32_t hexa_int;
-    if(strint_to_uint32(hexa, NULL, &hexa_int, 16) != StrintParseNoError) return false;
+    uint8_t rgba[4];
+    if(!hex_chars_to_uint8(hexa + 1, rgba)) return false;
 
-    *color_out = color_hexa_to_rgb(hexa_int);
+    *color_out = (Color)COLOR_MAKE_RGBA(rgba[0], rgba[1], rgba[2], rgba[3]);
     return true;
 }
 

--- a/lib/toolbox/color.h
+++ b/lib/toolbox/color.h
@@ -82,11 +82,21 @@ Color color_hex_to_rgb(uint32_t hex);
 Color color_hexa_to_rgb(uint32_t hexa);
 
 /**
+ * @brief Convert a HEX `"#RRGGBB"` representation to an RGB color
+ *
+ * @param[in] hex Hex value to convert (`"#RRGGBB"`)
+ * @param[out] color_out Color structure to fill
+ *
+ * @return Parsing status (`true` = success)
+ */
+bool color_parse_hex_string(const char* hex, Color* color_out);
+
+/**
  * @brief Convert a HEX `"#RRGGBBAA"` representation to an RGB color
- * 
+ *
  * @param[in] hexa Hex value to convert (`"#RRGGBBAA"`)
  * @param[out] color_out Color structure to fill
- * 
+ *
  * @return Parsing status (`true` = success)
  */
 bool color_parse_hexa_string(const char* hexa, Color* color_out);


### PR DESCRIPTION
> [!NOTE]
> * [**FW-1115**](https://flipper.atlassian.net/browse/FW-1115)

# What's new

- implement js application settings manifest parser
- implement js application settings storage configuration composer
- implement js application settings UI (**draft, needs rework with new menus**)
- implement `color_parse_hex_string` & make both `color_parse_*_string` APIs strict on format
- tune `var_item_list`'s increment/decrement to fix possible overflows (& forbid negative step value)

# Verification 

- parser unit tests pass
- js applications settings UI draws, allows settings change, saves/loads them correctly
- `color_parse_hexa_string` users function properly (with strict expected format)

[example settings.json for clock application](https://github.com/user-attachments/files/31906783/settings.json)

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
