### PR TITLE
JS: increase heap size

### DIFF
--- a/applications/services/js_runner/cli/cli_command_js.c
+++ b/applications/services/js_runner/cli/cli_command_js.c
@@ -15,7 +15,7 @@ typedef struct JsCliParams {
 } JsCliParams;
 
 #define CLI_APP_ID        "app.busy.cli"
-#define CLI_APP_HEAP_SIZE 64 * 1024
+#define CLI_APP_HEAP_SIZE 96 * 1024
 
 #define MAX_REPL_LINE_LENGTH 200
 


### PR DESCRIPTION
# What's new

- JS heap size 96 kB for CLI scripts

# Verification 

- Run integration tests

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
