### PR TITLE
docs: describe firmware subsystems in the developer documentation

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,58 @@
+name: 'Publish documentation to GitHub Pages'
+
+on:
+  push:
+    branches:
+      - dev
+      - 'docs/**'
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout code'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: 'Update submodules'
+        run: |
+          git submodule update --init --jobs=$(nproc) \
+            documentation/doxygen/doxygen-awesome-css
+
+      - name: 'Install Doxygen'
+        uses: AdarshRawat1/Install-Doxygen@v1.0
+        with:
+          version: "1.12.0"
+
+      - name: 'Generate documentation'
+        env:
+          DOXY_SRC_ROOT: ${{ github.workspace }}
+          DOXY_CONFIG_DIR: ${{ github.workspace }}/documentation/doxygen
+        run: |
+          doxygen documentation/doxygen/Doxyfile-awesome.cfg
+          touch documentation/doxygen/build/html/.nojekyll
+
+      - name: 'Upload Pages artifact'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: documentation/doxygen/build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: 'Deploy to GitHub Pages'
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/documentation/Architecture.dox.md
+++ b/documentation/Architecture.dox.md
@@ -1,0 +1,131 @@
+# Architecture {#architecture}
+
+This page describes the structure of the firmware: the split between the two MCUs, the runtime that both share, the service model, and the link between them. Hardware details are on the @ref hardware page. The individual subsystems have their own pages under @ref firmware.
+
+# Two MCUs, one source tree
+
+Both microcontrollers run firmware built from this repository, on the same FreeRTOS based runtime, with the same application manifest format. The `targets=` field in each `application.fam` decides on which side an application or service is compiled. Many services have two halves: a U5 half that owns the public API and a Si917 "backend" half that talks to the hardware.
+
+| Responsibility | STM32U5 (`f2x`) | SiWG917 (`f6x`) |
+| --- | --- | --- |
+| Displays, GUI, animations, fonts | Yes | |
+| Storage (eMMC), settings, logs | Yes | NVM3 key-value store and the crypto key storage only |
+| Power, charger, USB-PD, RTC, time sync | Yes | |
+| USB (CDC-NCM), lwIP IPv4, HTTP server, MQTT, TLS clients | Yes | |
+| Wi-Fi association, BLE GATT server | | Yes |
+| IPv6 lwIP and the Matter node | | Yes |
+| Buttons, mode switch, encoder, RGB status lights | | Yes |
+| TLS private keys, device certificates, Matter credentials | | Yes, in the secure key storage |
+| Busy timer, updater, JavaScript runtime, CLI | Yes | Small CLI only |
+
+Both images must come from the same git commit. The intercom handshake exchanges the git hash and refuses to start when it differs (see below).
+
+# Runtime
+
+The runtime is "furi", a set of core libraries that lives in the `fbt_layers/core_libs` submodule and wraps FreeRTOS. The firmware uses these primitives everywhere:
+
+- **Threads** (`FuriThread`) with an application id. The application id of the calling thread selects the per-application data directory (see @ref storage-and-settings).
+- **Records** (`furi_record_create`, `furi_record_open`): named singletons through which services publish their instance. `furi_record_open` blocks until the record exists, which orders service start-up implicitly.
+- **PubSub** (`FuriPubSub`) for broadcast events and **FuriState** for observable values with a current value (Wi-Fi info, switch position, brightness, timer state).
+- **Message queues** and **event loops** (`FuriEventLoop`). Almost every service is a single thread that runs an event loop subscribed to an API queue, a few timers and some pubsubs.
+- **API lock** (`lib/toolbox/api_lock.h`): the standard pattern for a synchronous call across a queue. The caller posts a message with a lock and blocks until the service thread unlocks it.
+- **Logging** (`FURI_LOG_E/W/I/D/T`) with pluggable handlers, and `furi_check` / `furi_assert` / `furi_crash` for invariants.
+
+The memory allocator returns zeroed memory, refuses zero-byte allocations and aborts on allocation failure, so allocation results are not checked in application code.
+
+# Service model
+
+An `application.fam` manifest declares every unit of code (see @ref native-applications for the format). The build (`lib/firmware_applications_u5`, `lib/firmware_applications_si917`) collects the manifests of the selected application set and generates the tables that the start-up code consumes:
+
+| Manifest type | Generated table | Started how |
+| --- | --- | --- |
+| `SERVICE` | `FLIPPER_SERVICES[]` | One thread per service, in `order` sequence, at boot |
+| `STARTUP` | `FLIPPER_ON_SYSTEM_START[]` | A short-lived hook thread, in `order` sequence, after the services |
+| `CLICMD` | `FLIPPER_CLI_COMMANDS[]` | Registered in the CLI registry by the CLI start-up hook |
+| `APP`, `SETTINGS`, `SYSTEM`, `DEBUG` | `FLIPPER_APPS`, `FLIPPER_SETTINGS_APPS`, ... | Launched on demand by the loader |
+| `METAPACKAGE` | none | Groups other applications through `provides=` |
+
+The `FIRMWARE_APP_SET` build variable selects a named set of metapackages, defined in `targets/<target>/fbt_conf/`:
+
+| Set | U5 | Si917 |
+| --- | --- | --- |
+| `default` | basic_services, extended_services, main_apps, settings, system_apps, debug_apps | basic_services, intercom_services, system_apps |
+| `unit_tests` | default plus `unit_tests` | default plus debug_apps |
+| `recovery` | basic_services, recovery | basic_services, intercom_services |
+| `factory_testing` | default plus `back_display_factory` | Same as default |
+| `917_crash` | Same as default | default plus `crash` (a build that crashes on purpose, used by the CI brick-recovery test) |
+| `hwtest` | | basic_services, system_apps, cli, cli_uart |
+
+The complete list of services, with their order and purpose, is on the @ref services page.
+
+# Boot to running
+
+1. Reset, HAL early init, NVM boot mode check (see @ref hardware).
+2. The scheduler starts. The Init thread runs `furi_hal_init()` and starts every service thread in `order` sequence, then every start-up hook.
+3. The `desktop` service starts the `power_on` application and waits for the mode switch position, which arrives from the Si917 over the intercom. If nothing arrives within 1.5 s the position defaults to BUSY.
+4. The `desktop` service launches the application that belongs to the switch position (see @ref user-interface).
+
+On the Si917 the sequence is the same without the desktop: the services bring up the radio, the input backend, the BLE and Matter stacks, and open their intercom channels.
+
+# Intercom: the U5 to Si917 link
+
+Service: `applications/services/intercom/` (both MCUs, record `intercom`).
+
+## Transport and framing
+
+- UART with hardware RTS/CTS flow control at 11.25 Mbaud, DMA on both sides. U5 USART1, Si917 USART0.
+- Fixed 1024 byte frames: 1 byte channel id, 2 byte data size (0..1019), 1019 bytes of payload, 2 byte CRC. A framing or CRC error is unrecoverable: the intercom logs the error, sets an error status and stops. Only a reset clears it.
+- One transmit buffer, one transmission in flight at a time. A transmission times out after 1 s and sets `IntercomStatusErrorTimeout`.
+
+## Start-up and version check
+
+1. The U5 hard-resets the Si917 (reset line low for 20 ms).
+2. Each side waits up to 2 s for the peer to assert CTS.
+3. Each side sends its control string one character at a time and expects each character echoed back. The control string is the firmware git hash, so images from different commits fail with "Handshake failure, possible version mismatch". The build variable `INTERCOM_FORCE_VERSION=<string>` replaces the hash with a fixed string and disables the check. It is meant for iterating on the U5 firmware without reflashing the Si917 (see @ref build-system).
+4. On success the status becomes `IntercomStatusOk`. A receive thread and a heartbeat thread (one meta frame every 5 s, no timeout logic) start.
+
+Clients subscribe to `intercom_get_state()`, initialize on `IntercomStatusOk` and tear down on any error status. The U5 `supervisor` service reacts to an error status by dumping the logs to `/ext/intercom_failure_log.txt` and rebooting the device after a 30 s grace period, unless the NVM debug flag is set.
+
+## Channels
+
+`intercom_channel_open(channel, callback, context)` registers a receive callback and announces the channel to the peer. `intercom_tx()` blocks until the peer announces the same channel, then sends the buffer in 1019 byte chunks. Receive callbacks run in the intercom receive thread and must copy the data out.
+
+| Channel | Users |
+| --- | --- |
+| `Input` | Button, switch and encoder events from the Si917 |
+| `WifiControl`, `WifiData` | Wi-Fi commands and raw Ethernet frames |
+| `StatusLights` | RGB LED presets and brightness |
+| `Cli` | Remote shell on the Si917 (`sl_cli`) |
+| `Ble` | GATT service and characteristic mirroring |
+| `CryptoBackup` | Raw backup of the crypto key storage |
+| `TlsCrypto` | Certificate retrieval and signing requests |
+| `Matter` | Commissioning, switch state, factory reset |
+| `SlInfo` | Si917 device information dump at start-up |
+| `Debug` | Loopback throughput test (`intercom_test`) |
+
+There is no generic RPC layer and no protobuf on the link. Each channel defines its own C structures in a header shared by both sides. Only the `state_publisher` service uses protobuf (nanopb, `assets/proto`) to serialize device state for WebSocket, BLE and MQTT clients.
+
+## Si917 firmware updates
+
+The Si917 has two images: the M4 application built from this tree, and the NWP radio firmware, a vendor binary. Both are installed by the U5 through the Si917 ROM bootloader over USART2 with the Kermit protocol. See @ref updater.
+
+# Network stack split
+
+There are two independent lwIP instances:
+
+- The **U5** runs IPv4 only, with a DHCP client, a DNS client, IGMP, an mDNS responder and TCP with SACK. It has two network interfaces: `WL` (Wi-Fi) and `EX` (USB CDC-NCM). Mongoose supplies the HTTP server, the MQTT client and the TLS client on top of lwIP sockets.
+- The **Si917** runs IPv6 only, without a socket API. It exists for the Matter node.
+
+On the Si917, the Wi-Fi backend inspects every Ethernet frame from the radio. IPv6 frames go to the local stack. It forwards everything else (IPv4, ARP) verbatim over the `WifiData` intercom channel into the U5 `WL` interface. Outbound frames travel the reverse path. Consequences: the U5 has IPv4 only over Wi-Fi, the `WL` MTU is 1005 bytes so a frame fits one intercom payload, and Matter commissioning is IPv6 "on network" only. See @ref connectivity.
+
+# Security model in one view
+
+| Asset | Where | Protection |
+| --- | --- | --- |
+| TLS device certificate and private key, signing CA | Si917 crypto key storage, slots 0x10 and 0x11 | Wrapped by the Si917 device key when secure boot is on. Signing happens on the Si917. |
+| Matter DAC, PAI, SPAKE2+ verifier, setup codes | Si917 crypto key storage, types 13, 14, 15 | Same |
+| BLE bond (LTK, IRK) | Si917 NVM3 key `0x10001` | Single bonded peer |
+| Wi-Fi passphrase, MQTT account token, HTTP access key, API token hashes | `/ext/apps_data/...` on the eMMC | Clear text (tokens are stored as SHA-256 hashes) |
+| Firmware images | Update bundles | Si917 images signed for secure-boot devices. U5 image unsigned. |
+| HTTP API | Port 80 | Trusted on USB and localhost. Access mode, key or tokens over Wi-Fi. See @ref http-api. |
+| CLI | TCP port 23 | No authentication. USB only unless `sysctl cli_wifi_enabled 1`. |

--- a/documentation/Busy Timer.dox.md
+++ b/documentation/Busy Timer.dox.md
@@ -1,0 +1,86 @@
+# Busy Timer {#busy-timer}
+
+The busy timer is the core product feature. It is a focus timer that shows a status on the front display, mirrors its state to the cloud, and can drive a smart home switch. The code is split into the `busy_timer` service, which owns the model, and the `busy` application, which owns the screens.
+
+# Model: the `busy_timer` service
+
+Service: `applications/services/busy_timer/` (record `busy_timer`, order 190, U5).
+
+## Modes and states
+
+| Mode | Meaning |
+| --- | --- |
+| `Infinite` (shown as "Off") | No countdown. Stays in Work until stopped. |
+| `Simple` | One Work interval of `total_time_ms` |
+| `Interval` | Work and Rest cycles, `cycles_count` times |
+
+States: `Idle`, `Work`, `Rest`. Transitions: Idle to Work on start; Work to Rest while cycles remain, otherwise Work to Idle; Rest to Work. When an interval ends without autostart the timer stops and publishes `IntervalEnded`; with autostart, or on a forced skip, it continues.
+
+Limits: time 5 min to 24 h in 5 min steps, work and rest 5 min to 8 h, cycles 2 to 35. Defaults: 20 min simple, 20/5 min times 3 interval, autostart off.
+
+## Profiles
+
+Two profiles exist, `Busy` and `Custom`. A profile is the timer configuration plus the application configuration (`theme_name`, `is_smart_home_enabled`, `is_show_work_only_enabled`), metadata (`sort_order`, `title`, `card_id`) and a timestamp.
+
+| Profile | Default | Theme | Show work only | Title |
+| --- | --- | --- | --- | --- |
+| `busy` | Interval 20/5 times 3 | `busy` (built in) | No | BUSY |
+| `custom` | Infinite | `keep_out` | Yes | ZEN |
+
+The service stores the profiles in `/ext/apps_data/busy_timer/settings_busy.json` and `settings_custom.json`, and the last snapshot in `state.json`. At boot it restores the snapshot. An active snapshot relaunches the `busy` application in timer mode.
+
+## Ticking
+
+A 33 ms poll timer reads the RTC and advances whole seconds. The timer therefore follows wall-clock time and survives RTC jumps in both directions. Infinite mode does not run the poll timer. `busy_timer_add_time(minutes)` rounds to 5 min multiples and clamps to the limits. The service ignores it while paused. In Infinite mode it converts the timer to Simple with 5 min remaining. A demo mode (visible only with the NVM debug flag) accelerates the countdown.
+
+## API and events
+
+Public API (`busy_timer.h`, synchronous through a 4 deep queue): `start(profile_id)`, `stop`, `toggle` (pause and resume), `skip`, `finalize`, `add_time`, `get_run_info`, `get_snapshot`, `set_snapshot`, `get_profile`, `set_profile`, `get_preset`, `set_preset`, `get_mode_names`.
+
+Events on `busy_timer_get_pubsub()`: `Tick{elapsed, remaining}`, `ModeChanged`, `StateChanged`, `IntervalEnded{is_forced}`, `Paused{is_paused}`, `ProfileChanged{id, profile}`, `SnapshotCreated{snapshot}`.
+
+## Snapshots and cloud sync
+
+A snapshot describes the current run: `type` (`NOT_STARTED`, `INFINITE`, `SIMPLE`, `INTERVAL`), `card_id`, `is_paused`, per-type progress fields, the application configuration and a timestamp. The service captures a snapshot on every start, stop, toggle, skip, finalize and add-time.
+
+Synchronization with the cloud goes over MQTT (see @ref connectivity), all at QoS 1:
+
+| Topic | Direction | Content |
+| --- | --- | --- |
+| `busy/snapshot` | Both | Snapshot JSON, debounced at 250 ms on publish |
+| `busy/profiles/busy`, `busy/profiles/custom` | Both | Profile JSON |
+
+The service ignores incoming snapshots that are older than or equal to the last known one. It accepts incoming profiles only if they are valid and strictly newer. It clamps future timestamps to now. The HTTP API exposes the same JSON on `/api/busy/snapshot` and `/api/busy/profiles/{slot}` (see @ref http-api). A remote start launches the `busy` application with the argument `timer`. The `state_publisher` service also streams both objects to WebSocket, BLE and MQTT clients.
+
+## Smart home coupling
+
+When the running profile has `is_smart_home_enabled`, the Matter On/Off switch mirrors the timer: Work while running is On, everything else is Off. In the other direction, a Matter On from Idle applies the busy profile, forces smart home on for the session, brings the application to the foreground and starts the timer. On while paused resumes. On during Rest skips to Work. Off stops the timer and exits the application.
+
+## Status lights
+
+Work is static red, Rest is static green, Idle, paused and interval-ended turn the lights off.
+
+# Screens: the `busy` application
+
+Application: `applications/main/busy/` (appid `busy`, type `APP`, order 10, 4 KiB stack). The BUSY and CUSTOM switch positions run the same binary. CUSTOM passes the `custom` argument, which selects the `Custom` profile, its header image, start animation and MQTT topic. The `timer` argument (used by remote starts) skips the Start scene and waits for a `ShowTimer` request.
+
+## Scene flow
+
+1. **Start**: the profile logo animation and a two-option animated menu on the front, a Start/Setup menu on the back. Start loads the profile and goes to Overview (Interval mode) or straight to Timer. Setup opens the setup menus. Back does nothing here.
+2. **Setup**: Timer (mode, time, work, rest, cycles, autostart, "Show work phase only", demo mode with the debug flag), Theme (front display theme picker with a live mirror on the back), Smart home (one switch). The scene writes changes back to the profile on exit.
+3. **Overview** (Interval only): shows work and rest minutes, auto-advances after 2.25 s.
+4. **Timer**: the running state. Up and Down add or remove 5 min, OK skips the interval, Start pauses and resumes, Back stops (or resumes when paused). Ticks drive a progress indicator and a countdown label. A tick sound plays at 3 s and a finish sound at 0. The front display shows the theme background (an image or animation) for custom themes and hides the countdown for 15 s out of every 20 s. With "Show work only" the application blanks the front display outside Work. While the timer is active the application raises its loader priority to blocking, which refuses HTTP canvas draws, and pauses automatic firmware updates.
+5. **Progress** (Interval): "done/total" dots for 2 s, then Next.
+6. **Next** (Interval, autostart off): prompts to start the next BUSY or REST interval.
+7. **Ending** (Interval, all cycles done): particle animation and a cycle summary.
+8. **Finish**: confetti and a summary, plays `session_completed.snd`. Start or Back finalizes the timer and returns to Start.
+
+Transitions between scenes use the `transition_overlay` widget with presets such as fade to black, oval mask, press effect and flash.
+
+## Themes
+
+The theme picker lists the built-in `busy` theme plus every directory under `/ext/apps_assets/busy/themes/<name>/theme.json` (`bg_path`, `order`). Shipped themes, in order: `keep_out`, `dnd`, `meeting`, `on_call`, `lunch`, `back_soon`, `booked`, `flow`, `chill_time`, `on_air`, `coding`, `low_social_battery`. Each points at a 72x16 animation in the shared animations directory.
+
+## Cross-thread API
+
+`busy_api.c` exposes `busy_set_config()`, `busy_show_timer()` and `busy_request_exit()` through the record `busy_app`, which exists only while the application runs. The `busy_timer` service uses them (`busy_timer_start_app()`, `busy_timer_exit_app()`) when a remote snapshot or a Matter switch starts or stops the timer. If the application is not running, the service launches it with `desktop_replace_current_app("busy", "timer")`.

--- a/documentation/Command Line Interface.dox.md
+++ b/documentation/Command Line Interface.dox.md
@@ -1,0 +1,136 @@
+# Command Line Interface {#cli}
+
+Both MCUs run a command shell built on `lib/cli`. This page lists the transports and every command. Commands marked **U5** exist on the main MCU, commands marked **Si917** on the wireless co-processor and reachable through `sl_cli`.
+
+# Transports
+
+| Transport | MCU | How |
+| --- | --- | --- |
+| TCP socket (telnet style) | U5 | The `cli_socket` start-up hook listens on port 23 on every interface. Connections over the USB network are always accepted. The hook refuses connections over Wi-Fi unless `sysctl cli_wifi_enabled 1` was set. Each connection gets its own shell thread. This is the primary developer CLI: `telnet 10.0.4.20 23`. |
+| Intercom | Both | The U5 command `sl_cli` spawns a shell on the Si917 and relays bytes in both directions over the `Cli` intercom channel. Only one session at a time. |
+| UART1 | Si917 | The `cli_uart` service opens UART1 at 230400 baud. Only in the `hwtest` application set. |
+
+There is no USB CDC shell. `cdc_echo` and `cdc_screen` under `applications/services/` are unused test services.
+
+The U5 debug log console is a separate UART (USART6, 230400 baud) and is read-only. The `log` command streams the same output over the CLI.
+
+# Library
+
+`lib/cli/`:
+
+- `CliRegistry`: a mutex protected dictionary of commands. `cli_registry_add_command(registry, name, flags, callback, context)` with a default 4 KiB command stack, or `_ex` with an explicit size. The `cli_on_system_start` hook publishes the main registry as `RECORD_CLI` and adds every `CLICMD` manifest entry.
+- Command flags: `ParallelUnsafe`, `InsomniaSafe`, `DontAttachStdio`, `UseShellThread`, `Exclusive` (one instance at a time).
+- Callback signature: `void (*)(PipeSide* pipe, FuriString* args, void* context)`. The pipe is installed as the command thread's stdio, so `printf` and `getchar` work. `cli_is_pipe_broken_or_is_etx_next_char()` detects Ctrl+C.
+- `args.h`: helpers to read integers, strings and quoted strings from the argument string.
+- `cli_status.h`: commands print `RET: 0` (`CLI_STATUS_OK`) or `RET: 1` (`CLI_STATUS_ERROR`) so scripts can parse the result.
+- The shell (`shell/`) implements line editing, history, completion, `help`, `?` and `exit`.
+
+On the U5 the `gpio` and `otp` commands exist only while the NVM debug flag is set (`sysctl debug 1`).
+
+# Command reference
+
+## Shell and diagnostics
+
+| Command | MCU | Description |
+| --- | --- | --- |
+| `help`, `?` | Both | List commands |
+| `exit` | Both | Close the session |
+| `uptime` | Both | Print uptime |
+| `log [error, warn, info, default, debug, trace, ?]` | Both | Stream the log to the session until Ctrl+C, with an optional temporary level |
+| `top [interval_ms]` | Both | Thread table: application id, name, state, priority, stack, heap, CPU share. `0` prints once. |
+| `free`, `free_blocks` | Both | Heap statistics, free block dump |
+| `echo <text>` | Both | Print the arguments |
+| `device_info` | Both | All device information pairs (firmware version, target, hashes, MACs, security bits, name) |
+| `log_dump [-h] [path]` | U5 | Write device information plus the U5 and Si917 log rings to `/ext/log.txt` or the given path |
+| `sl_cli` | U5 | Interactive shell on the Si917 |
+| `crash` | Si917 | Crash on purpose (only in the `917_crash` application set) |
+
+## System control
+
+| Command | MCU | Description |
+| --- | --- | --- |
+| `sysctl debug <1 or 0>` | U5 | Set the NVM debug flag ("Dev mode"). Enables the debug applications menu, the update channel selector, demo mode, `gpio` and `otp`, and suppresses the automatic reboot on intercom failure. |
+| `sysctl ui_debug <0, 1, 2>` | U5 | Draw widget bounding boxes on the main layer or all layers, after restart |
+| `sysctl cli_wifi_enabled <1 or 0>` | U5 | Allow the CLI socket over Wi-Fi |
+| `sysctl websrv_accesslog_level <0..3>` | U5 | Web server access log verbosity |
+| `sysctl storage_bkp_unlock <1 or 0>` | U5 | Make `/bkp` writable (debug flag only) |
+| `power info` | U5 | Charger and battery readings |
+| `power off` | U5 | Power off (refused while USB is connected) |
+| `power reboot [sw, hw, u5, 917]` | U5 | Reboot both MCUs, hardware reset through the charger, or one MCU only |
+| `power boot <u5 or 917>` | U5 | Reboot into the DFU bootloader of the given MCU |
+| `power ch <1 or 0>`, `power ch_limit <pct>`, `power ch_current <mA>` | U5 | Charger enable, charge limit (50..100, or 30..100 with the debug flag), charge current (1..1500) |
+| `power pd_info`, `power pd_set <mV>` | U5 | USB-PD status, request a voltage |
+| `date [iso8601]` | U5 | Read or set the RTC (input is UTC) |
+| `timezone [name]` | U5 | Read or set the time zone |
+| `gpio <pin_name> <0 or 1>` | U5 | Set a named GPIO (debug flag only) |
+| `otp <dump or program> <OTP1..OTP4> [hex]` | U5 | Dump or irreversibly program an OTP block (debug flag only) |
+| `factory_reset [-s]` | U5 | Factory reset after a y/n prompt. `-s` also enters shipping mode. |
+
+## Storage and files
+
+| Command | MCU | Description |
+| --- | --- | --- |
+| `storage list <path>`, `tree`, `stat`, `info`, `timestamp` | U5 | Inspect files and filesystems. Paths must start with `/ext` or `/bkp`. |
+| `storage read <path>`, `write <path>`, `read_chunks <path> <n>`, `write_chunk <path> <n>` | U5 | Text and binary transfer (`write` reads until Ctrl+C) |
+| `storage copy`, `rename`, `remove`, `mkdir`, `md5` | U5 | File operations |
+| `storage extract <tar> <dst>` | U5 | Unpack a tar archive |
+| `storage format <path>` | U5 | Format the partition that owns the path |
+| `storage mkfs /` | U5 | Repartition and format both partitions (debug builds with the debug flag) |
+| `tar <c or x> <archive> <directory>` | U5 | Create or extract an archive under `/ext` or `/bkp` |
+| `storage_benchmark` | U5 | Throughput test (debug application set) |
+
+`scripts/storage.py` and `scripts/flipper/storage_socket.py` drive these commands to transfer whole directories from a host.
+
+## User interface and media
+
+| Command | MCU | Description |
+| --- | --- | --- |
+| `loader open <name>`, `loader kill` | U5 | Start or stop an application by name or id |
+| `input send <key> <type>`, `input dump` | U5 | Inject an input event, or print events as they arrive |
+| `display show <front or back> <file>` | U5 | Load an image onto a display |
+| `display brightness <0..100 or auto>` | U5 | Set brightness |
+| `display gamma back <max> <gamma>` | U5 | Back display gamma table |
+| `light_sensor` | U5 | Raw sensor channels and lux |
+| `audio start <path>`, `audio stop` | U5 | Play or stop a `.snd` file |
+| `fontstat` | U5 | Font cache statistics |
+| `status_lights <r> <g> <b>` | Si917 | Set the RGB LED |
+
+## Network and cloud
+
+| Command | MCU | Description |
+| --- | --- | --- |
+| `netstat` | U5 | Dump lwIP TCP control blocks |
+| `fetch [options] <url>` | U5 | HTTP client: `-o` output file, `-d` body, `-H` header, `-X` method, `-k` ignore the server certificate, `-a none/device/cert` client authentication, `-C` and `-K` custom certificate and key, `-v` verbose |
+| `matter` | U5 | Sub-shell: `switch on/off`, `startup off/on/toggle/last`, `reset`, `comm`, `fabrics`, `cert <production, development, certification>` |
+| `tls_crypto_test` | U5 | Stress the Si917 signer |
+| `wifi_cli_test <wifi_init [mode], wifi_deinit, wifi_scan>` | Si917 | Silicon Labs console commands for the radio |
+
+## Update
+
+| Command | MCU | Description |
+| --- | --- | --- |
+| `update install <manifest>` | U5 | Prepare and apply an unpacked bundle |
+| `update install_tar <tar>` | U5 | Unpack, prepare and apply |
+| `update install_web <url>` | U5 | Download, unpack, prepare and apply |
+| `update 917 <rps>`, `update 917_ta <rps>` | U5 | Flash the Si917 application or radio image directly |
+| `update 917_probe` | U5 | Print the Si917 bootloader version (debug flag only) |
+
+## Keys and crypto
+
+| Command | MCU | Description |
+| --- | --- | --- |
+| `crypto init`, `list <partition>`, `read`, `write`, `gen`, `gen_csr`, `wipe`, `protect <0 or 1>`, `dump` | Si917 | Manage the crypto key storage. Partition 0 is `Main`, 1 is `User`. See @ref connectivity. |
+| `crypto_backup create`, `remove`, `restore`, `verify` | U5 | Raw backup of the key storage to `/bkp/crypto_backup.bin` |
+| `crypto_test` | Si917 | Sub-shell: `aes`, `ecdsa`, `hmac`, `sha`, `mbedtls_edsa`, `csr`, `aes_vectors` |
+| `nvm_test` | Si917 | Sub-shell: `read`, `write`, `del`, `test`, `erase`, `purge` against NVM3 |
+
+## JavaScript and tests
+
+| Command | MCU | Description |
+| --- | --- | --- |
+| `js [-i app_id] [file]` | U5 | Run a script or open a REPL. `js -k` aborts the running script. See @ref javascript-applications. |
+| `unit_tests` | U5 | Run the minunit suites (`unit_tests` application set) |
+
+# Host tooling
+
+`scripts/testops.py` wraps the CLI and the HTTP API for CI: `wait`, `get-version`, `power`, `input`, `device_info`, `sanity`, `uptime`, `debug`, `format`, `update-fw`, `update-bundle`, `unit-tests`. `scripts/update.py` and `scripts/storage.py` use the socket on port 23. See @ref tooling-tests-ci.

--- a/documentation/Connectivity.dox.md
+++ b/documentation/Connectivity.dox.md
@@ -1,0 +1,211 @@
+# Connectivity {#connectivity}
+
+This page covers Wi-Fi, BLE, the cloud link over MQTT, Matter, the USB network, service discovery, and the TLS and key storage that these rely on. The @ref architecture page describes the split of work between the two MCUs and the intercom link. The HTTP API has its own page, @ref http-api.
+
+# Wi-Fi
+
+Service: `applications/services/wifi/` (record `wifi` on both MCUs, order 110).
+
+## Roles
+
+- The **Si917** does association: `sl_net` client mode, 2.4 GHz, WPA, WPA2 and WPA3 personal (PSK). The backend reports Enterprise modes as unsupported. The NWP reconnects on its own after a beacon loss. The backend reports `Connected`, `Reconnecting` and `Disconnected` to the U5. While associated it polls link statistics (BSSID, RSSI, channel) every 15 s.
+- The **U5** owns the IPv4 stack, DHCP, the saved network and the public API. Raw Ethernet frames cross the intercom `WifiData` channel and enter the `WL` lwIP interface, whose MTU is 1005 bytes. IPv6 frames stay on the Si917 for Matter.
+
+There is no access point mode and no captive portal in the production firmware. Provisioning happens from a PC over USB or from the phone application over BLE, both through the HTTP API. `applications/services/wifi_test/` contains stand-alone Si917 demos that are not part of the normal build.
+
+## API and state machine
+
+`wifi.h`: `wifi_get_state()` returns a `FuriState` of `WifiInfo{ssid, bssid, rssi, channel, security_mode, ip_config, state}`. `wifi_scan()` (only when disconnected, up to 28 results), `wifi_connect(credentials, ip_config)`, `wifi_disconnect()`, `wifi_forget()` (only when disconnected). The service runs one call at a time.
+
+States: `Unknown` (before the intercom is up), `Disconnected`, `Connecting`, `Connected`, `Reconnecting`, `Disconnecting`. Status codes: `Ok`, `Error`, `Timeout`, `AlreadyConnected`, `AlreadyDisconnected`, `ScanNotPossible`, `AccessPointNotFound`, `AuthenticationFailed`, `ConfigurationFailed` (DHCP failure after a 30 s wait).
+
+Connect flow: the credentials go to the Si917. On success the `WL` interface comes up with a static configuration or a DHCP client. Once the interface has an address, the state becomes `Connected` and the service saves the settings. The DHCP hostname is `BUSY Bar` or `BUSY Bar <device name>`. On `PowerEventShutdown` the service disconnects synchronously.
+
+## Saved network
+
+The service stores one network in `/ext/apps_data/wifi/settings.json` (see @ref storage-and-settings), with the passphrase in clear text. `wifi_forget()` resets the file. On boot, a saved SSID triggers an automatic connect.
+
+Consumers of the Wi-Fi state: MQTT (connects only when `Connected`), discovery, the DNS forwarder, the web server, the time service (SNTP on connect) and the Wi-Fi settings application.
+
+# Bluetooth Low Energy
+
+Service: `applications/services/ble/` (record `ble` on both MCUs, order 140).
+
+## Architecture
+
+The GATT server runs on the Si917 (WiSeConnect `rsi_ble_*` APIs). The U5 owns the characteristic content, the on/off policy and the two bridges described below. Both sides compile the same service table. The intercom `Ble` channel mirrors characteristic data with a small command protocol (`Init`, `Deinit`, `Enable`, `Disable`, `GetStatus`, `SetStatus`, `ForgetPairing`, plus per-service `Init`, `Run`, `Update`).
+
+Status (`BleServiceStatus`): `Reset`, `Initialization`, `Ready`, `Advertising` (enabled, not paired, visible to all), `Connectable` (enabled, paired, only the bonded peer can connect), `Connected`, `Error`. The service publishes the state on `ble_get_pubsub()`.
+
+## GATT services
+
+| Service | UUID | Characteristics |
+| --- | --- | --- |
+| Generic Access | 0x1800 | Device Name (from the `device_name` service, live), Appearance |
+| Generic Attribute | 0x1801 | Standard |
+| Device Information | 0x180A | Serial Number (hardware UID), Hardware Revision (target), Software Revision (commit) |
+| Battery | 0x180F | Battery Level from the power service |
+| Nordic UART (NUS) | 6E400001-B5A3-F393-E0A9-E50E24DCCA9E | RX (write), TX (read, indicate), Session counter (read, write) |
+| HM-10 UART | 0000FFE0-0000-1000-8000-00805F9B34FB | RX (read, write), TX (read, notify) |
+
+The MTU is 240, so the service splits payloads into 237 byte chunks. Advertising uses the extended API with a legacy PDU, service UUID `0x308A`, manufacturer id `0x0E29` and the local name in the scan response. Once paired, the device advertises with a resolvable private address, an accept list holding the bonded peer, and no name or manufacturer data.
+
+## Pairing and bonding
+
+Pairing is LE Secure Connections "Just Works" (no input, no output). The service supports **one bonded peer** only. It refuses a pairing request from a second device until the first bond is forgotten. It stores the keys (LTK, IRK) in Si917 NVM3 key `0x10001`. `ble_forget()` removes the bond, regenerates the IRK and returns to open advertising. After a connection the stack negotiates 2M PHY and data length extension.
+
+## What the mobile application does over BLE
+
+1. **HTTP over NUS** (`http/ble_http_repeater.c`). The U5 forwards bytes written to NUS RX into a TCP connection to `http://127.0.0.1:80`. It indicates the response back on NUS TX. The Session characteristic counts connections; writing 0 resets it. The phone therefore uses the same REST API as over USB or Wi-Fi. Because the source is localhost, it needs no API token. This is the Wi-Fi provisioning path.
+2. **State streaming over HM-10** (`streaming/ble_streaming.c`). While connected, the U5 registers a BLE transport with the `state_publisher` service and notifies protobuf state frames, chunked with a `{num, count, size}` header, rate limited between 1 s and 5 s per frame.
+
+## Settings and API
+
+`/ext/apps_data/ble/settings.json` holds `enabled` (default false), updated on every successful enable or disable so the state persists across reboots. HTTP: `/api/ble/enable`, `/api/ble/disable`, `/api/ble/status`, `DELETE /api/ble/pairing`. The Bluetooth settings application starts a 5 minute pairing window. The service registers no CLI command.
+
+# MQTT and the BUSY account
+
+Service: `applications/services/mqtt/` (record `mqtt`, order 160, U5). Built on the Mongoose MQTT 5 client.
+
+## Connection
+
+| Property | Value |
+| --- | --- |
+| Broker | `mqtts://mqtt.busy.app:8883` when the configured URL is `default` |
+| Protocol | MQTT 5, clean session, keep-alive ping every 10 min |
+| Client id | `busybar-<16 hex>`, random, regenerated on unlink |
+| Username | `BusyBar device <serial hex>` |
+| Password | The account token (empty when not linked) |
+| TLS | Server verified against the CA bundle. Mutual TLS with the device certificate from the Si917 key storage (`client_cert_type` `default`), custom PEM files under `/ext/apps_assets/mqtt/` (`custom`), or none. |
+| Last will | `{"status":"offline"}` on the presence topic |
+| Reconnect | Exponential backoff 2 s to 60 s, only while Wi-Fi is connected |
+
+Status: `Error`, `NotConnected`, `ConnectedNotLinked`, `ConnectedLinked`. A `Not authorized` reply to a subscription while linked wipes the saved account (token revoked).
+
+## Topics
+
+Layout: `<root>/<id>/<dir>/v1/<topic>`, where root and id are `devices/<serial>` (device scope) or `sessions/<session_id>` (session scope, available only when linked), and dir is `up` for publish and `down` for subscribe.
+
+| Scope | Direction | Topic | Content |
+| --- | --- | --- | --- |
+| device | up | `presence` | `{"firmware_version","api_version","status":"online"}` |
+| device | up | `link/request` | Asks for a linking PIN |
+| device | down | `link/otp` | `{"code":"1234","expires_at":N}` |
+| device | down | `link/token` | `{"session_id","token","email","user_id"}` |
+| session | up | `unlink` | Sent when the user unlinks on the device |
+| session | down | `gone` | The cloud unlinked the device |
+| session | down | `http-request` | Raw HTTP request text with a response topic and correlation data |
+| session | down | `stream-request` | `{"message_limits":{"max_count":N,"interval_s":S}}` |
+| session | up | `busy/snapshot`, `busy/profiles/busy`, `busy/profiles/custom` | Busy timer state and profiles, see @ref busy-timer |
+| session | up | `state` | `{"name":"..."}` when the device name changes |
+
+`mqtt_publish()` and `mqtt_subscribe()` work only in session scope. Supported MQTT 5 properties: expiry interval, response topic, correlation data.
+
+## Modules
+
+- **HTTP proxy** (`modules/mqtt_http_proxy.c`): the module parses each `http-request` message, replays it to `http://127.0.0.1` with a 5 s timeout, and publishes the full response to the response topic. Requests must target `/api/`, must not be WebSocket upgrades, and a block list refuses `POST update`, `DELETE account`, `POST account/link`, `PUT account/backend`, `POST wifi/connect`, `POST wifi/disconnect` and `GET wifi/networks`.
+- **State streaming** (`modules/mqtt_streaming.c`): a `stream-request` starts or reconfigures a `state_publisher` transport with the given rate limit and a 60 s default expiry. The module publishes frames at QoS 0 to the response topic.
+
+## Account linking
+
+1. The device is connected to Wi-Fi and to the broker (`ConnectedNotLinked`).
+2. The user opens Settings, Account, or a client calls `POST /api/account/link`. The device publishes `link/request`.
+3. The cloud answers on `link/otp` with a 4 digit PIN and its expiry. The device shows the PIN. The user enters it at `cloud.busy.app`.
+4. The cloud publishes `link/token`. The device stores the session, user, email and token in `/ext/apps_data/mqtt/state.json`, reconnects with the token as password, and reaches `ConnectedLinked`.
+5. Unlinking from the device publishes `unlink` and wipes the state. Unlinking from the cloud arrives as `gone`.
+
+Events: `StatusChanged`, `LinkPinReceived`, `LinkDone`, `Unlinked`. The @ref http-api page lists the endpoints under `/api/account`.
+
+# Matter
+
+Service: `applications/services/matter/` (Si917 half `matter_f64.cpp`, order 200; U5 half `matter.c`, order 250, record `matter`). SDK: `lib/matter_ext` (Silicon Labs Matter extension), ZAP generated clusters in `lib/matter_zap`, platform glue in `lib/matter_glue/platform/bsb/`.
+
+## What is exposed
+
+- One endpoint (id 1) with the **On/Off** cluster (including `StartUpOnOff`) and the **Identify** cluster (the status lights blink amber). Vendor id `0x158A` (Flipper FZCO), product id `0xBB01`, product name `BUSY Bar`.
+- Commissioning is **on network over IPv6 only**. BLE commissioning is compiled out. The Si917 lwIP instance and the CHIP DNS-SD (`_matterc._udp`, `_matter._tcp`) serve it.
+- The U5 sees the switch state as a `FuriState` (`matter_get_switch_state()`). The U5 can set it, set the start-up mode (`off`, `on`, `toggle`, `last`), open a commissioning window, factory reset, and read the fabric count.
+
+## Commissioning flow
+
+1. The settings application (Settings, Smart home, Pair device), the `matter comm` CLI command, or `POST /api/smart_home/pairing` calls `matter_enable_commissioning()`. The UI first checks that Wi-Fi is connected.
+2. The Si917 opens a basic commissioning window for 15 minutes and returns the QR payload and the manual pairing code. The back display shows the QR code, the status lights blink white, the front display says "Look at back screen".
+3. The commissioner discovers the node over mDNS, runs PASE with the SPAKE2+ verifier from the key storage, device attestation with the DAC, PAI and Certification Declaration, then CASE.
+4. Status events (`Started`, `Complete`, `Failed`) update the UI. Fabrics persist in Si917 NVM3 in the reserved key range starting at `0x87000`.
+
+A factory reset (`DELETE /api/smart_home/pairing`, `matter reset`, or the device factory reset) wipes the fabrics and reboots the device.
+
+## Credentials
+
+| Item | Location |
+| --- | --- |
+| DAC private key (wrapped when secure boot is on), DAC, PAI | Si917 crypto storage, type `MatterAttestation` (13), ids 0, 1, 2 |
+| SPAKE2+ salt, verifier, iteration count, discriminator, passcode | Type `MatterSetup` (14), ids 0..4. Read-only at run time. |
+| Vendor and product ids and names, part number, URL, serial, manufacturing date | Type `MatterDeviceInfo` (15) |
+| Certification Declaration | `/ext/apps_assets/matter/cd-production.der`, `cd-dev.der`, `cd-certification.der`, selected by `/ext/apps_data/matter/cd_selection.txt` (takes effect after reboot) |
+
+`scripts/matter_provision.py` writes these during manufacturing (see Provisioning below). The hardware version comes from OTP; unprovisioned lab samples are reported as version `4.F22.B7.C2` by a workaround in `matter.c`.
+
+CLI: `matter` opens a sub-shell with `switch`, `startup`, `reset`, `comm`, `fabrics` and `cert`.
+
+# USB network
+
+Service: `applications/services/usb_network/` (`usb_srv`, order 20, record `usb_network`, U5).
+
+- Class: **CDC-NCM** only. VID `0x37C1`, PID `0x6213`, product string `BUSY Bar USB Ethernet`. MS OS 2.0 descriptors make Windows bind its inbox NCM driver.
+- lwIP interface `EX` with a MAC derived from the OTP USB MAC (last byte XOR 1 on the device side).
+- Static device address `10.0.4.20/24` by default, from `/ext/apps_data/usb_srv/settings.json`. A minimal DHCP server (`lib/network/dhserver`, 3 leases, no router or DNS) assigns the host an address on the same subnet.
+- Reachable over USB: the HTTP API and web UI on port 80, the CLI on TCP port 23, mDNS. The HTTP API trusts requests that arrive on this interface (see @ref http-api).
+
+State: `UsbNetworkInfo{state Unknown, Down, Up}` via `usb_network_get_state()`.
+
+# Discovery (mDNS)
+
+Service: `applications/services/discovery/` (order 165, U5). The lwIP mDNS responder announces the hostname `<device name>.local` with all non-alphanumeric characters removed and lower cased, so the default name becomes `busybar.local`. The `EX` interface is added when USB comes up, `WL` when Wi-Fi connects, and a rename re-announces. The only registered service is the web server: `_http._tcp` on port 80 with TXT records `path=/` and `name=<device name>`.
+
+# TLS, keys and certificates
+
+## Si917 crypto storage
+
+`targets/f64/furi_hal/furi_hal_crypto_storage.h`: a 20 KiB region in NWP managed common flash, split into a 16 KiB `Main` partition and a 4 KiB `User` partition. Each slot has a header with magic, size, type, flags, id and CRC32. Key types: AES 128/192/256, HMAC SHA1/256/384/512, ECDSA private and public keys for P-224 and P-256, `CsrDerEcdsa256`, `CrtDerEcdsa256`, `MatterAttestation`, `MatterSetup`, `MatterDeviceInfo`. The `Wrap` flag stores a private key wrapped with the Si917 device key. A wrapped key can sign, but nothing can read it out. Wrapping requires secure boot. NVM3 key `0x10002` persists a read-only access mode.
+
+The Si917 CLI command `crypto` (reachable from the U5 through `sl_cli`) manages the slots: `list`, `read`, `write`, `gen` (on-device key generation), `gen_csr` (P-256 key pair plus a DER CSR generated on the device), `wipe`, `protect`. `crypto_backup` on the U5 can `create`, `restore`, `verify` and `remove` a raw copy of the region at `/bkp/crypto_backup.bin`, through the `CryptoBackup` intercom channel, with an enclave self-test after restore.
+
+## tls_crypto service
+
+The Si917 serves the U5 calls `tls_crypto_get_certificate(key_id)` and `tls_crypto_sign(key_id, message)` over the `TlsCrypto` channel. Key id 0 is the signing CA certificate (slot `0x10`), key id 1 is the device certificate and private key (slot `0x11`). Signing is ECDSA-SHA256 in hardware. Limits: 800 byte messages and certificates, 80 byte signatures, one request at a time. The Si917 `supervisor` service signs random data once per second as a health check and crashes after more than 10 consecutive failures.
+
+## TLS client
+
+`targets/f21/mongoose/mongoose_tls.c` implements TLS for every outbound connection (MQTT, the `fetch` HTTP client used by the updater and the `fetch` CLI command, JavaScript `fetch`):
+
+- Mbed TLS 3.x with PSA, TLS 1.2 and 1.3, ECDHE with P-256, P-384, P-521 and X25519, AES-GCM and AES-CCM, SNI from the URL, hostname verification. The RNG is the hardware RNG.
+- Server verification against the CA chain from `ca_storage` unless the caller sets `is_server_cert_ignored`.
+- Client certificates (`TlsClientCertType`): `None`, `Device` (certificates fetched from the Si917, and a patched `mbedtls_pk_info_t` hook forwards the CertificateVerify signature to the Si917), `Custom` (PEM files). The patches live in `lib/mbedtls_patch/`.
+
+`ca_storage` (start-up hook) parses `/ext/apps_assets/shared/ca/cacert.pem` once at boot. `./fbt update_cacert` refreshes the bundle.
+
+## Provisioning
+
+The host scripts drive the Si917 `crypto` CLI through the U5 CLI on `10.0.4.20:23`:
+
+| Script | Purpose |
+| --- | --- |
+| `scripts/matter_provision.py` | Wipes the `Main` partition, writes the DAC key (wrapped unless `--insecure-crypto`), DAC, PAI, SPAKE2+ values and device information. Test certificates come from `scripts/test_certs/matter/`. |
+| `scripts/mqtt_provision.py` | On-device CSR (`gen_csr`), signed by the local test CA in `scripts/test_certs/mqtt/`, written to slots `0x10` and `0x11`. Refuses to overwrite occupied slots. |
+| `scripts/vault_provision.py` | Same slots, but the CSR is signed by a HashiCorp Vault intermediate PKI. |
+| `scripts/credentials.py`, `scripts/crypto_storage.py` | Lower level primitives |
+
+`./fbt crypto_provision` runs the Matter and MQTT scripts in order (Matter first, because it wipes the partition) and adds `--insecure-crypto` when `SIL917_INSECURE=True`, which is the default for lab devices without secure boot.
+
+# Time synchronization
+
+The `time` service (record `time`, order 150) keeps the RTC in sync with SNTP through Mongoose. Sync runs 300 s after boot, again when Wi-Fi connects, every 3 h after a success and every 10 min after a failure. The server, intervals, time zone (a `utz` zone name) and 12 h or 24 h format are settings (see @ref storage-and-settings). The API offers `time_get_timestamp()`, `time_get_local_time()` and `time_set_settings()`. CLI: `date [iso8601]`, `timezone [name]`. There is no RTC alarm API.
+
+# Known limitations
+
+- The eMMC holds Wi-Fi passphrases, MQTT account tokens and the HTTP access key in clear text.
+- The CLI socket on port 23 has no authentication. Only the network interface origin guards it.
+- The intercom does not recover from framing or timeout errors without a reset.
+- USB-origin HTTP requests bypass authentication by design, and the BLE tunnel inherits the localhost exemption. BLE pairing is the effective access control for the mobile application.
+- Nothing can rotate the Matter setup codes at run time.

--- a/documentation/Contributing.dox.md
+++ b/documentation/Contributing.dox.md
@@ -4,3 +4,4 @@ Instructions on contributing to the @bsb project.
 
 - @subpage code-style -- Keeping the code neat and organised
 - @subpage docs-howto -- Adding, improving and changing documentation
+- @subpage tooling-tests-ci -- Host scripts, the device test suite and the CI workflows

--- a/documentation/Firmware.dox.md
+++ b/documentation/Firmware.dox.md
@@ -1,9 +1,38 @@
 # Firmware {#firmware}
 
-This is a stub page about the firmware.
+The firmware runs on two microcontrollers (see @ref hardware): the STM32U5 main MCU and the SiWG917 wireless co-processor. Both are built from this tree on the same FreeRTOS based runtime. The user facing functionality is split into applications and services (see @ref concepts). The pages below describe each subsystem.
 
-This page must be expanded with the info on the following:
+- @subpage architecture -- The two MCUs, the runtime, the service model, the intercom link and the network stack split
+- @subpage storage-and-settings -- Partitions, path aliases, the settings library and every settings file
+- @subpage user-interface -- Displays, GUI framework, input, desktop and loader, animations, status indicators, brightness, audio, assets
+- @subpage busy-timer -- The timer model, cloud synchronization, smart home coupling and the screens
+- @subpage connectivity -- Wi-Fi, BLE, MQTT and the cloud account, Matter, USB network, mDNS, TLS and key storage
+- @subpage http-api -- Server, access control and the complete endpoint catalogue
+- @subpage cli -- Transports and every command
+- @subpage updater -- Bundle format, update flow, recovery and factory reset
+- @subpage file_formats -- The animation file format
 
-- Cross-references with @ref concepts
-- Cross-references to APIs (feat. generated pages)
-- Programming examples
+# Feature map
+
+| Feature | Where it lives |
+| --- | --- |
+| Focus timer with themes, sounds and status lights | `applications/main/busy`, `applications/services/busy_timer` |
+| Clock | `applications/main/clock` |
+| Settings menu and settings screens | `applications/main/settings_menu`, `applications/settings/*` |
+| Two displays and the widget toolkit | `applications/services/gui`, `front_display`, `back_display`, `lib/lvgl_addons` |
+| Animations | `lib/anim_file`, `scripts/seq2anim.py` |
+| Buttons, mode switch, encoder | `applications/services/input` (both MCUs) |
+| Power, charging, USB-PD | `applications/services/power` |
+| Wi-Fi | `applications/services/wifi` (both MCUs) |
+| BLE with an HTTP tunnel for the mobile application | `applications/services/ble` (both MCUs) |
+| Cloud account over MQTT with mutual TLS | `applications/services/mqtt`, `tls_crypto`, `ca_storage` |
+| Matter On/Off device | `applications/services/matter` (both MCUs), `lib/matter_glue` |
+| USB virtual Ethernet | `applications/services/usb_network` |
+| HTTP API, web UI, OpenAPI | `applications/services/web_server`, `assets/frontend` |
+| Remote drawing on the displays | `applications/services/canvas` |
+| State streaming (WebSocket, BLE, MQTT) | `applications/services/state_publisher`, `assets/proto` |
+| JavaScript applications | `applications/services/js_runner`, `applications/system/js_app_launcher`, `lib/js_app` |
+| Firmware updates, recovery, factory reset | `applications/system/updater`, `lib/toolbox/update_lib` |
+| Command line interface | `lib/cli`, `applications/services/cli_*` |
+| Secure key storage and provisioning | `targets/f64/furi_hal/furi_hal_crypto_storage.c`, `applications/system/crypto`, `scripts/*_provision.py` |
+| Logging, diagnostics, fault handling | `applications/services/log_storage`, `supervisor`, `device_info` |

--- a/documentation/HTTP API.dox.md
+++ b/documentation/HTTP API.dox.md
@@ -1,0 +1,291 @@
+# HTTP API {#http-api}
+
+The @bsb exposes a plain HTTP API on TCP port 80. The same API serves the built-in web UI, the desktop and mobile apps, host-side scripts and JavaScript applications running on the device. This page describes the server, the access control model and every endpoint as implemented in `applications/services/web_server/`.
+
+The public, user-facing version of this reference lives at [docs.busy.app](https://docs.busy.app/bar/dev/http-api). The device also serves its own OpenAPI document at `/openapi.yaml` and a Swagger UI at `/docs/`.
+
+# Server
+
+| Property | Value |
+| --- | --- |
+| Implementation | Mongoose HTTP server on lwIP sockets, one poll thread (`web_server.c`) |
+| Listener | `http://0.0.0.0`, port 80, all interfaces (USB network and Wi-Fi) |
+| TLS | None. Mbed TLS is linked only for outbound client connections. |
+| API version | `27.7.0` (`http_api/http_api.h`, mirrored in `openapi/openapi.yaml`) |
+| USB address | `10.0.4.20` by default (see @ref connectivity) |
+| mDNS | `_http._tcp` on port 80, instance `busybar-<usb mac>`, TXT `path=/`, `name=<device name>` |
+| Static root | `/ext/apps_assets/web_server/www` (the built web UI, gzip-only assets) |
+
+Routing is prefix based. The `/api` handler table (`http_api/api_root.c`) dispatches to one file per area: `version`, `transport`, `assets`, `storage`, `display`, `audio`, `input`, `status`, `status/ws`, `wifi`, `update`, `screen`, `ble`, `time`, `name`, `log_dump`, `account`, `busy`, `smart_home`. The root handler serves `access` and `access/tokens` directly. Any path under `/api` that no handler accepts returns 400. The static root serves any other path, and a missing file renders `404.html`.
+
+The server processes requests in two phases. Access control and API version checks run when the headers arrive, before the body is read. A rejected request receives 403 and the connection closes. Upload endpoints take over the raw socket at this point and stream the body straight to storage.
+
+## Limits
+
+| Limit | Value |
+| --- | --- |
+| Request body for JSON endpoints | 256 KiB (Mongoose receive buffer) |
+| Update bundle upload | 100 MiB, 413 above |
+| Storage and asset upload | No explicit cap. Limited by free space. |
+| Upload idle timeout | 3 s for storage and assets, 5 s for update. Returns 408. |
+| Overload shedding | Any monitored lwIP pool at 85% or more returns 508 and closes the connection |
+| Status WebSocket clients | 4. A fifth client receives a protobuf error frame and is closed. |
+| Status WebSocket rate | 11 messages per second per client |
+| Canvas elements per draw | 100 |
+| Wi-Fi scan results | 20 |
+
+There is no per-client request rate limiter.
+
+## Response conventions
+
+- Success replies `{"result":"OK"}` unless the endpoint documents a body.
+- Errors reply `{"error":"<message>"}`. The update install endpoint adds `error_code`.
+- Every response carries `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Headers: *`. An `OPTIONS` request that does not match a handler method receives a CORS preflight reply with the allowed methods. Preflights bypass access control.
+- Status codes in use: 200, 400, 403, 404, 405, 406, 408, 409, 410, 413, 503, 508.
+
+## Access log
+
+The access log format is nginx style. The CLI command sets the verbosity: `sysctl websrv_accesslog_level N`
+
+| Level | Content |
+| --- | --- |
+| 0 (default) | Requests with status 400 or higher |
+| 1 | All requests, plus the `x-request-id` or `x-trace-id` header when present |
+| 2 | Adds the user agent |
+| 3 | Adds a local timestamp |
+
+# Access control
+
+The access check (`api_root.c`, `http_api_access_status()`) runs for every `/api` request in this order:
+
+1. `OPTIONS` requests are always allowed.
+2. `GET /api/version`, `GET /api/access` and `GET /api/transport` are always allowed.
+3. Requests from `127.0.0.1` are always allowed. This is the path used by JavaScript applications, the BLE HTTP tunnel and the MQTT HTTP proxy.
+4. If the connection did not arrive on the USB network interface, the persisted access mode applies: `disabled` rejects, `enabled` accepts everyone, `key` continues to the credential check.
+5. The server reads a credential from the `X-API-Token` header, or from the `x-api-token` query parameter for WebSocket upgrades. It accepts the credential if it equals the configured access key, or if it is a valid API token.
+6. The server accepts a request without a credential on USB and rejects it elsewhere.
+
+The server stores the access mode and key in `/ext/apps_data/web_server/access.json`. The default mode is `disabled`. In practice: USB and BLE clients need no credentials, and over Wi-Fi the API is closed until the user enables open access, sets a numeric key, or mints a token.
+
+## Access key
+
+The key is 4 to 10 ASCII digits. It is set with `POST /api/access?mode=key&key=NNNN`. A caller that authenticates with the key has admin rights over tokens.
+
+## API tokens
+
+The `api_tokens` service manages tokens (`applications/services/api_tokens/`):
+
+- A token is 32 characters, derived from 24 random bytes.
+- The service stores only the SHA-256 hash, with `short_id`, `display_id`, `name`, `created_at` and `last_used_at`, in `/ext/apps_data/tokens/access.json`.
+- The mint response returns the full token once.
+- A caller that authenticated with a token cannot mint tokens, cannot revoke all tokens, and can revoke only itself.
+
+## API version negotiation
+
+A client can send `X-API-Sem-Ver` (or the `x-api-sem-ver` query parameter on WebSocket upgrades). The major number must equal the firmware API major. A mismatch returns 405 `{"error":"Incompatible API version"}`. Requests without the header are not checked.
+
+# Endpoint catalogue
+
+The `Auth` column uses these values: `open` for the whitelisted endpoints, `std` for the rules above, and `admin` where token callers are refused.
+
+## System
+
+| Method | Path | Auth | Request | Response |
+| --- | --- | --- | --- | --- |
+| GET | `/api/version` | open | | `{"api_semver":"27.7.0"}` |
+| GET | `/api/transport` | open | | `{"type":"usb"}` or `{"type":"wifi"}` |
+| GET | `/api/status` | std | | `{device, firmware, system, power}` |
+| GET | `/api/status/device` | std | | `serial_number`, `usb_mac`, `wifi_mac`, `ble_mac`, `otp_valid`, `otp_model`, `otp_timestamp`, `firmware_security` (`secure`, `insecure`, `other`, `unknown`) |
+| GET | `/api/status/firmware` | std | | `version`, `target`, `branch`, `build_date`, `commit_hash`, `intercom_version`, `nwp_version`, `matter_version` |
+| GET | `/api/status/system` | std | | `api_semver`, `uptime`, `boot_time`, `auto_update_enabled` |
+| GET | `/api/status/power` | std | | `state` (`discharging`, `charging`, `charged`), `battery_charge`, `battery_voltage`, `battery_current`, `usb_voltage` |
+| POST | `/api/log_dump` | std | query `filename` (optional, `[A-Za-z0-9_-]`) | `{"result":"OK","path":"/ext/log.txt"}` |
+| GET | `/api/name` | std | | `{"name":"..."}` |
+| POST | `/api/name` | std | `{"name":"..."}`, no other keys | 400 on empty, too long, illegal character, or only spaces |
+| POST | `/api/input` | std | query `key` in `up`, `down`, `ok`, `back`, `start`, `busy`, `custom`, `off`, `apps`, `settings` | Toggles the key |
+
+## Access and settings
+
+| Method | Path | Auth | Request | Response |
+| --- | --- | --- | --- | --- |
+| GET | `/api/access` | open | | `{"mode":"disabled","key_valid":false}` |
+| POST | `/api/access` | std | query `mode` (`disabled`, `enabled`, `key`), `key` required for `key` mode | |
+| GET | `/api/access/tokens` | std | | `{"tokens":[{short_id, display_id, name, created_at, last_used_at}]}` |
+| POST | `/api/access/tokens` | admin | `{"name":"..."}` | Token entry including `token` |
+| DELETE | `/api/access/tokens` | admin | | Revokes all tokens |
+| DELETE | `/api/access/tokens/{short_id}` | std | | 404 if unknown. A token caller may revoke only itself. |
+| GET | `/api/display/brightness` | std | | `{"value":"auto"}` or `{"value":"50"}` |
+| POST | `/api/display/brightness` | std | query `value` = `auto` or 0..100 | |
+| GET | `/api/audio/volume` | std | | `{"volume":0..100}` |
+| POST | `/api/audio/volume` | std | query `volume` 0..100, `silent` 0 or 1 | Plays the volume-change sound unless silent |
+
+## Time
+
+| Method | Path | Auth | Request | Response |
+| --- | --- | --- | --- | --- |
+| GET | `/api/time` | std | | `{"timestamp":"<local time>"}` |
+| POST | `/api/time/timestamp` | std | query `timestamp` (ISO 8601, treated as UTC) | Sets the RTC |
+| GET | `/api/time/timezone` | std | | `{"name","offset","abbr"}` |
+| POST | `/api/time/timezone` | std | query `timezone` (a zone name known to `utz`) | |
+| GET | `/api/time/tzlist` | std | | `{"list":[{name, offset, abbr}]}` |
+
+## Busy timer
+
+See @ref busy-timer for the meaning of the fields.
+
+| Method | Path | Auth | Request | Response |
+| --- | --- | --- | --- | --- |
+| GET | `/api/busy/snapshot` | std | | Snapshot JSON |
+| PUT | `/api/busy/snapshot` | std | Snapshot JSON | 400 on parse failure. The busy timer service ignores stale or future timestamps. |
+| GET | `/api/busy/profiles/{slot}` | std | slot `busy` or `custom` | Profile JSON |
+| PUT | `/api/busy/profiles/{slot}` | std | Profile JSON | |
+
+Snapshot shape: `{"snapshot_timestamp_ms":N,"snapshot":{"type":"NOT_STARTED" or "INFINITE" or "SIMPLE" or "INTERVAL","card_id":"...","is_paused":bool, ...per-type progress fields...}}`. Profile shape: `{"profile_timestamp_ms":N,"id":"...","title":"...","sort_order":N,"timer_settings":{"type":...,"total_time_ms":N,"interval_work_ms":N,"interval_rest_ms":N,"interval_work_cycles_count":N,"is_autostart_enabled":bool,"busy_bar_settings":{"theme":"...","show_work_phase_only":bool,"trigger_smart_home":bool}}}`. The full schemas are in `openapi/busy.yaml`.
+
+## Screen, drawing and streaming
+
+| Method | Path | Auth | Request | Response |
+| --- | --- | --- | --- | --- |
+| GET | `/api/screen` | std | query `display` = `0` (front) or `1` (back) | `image/bmp` body containing base64 of the raw frame: front 72x16 BGR888 (3456 bytes), back 160x80 4 bpp (6400 bytes) |
+| GET | `/api/status/ws` | std | WebSocket upgrade, token via `?x-api-token=` | See the Status WebSocket section below |
+| POST | `/api/display/draw` | std | Draw request JSON | 200 after the canvas commits. 409 `Not drawn due to low priority`. 400 names the invalid field. |
+| DELETE | `/api/display/draw` | std | query `application_name`, or JSON `{"application_name","element_ids":[...]}`. Empty body clears everything. | |
+
+Draw request body:
+
+- `application_name` (required, `[A-Za-z0-9._-]{1,32}`).
+- `priority` (1..100, default 50). The canvas rejects the draw if the running application has a higher priority. Built-in applications run at 10. An active BUSY session runs at the blocking priority and refuses all draws.
+- `led_notification_color` (`#RRGGBBAA`, optional). Blinks the status lights on success.
+- `elements` (1..100 items). Common fields: `id` (required), `type` (required), `timeout` in seconds or `display_until` epoch string, `x`, `y`, `align` (`top_left`, `top_mid`, `top_right`, `mid_left`, `center`, `mid_right`, `bottom_left`, `bottom_mid`, `bottom_right`), `display` (`front` default, `back`), `z_index`.
+
+Element types:
+
+| Type | Fields |
+| --- | --- |
+| `text` | `text`, `font` (`tiny`, `small`, `normal`, `condensed`, `bold`, `large`, `extra_large`, `global`, `superscript`), `color`, `width`, `scroll_rate`, `scroll_start_delay`, `scroll_repeat_delay` |
+| `image` | `path` (under `/ext/user_assets/<app>/`) or `stock_path` (shared images), `opacity` 0..100 |
+| `animation` | `path` or `stock_path`, `section`, `loop`, `await_previous_end`, `opacity` |
+| `rectangle` | `width`, `height`, `fill` (`none`, `solid`, `gradient_h`, `gradient_v`), `fill_colors[2]`, `border_width`, `radius`, `border_color` |
+| `countdown` | `timestamp`, `direction` (`time_left`, `time_since`), `show_hours` (`when_non_zero`, `always`), `color` |
+| `xpmbitmap` | `data` (XPM text, 32 colors max, 4 characters per pixel max, must fit the display), `opacity` |
+
+The `canvas` service implements the draw API, see @ref user-interface.
+
+## Storage
+
+Every `path` must start with `/ext`, must not contain `..`, and is limited to 63 characters.
+
+| Method | Path | Auth | Request | Response |
+| --- | --- | --- | --- | --- |
+| POST | `/api/storage/write` | std | query `path`, `append` 0 or 1. Raw body with `Content-Length`. | Streamed to the file |
+| GET | `/api/storage/read` | std | query `path` | `application/octet-stream`, `Content-Disposition: attachment` |
+| DELETE | `/api/storage/remove` | std | query `path` | Recursive |
+| POST | `/api/storage/mkdir` | std | query `path` | |
+| POST | `/api/storage/rename` | std | query `path`, `new_path` | |
+| GET | `/api/storage/list` | std | query `path` | `{"list":[{"type":"dir","name"},{"type":"file","name","size"}]}` |
+| GET | `/api/storage/status` | std | | `{"used_bytes","free_bytes","total_bytes"}` for `/ext` |
+
+## Application assets and audio
+
+| Method | Path | Auth | Request | Response |
+| --- | --- | --- | --- | --- |
+| POST | `/api/assets/upload` | std | query `application_name` (`[A-Za-z0-9._-]{1,31}`), `file` (relative path, `[A-Za-z0-9._/-]{1,64}`, no `..`). Raw body. | Written to `/ext/user_assets/<app>/<file>`. Parent directories are created. |
+| DELETE | `/api/assets/upload` | std | query `application_name` | Removes the whole application directory |
+| POST | `/api/audio/play` | std | `{"application_name","path"}` or `{"application_name","stock_path"}` | 404 `Failed to play audio` |
+| DELETE | `/api/audio/play` | std | | Held until playback ends. 410 if nothing plays, 503 after 30 s. |
+
+## Update
+
+@ref updater describes the update flow.
+
+| Method | Path | Auth | Request | Response |
+| --- | --- | --- | --- | --- |
+| POST | `/api/update` | std | Raw update bundle (tar or tgz), `Content-Length` required, 100 MiB max | `{"result":"OK","message":"Update accepted. System will reboot."}` then reboot. 400 with a reason, 409 if busy, 413 if too large. |
+| POST | `/api/update/check` | std | | Starts an asynchronous check. 409 if busy. |
+| GET | `/api/update/status` | std | | `{"install":{is_allowed, event, action, status, detail, download{speed_bytes_per_sec, received_bytes, total_bytes}},"check":{available_version, event, status}}` |
+| GET | `/api/update/changelog` | std | query `version` | `{"changelog":"..."}` |
+| POST | `/api/update/install` | std | query `version` (must equal the available version) | 400 with `error_code` in `version_missing`, `not_available`, `version_mismatch`. 503 when not allowed, for example `battery_low`. |
+| POST | `/api/update/abort_download` | std | | |
+| GET | `/api/update/autoupdate` | std | | `{"is_enabled":bool,"interval_start":"HH:MM","interval_end":"HH:MM"}` |
+| POST | `/api/update/autoupdate` | std | Any subset of the three fields | |
+
+Install `status` values: `ok`, `battery_low`, `busy`, `download_failure`, `download_abort`, `sha_mismatch`, `unpack_staging_dir_failure`, `unpack_archive_open_failure`, `unpack_archive_unpack_failure`, `install_manifest_not_found`, `install_manifest_invalid`, `install_session_config_failure`, `install_pointer_setup_failure`, `unknown_failure`. `action` values: `download`, `sha_verification`, `unpack`, `prepare`, `apply`, `none`. `event` values: `session_start`, `session_stop`, `action_begin`, `action_done`, `detail_change`, `action_progress`, `none`.
+
+There is no endpoint for a plain reboot or for entering DFU. The OpenAPI document marks `POST /api/update` and `GET /api/status/ws` as `x-local-only`, but the firmware applies only the standard access rules to them.
+
+## Wi-Fi
+
+All Wi-Fi endpoints return 503 when the `wifi` service is absent.
+
+| Method | Path | Auth | Request | Response |
+| --- | --- | --- | --- | --- |
+| GET | `/api/wifi/status` | std | | `{"state":...}` plus `ssid`, `security`, `bssid`, `channel`, `rssi`, `ip_config{ip_method, ip_type, address}` when connected. States: `unknown`, `disconnected`, `connected`, `connecting`, `disconnecting`, `reconnecting`. |
+| GET | `/api/wifi/networks` | std | | Blocking scan. `{"count":N,"networks":[{ssid, security, rssi}]}`. 400 when connected. |
+| POST | `/api/wifi/connect` | std | `{"ssid","password","security","ip_config":{"ip_method":"dhcp"}}` or static `{"ip_method":"static","address","mask","gateway"}`. `security` in `Open`, `WPA`, `WPA2`, `WEP`, `WPA/WPA2`, `WPA3`, `WPA2/WPA3`. | 400 with reason: `Already connected`, `Access point not found`, `Authentication failed`, `DHCP error`, `Command timed out` |
+| POST | `/api/wifi/disconnect` | std | | Disconnects and forgets the credentials. 400 `Already disconnected`. |
+
+## Bluetooth
+
+| Method | Path | Auth | Request | Response |
+| --- | --- | --- | --- | --- |
+| POST | `/api/ble/enable` | std | | |
+| POST | `/api/ble/disable` | std | | |
+| GET | `/api/ble/status` | std | | `{"status":...,"address"}`. Status in `reset`, `initialization`, `disabled`, `enabled`, `connectable`, `connected`. |
+| DELETE | `/api/ble/pairing` | std | | Forgets the bonded peer |
+
+## Smart home (Matter)
+
+| Method | Path | Auth | Request | Response |
+| --- | --- | --- | --- | --- |
+| GET | `/api/smart_home/pairing` | std | | `{"fabric_count":N,"latest_pairing_status":{"value":...,"timestamp"}}`. Values: `never_started`, `started`, `completed_successfully`, `failed`. |
+| POST | `/api/smart_home/pairing` | std | | Opens a 15 minute commissioning window. `{"available_until","qr_code","manual_code"}` |
+| DELETE | `/api/smart_home/pairing` | std | | Matter factory reset. The device reboots. |
+| GET | `/api/smart_home/switch` | std | | `{"state":bool}` |
+| POST | `/api/smart_home/switch` | std | `{"state":bool}` and/or `{"startup":"off" or "on" or "toggle" or "last"}` | 400 if neither key is present |
+
+## Cloud account
+
+| Method | Path | Auth | Request | Response |
+| --- | --- | --- | --- | --- |
+| GET | `/api/account/info` | std | | `{"linked":bool,"id","email","user_id"}` |
+| GET | `/api/account/status` | std | | `{"status":"error" or "disconnected" or "connected"}` |
+| POST | `/api/account/link` | std | | Held until the cloud returns a PIN. `{"code":"1234","expires_at":N}`. 400 `Already linked` or `Not connected`. 503 after 3 s. |
+| DELETE | `/api/account` | std | | Unlinks the account |
+| GET | `/api/account/backend` | std | | `{"server_url","client_cert_type","ignore_server_cert"}` |
+| PUT | `/api/account/backend` | std | Same JSON | 400 `Malformed request` or `Invalid value` |
+
+# Status WebSocket
+
+`GET /api/status/ws` upgrades to a WebSocket that streams device state as protobuf `StateFrame` messages produced by the `state_publisher` service. The same payload is delivered over BLE and MQTT.
+
+- The client sends text JSON. `{"enable":true}` starts the stream, `{"enable":false}` stops it, `{"send":"all"}` requests a complete snapshot.
+- The server sends binary frames. Updates are rate limited to 11 per second with a 100 ms frame interval for screen frames.
+- Each client has a queue of 8 messages. The publisher pauses at 6 and resumes at 2. Overflow drops the update.
+- The server pings every 10 s and closes the socket when no pong arrives.
+- The server allows four clients. It upgrades a fifth client, sends it a `FATAL` / `RESOURCE_LIMIT` error frame, and closes it.
+
+A Python decoder and transport clients live under `tests/clients/state_publisher/`.
+
+# Static content
+
+The server serves files under `/ext/apps_assets/web_server/www` for every non-API path. Directory requests resolve to `index.html`. The build stores compressible files only as `.gz`. When a client sends no `Accept-Encoding`, the server injects `gzip` so the compressed variant is served. When a client explicitly excludes gzip and only the `.gz` variant exists, the server replies 406. Static content accepts `GET` only.
+
+The served tree contains the Nuxt 3 web UI (`index.html`, `login/`, `_nuxt/`), `openapi.yaml`, the Swagger UI at `docs/`, and `api/index.html` which redirects to `../docs/`.
+
+# OpenAPI pipeline
+
+1. The specification consists of one YAML segment per tag in `applications/services/web_server/openapi/` plus a template `openapi.yaml` with `# {PATHS}`, `# {SCHEMAS}` and `# {TAGS}` markers.
+2. `scripts/openapi_merge.py merge` combines the segments (duplicate keys are an error) and `validate` checks the result.
+3. The build (`scripts/fbt_env_modules/fwenv/bsb_assets.scons`) installs the merged file into the web root and into `dist/` (targets `openapi_spec` and `openapi_dist`).
+4. `scripts/swagger.py` wraps the specification with the cached Swagger UI distribution from `assets/swagger/`.
+5. CI (`openapi-diff.yml`) runs `oasdiff` against the base branch, enforces a semantic version bump on changes, and checks that `API_VERSION` in `http_api.h` equals the version in `openapi.yaml`.
+
+# Host-side clients
+
+| Tool | Endpoints |
+| --- | --- |
+| `scripts/update_over_http.py` | `GET /api/status/firmware` (optional intercom version gate), `POST /api/update` |
+| `scripts/testops.py update-fw` | `POST /api/update` with retries and optional OpenOCD reset |
+| `tests/clients/api/*.py` | Typed clients for every area, used by the integration tests |
+
+`scripts/streaming.py` targets a `ws://<ip>/api/screen/ws` route that no longer exists. Use `GET /api/screen` instead.

--- a/documentation/Hardware.dox.md
+++ b/documentation/Hardware.dox.md
@@ -1,15 +1,227 @@
 # Hardware {#hardware}
 
-This is a stub page about the hardware.
+The @bsb is built around two microcontrollers. The STM32U595 ("U5") is the main MCU. It drives both displays, the storage, the USB port, the audio path, the charger and the whole application layer. The SiWG917 ("Si917") is the wireless co-processor. It owns the Wi-Fi and BLE radio, the Matter node, the secure key storage, the physical buttons, the mode switch, the rotary encoder and the RGB status lights. The two MCUs communicate over a high speed UART link called the intercom (see @ref architecture).
 
-This page must be expanded with the info on the following:
+# Hardware targets
 
-- @bsb hardware capabilities
-    - MCUs
-    - Displays
-    - Buttons
-    - Battery
-    - Wireless
-- Hardware targets
-- External connections
-- etc
+Each firmware image targets one hardware target. Target descriptors live in `targets/<target>/target.json`, target specific HAL code in `targets/<target>/furi_hal/`, and target configuration in `targets/<target>/config/`. See `targets/README.md` for the directory layout.
+
+| Target | MCU | Role | Notes |
+| --- | --- | --- | --- |
+| `f20` | STM32U595 | Main MCU | Earliest prototypes that are still supported. Inherits `f21` with different pin assignments. |
+| `f21` | STM32U595 | Main MCU | Manufacturing prototype. Base target for all U5 code. |
+| `f22` | STM32U595 | Main MCU | Production device. Inherits `f21`. Differs only in the expected OTP hardware target value. |
+| `f64` | SiWG917M111 | Wireless co-processor | Pairs with `f20` and `f21`. |
+| `f65` | SiWG917M111 | Wireless co-processor | Pairs with `f22`. The DFU button is OK instead of Start. |
+
+The default build pair is `f22` + `f65` (`U5_TARGET_HW=22`, `SIL_TARGET_HW=65` in `project.scons`).
+
+## Differences between targets
+
+| Item | f20 | f21 / f22 |
+| --- | --- | --- |
+| Si917 interrupt line into the U5 | PC6 | PA0 |
+| BQ25798 charger interrupt | PC0 | PC6 |
+| Back display VCC enable | PA0 | PC0 |
+| Audio amplifier enable | PC7 (shared with the Si917 SWO line) | PH3 |
+| Front display power enable output | Push-pull | Open drain |
+| Expected OTP `hw_target` | 20 | 21 or 22 |
+
+`f64` and `f65` differ only in the DFU boot button (Start on `f64`, OK on `f65`).
+
+# STM32U595 main MCU
+
+## Core and clocks
+
+- Cortex-M33 with FPU, TrustZone disabled.
+- HSE 16 MHz crystal, LSE 32.768 kHz for the RTC.
+- PLL1 from HSE gives a 160 MHz system clock. AHB and all APB buses run at 160 MHz. PLL1P (160 MHz) also feeds SDMMC1 and SAI1.
+- Instruction cache and flash prefetch are enabled. The data cache is off by default.
+- The DWT cycle counter supplies FreeRTOS runtime statistics.
+
+Clock setup lives in `targets/f21/furi_hal/furi_hal_clock.c`.
+
+## Memory map
+
+| Region | Origin | Size | Use |
+| --- | --- | --- | --- |
+| Flash | `0x08000000` | 4 MiB (linker reserves 2 MiB for the image) | Firmware. `__free_flash_start__` marks the end of the image. |
+| RAM | `0x20000000` | 2496 KiB | Data, BSS, heap, 4 KiB main stack |
+| SRAM4 | `0x28000000` | 16 KiB | Declared, unused |
+| Backup SRAM | `0x40036400` | 2 KiB | Persistent NVM block (flags, boot mode, switch position, version pointer) |
+| OTP | Flash OTP area | 512 bytes | Factory provisioning, four 128 byte blocks |
+
+Three linker scripts exist: `STM32U595xx_FLASH.ld` for the normal image, `STM32U595xx_RAM.ld` for the RAM resident updater stage, and `application_ext.ld` for relocatable external applications. Flash pages are 8 KiB. The linker sizes the FreeRTOS heap (heap_4).
+
+The MPU guards the first 1 MiB (null pointer accesses), a 32 byte read-only region at the base of the current task stack (updated on every context switch), and marks the backup SRAM as normal non-cacheable memory.
+
+## Peripherals
+
+| Function | Device | Interface | Pins |
+| --- | --- | --- | --- |
+| Front display | 72x16 RGB LED matrix, 3 chained constant-current PWM LED driver ICs, 24 scan blocks | OCTOSPI1 in dual-line mode fed by GPDMA (pixel data), TIM8 (grayscale clock, 138 pulses per scan), TIM5 (scan cadence), SPI2 with DMA (row select shift register) | SDI PB1, LE PB0, DCLK PB10, GCLK PB2, scan SDI PC1, scan CLK PB13, latch PA1, power enable PB12 |
+| Back display | SSD1320 160x80 4 bpp grayscale OLED | SPI1, simplex TX | SDIN PA7, SCLK PA5, CS PA6, D/C PC4, frame sync PC5, VCC enable PC0 |
+| Ambient light sensor | ROHM BH1730 | I2C1, address 0x52 | SCL PB8, SDA PB9 |
+| Charger | TI BQ25798 buck-boost charger with ADC | I2C1, address 0xD6 | Interrupt PC6, QON PC13 |
+| USB-PD | STM32U5 UCPD1 | | CC1 PA15, CC2 PB15 |
+| Audio | SAI1 block A, 44.1 kHz 16 bit mono, DMA | NS4168 class-D amplifier with single-wire enable | FS PA9, SCK PA8, SD PA10, amplifier enable PH3 |
+| Storage | eMMC (SD fallback) | SDMMC1, 4 bit bus, IDMA, MMC high speed 52 MHz | D0..D3 PC8..PC11, CK PC12, CMD PD2 |
+| USB | USB OTG HS with on-chip HS PHY, TinyUSB, CDC-NCM only | | DM PA11, DP PA12 |
+| Intercom | USART1 with RTS/CTS, 11.25 Mbaud, DMA | Si917 USART0 | TX PB6, RX PB7, RTS PB3, CTS PB4 |
+| Si917 console | USART2 | Si917 ULP-UART: log capture at 230400 baud and the ROM bootloader at 115200 baud during updates | TX PA2, RX PA3 |
+| U5 debug console | USART6, 230400 baud | | TX PC3, RX PC2 |
+| Si917 control | GPIO | Reset PA4, SWO (boot select) PC7, interrupt PA0 | |
+| SWD | | Only reachable on the debug board | SWDIO PA13, SWCLK PA14 |
+| RTC | On LSE, millisecond resolution | | |
+| RNG | Hardware RNG on HSI48 | | |
+
+There is no QSPI flash and no PSRAM. OCTOSPI1 acts as a DMA-fed shifter for the LED matrix, not as a memory interface. There are no buttons on the U5. The only U5 side input is a fallback confirm pin (PH3) that is polled when the firmware is built without the intercom service.
+
+## Power
+
+The BQ25798 controls the battery path, the 3V3 rails, hardware reset, power off and shipping mode. The power service (see @ref services) programs 4200 mV charge voltage and a 1500 mA maximum charge current, starts with a 500 mA input limit and raises it after USB-PD negotiation (a 9 V request is issued when the source offers more than one PDO). An NVM flag requests shipping mode, which the device enters once VBUS is absent.
+
+The power service computes the state of charge from the charger ADC with a calibration table stored at `/bkp/recovery/resources/power/factory.bat_cal`. The tooling that produces this table is in `scripts/battery_calibration/`.
+
+Low power modes are not implemented. The FreeRTOS tickless idle hook executes `WFI` only.
+
+## Watchdog and crash handling
+
+No IWDG or WWDG is configured. On `furi_crash()` the crash handler (`targets/f21/src/crash_handler.c`) reboots the device unless a debugger is attached, or, in debug builds, the NVM debug flag is set.
+
+## OTP provisioning
+
+The 512 byte OTP area is split into four 128 byte blocks, each starting with the magic `0x3713`, a block index and a version:
+
+| Block | Content |
+| --- | --- |
+| OTP1 | Production timestamp, USB MAC, model string (for example `BB.1`), hardware version, target (20, 21, 22), body and connector codes |
+| OTP2 | QC timestamp, color, region |
+| OTP3 | Curve id and the 56 byte secp224r1 public key |
+| OTP4 | MCU UID and two ECDSA signatures that bind OTP1 and OTP2 to this MCU |
+
+`scripts/bsbotp.py` builds and verifies the blobs (`genkey`, `create-otp1..4`, `load`, `verify`, `dump-all`). The write happens on the device with the CLI command `otp program`, which is available only when the NVM debug flag is set and refuses to overwrite a non-blank block. `furi_hal_version.c` parses the blocks and derives the hardware version string (`4.F22.B7.C2` style), the USB MAC (fallback prefix `0C:FA:22` plus UID), and the FCC and IC identifiers.
+
+# SiWG917 wireless co-processor
+
+## Core and clocks
+
+- SiWG917M111MGTBA. The Cortex-M4F application core (M4) runs this firmware. The network processor (NWP) core runs the Silicon Labs connectivity firmware, a vendor binary shipped in `lib/wiseconnect_extra/connectivity_firmware/`.
+- 40 MHz crystal, M4 PLL at 180 MHz, interface PLL at 160 MHz, QSPI flash clock 80 MHz.
+- The M4 gets 320 KiB of RAM (`SL_SI91X_SI917_RAM_MEM_CONFIG=3`).
+
+## Memory map
+
+| Region | Origin | Size | Use |
+| --- | --- | --- | --- |
+| Flash | `0x08202000` | 2040 KiB | M4 application image in the shared 8 MiB flash |
+| RAM | `0x0000000C` | 320 KiB less 1 KiB | Data, BSS, heap, 512 byte stack |
+| uDMA descriptors | Top 1 KiB of RAM | 1 KiB | |
+| NVM3 | End of the M4 region, before the last 4 KiB | 40 KiB | Key-value store used by Matter and the BLE bonding data |
+| NWP MBR | `0x081F0000` | 496 bytes | Secure boot, anti-rollback and encryption flags of the TA and M4 images |
+| Crypto key storage | NWP managed common flash | 16 KiB main partition + 4 KiB user partition | Certificates, private keys, Matter credentials |
+
+Code that runs while flash is reprogrammed (`critical.o`, `furi_hal_interrupt.o`, `furi_hal_qspi_flash.o`, the WiseConnect RAM functions) is forced into RAM.
+
+## Peripherals
+
+| Function | Pins |
+| --- | --- |
+| Intercom (USART0 to U5 USART1) | TX GPIO54, RX GPIO55, RTS GPIO53, CTS GPIO56 |
+| ULP-UART (log console at 230400 baud, ROM bootloader UART) | RX GPIO8, TX GPIO9 |
+| UART1 (CLI in the `hwtest` configuration) | ULP GPIO8 RX, ULP GPIO11 TX |
+| Status RGB LED (MCPWM, 3 kHz) | Red GPIO7, green GPIO11, blue GPIO15 |
+| Rotary encoder (QEI) | ULP GPIO9 A, ULP GPIO10 B |
+| Buttons | UULP0 Off, UULP1 OK, UULP2 Start/Pause, UULP3 Back |
+| Mode switch contacts | GPIO50 Busy, GPIO51 Settings, ULP GPIO6 Apps, ULP GPIO7 Status (Custom), UULP0 Off |
+| Interrupt to U5 | ULP GPIO1 |
+| U5 SWD pass-through | SWCLK GPIO10, SWDIO GPIO47 |
+
+Early init pulls up unused pins. The Si917 crash handler never reboots on its own.
+
+## Wireless and security
+
+- 2.4 GHz Wi-Fi client with BLE coexistence (`targets/f64/config/wifi_config.c`). The firmware bypasses the NWP TCP/IP offload, so raw Ethernet frames reach the M4.
+- Hardware crypto through the NWP: AES 128/192/256, ECDSA sign and verify, HMAC, SHA, TRNG and key wrapping. Wrapped private keys can sign, but nothing can read them out. Key wrapping requires secure boot. The `SIL917_INSECURE` build variable (default true) disables wrapping during provisioning for lab devices.
+- The M4 `HWRNG` block feeds `furi_hal_random`.
+
+# Boot sequence
+
+## STM32U5
+
+1. `Reset_Handler` calls `SystemInit()` (FPU on, RCC reset to MSI 4 MHz, vector table at flash or SRAM for the RAM image), initializes data and BSS, then calls `main()`.
+2. `main()` (`targets/f21/src/main.c`) runs `furi_hal_init_early()`, which validates or resets the backup SRAM NVM block, enables debug features when the NVM debug flag is set, and parses the OTP blocks.
+3. `main()` checks the boot mode from NVM. In `Normal` mode the Init thread starts the scheduler, runs `furi_hal_init()` and starts every service (see @ref services).
+4. In `Update` mode (set by the updater before a reboot) the mode is cleared and `boot_update.c` runs before the scheduler: it mounts both eMMC partitions with FatFs, reads the manifest path from `/ext/.sys_update.txt`, loads the `updater_stage` binary named in `update.json`, verifies its CRC32, copies it to SRAM1 and jumps to it. Any failure falls back to a power reset.
+5. The updater stage is the same firmware linked for RAM execution with the `update_executor` application set. It flashes the U5 DfuSe image, then the Si917 M4 and NWP images, then unpacks the resources. See @ref updater.
+6. The ST ROM DFU bootloader at `0x0BF90000` is reachable only through the power service (`power boot u5` on the CLI). There is no button combination for it.
+
+The flash driver clears the `PA15_PUPEN` option bit if it is set, because PA15 is the UCPD CC1 line. No read-out or write protection is configured in code.
+
+## SiWG917
+
+The Silicon Labs ROM bootloader and MBR run first. `main()` (`targets/f64/src/main.c`) runs `furi_hal_init_early()`, then the Init thread runs `furi_hal_init()` and starts the services. There is no NVM boot mode logic on this side.
+
+Holding the SWO line low during reset enters the ROM bootloader. The U5 does this with `furi_hal_power_reset_917(true)`. A host can do the same by grounding `JTAG_TDO_SWO` before flashing with `scripts/flashrps.py`. When the DFU button is held at boot, the `startup_dfu_hook` service blinks the status LED orange for 3 s, then turns it solid red and waits for the intercom so the U5 can take over.
+
+# Si917 firmware image (RPS)
+
+- The build turns the M4 ELF into `.bin` and then `.rps` with `scripts/bin2rps.py`. The RPS header carries the magic `0x900D900D`, the image size, the flash address, a boot descriptor and a CRC-32 (polynomial `0xD95EAAE5`) at offset 0x14. This image has no signature and no encryption.
+- `scripts/sign_silabs_rps.py` signs an image either locally with Simplicity `commander-cli` and a keystore, or through a signing service (`SI917_SIGN_SERVICE_URL`, `SI917_SIGN_SERVICE_TOKEN`, `SI917_SIGN_SERVICE_PROFILE`). Secure-boot devices accept only signed images.
+- From a host, `scripts/flashrps.py` (or `./fbt flash` on `f64`/`f65`) drives the ROM bootloader text menu over the ULP-UART at 115200 baud, switches to 921600 baud, selects the M4 or NWP image slot, and streams the file with the Kermit protocol.
+- From the U5, the updater does the same over USART2 with an embedded Kermit implementation, trying baud rates from 921600 down to 9600.
+
+# FreeRTOS configuration
+
+| Setting | U5 | Si917 |
+| --- | --- | --- |
+| Tick | 1000 Hz | 1000 Hz |
+| Priorities | 32 | 32 |
+| Heap | heap_4, size from linker | heap_4, size from linker |
+| Tickless idle | Custom hook, `WFI` only | Off |
+| Stack overflow check | Off, MPU guard instead | Off |
+| Task return address | `furi_thread_catch` | `furi_thread_catch` |
+| `configASSERT` | `furi_crash("FreeRTOS Assert")` in debug builds | Same |
+
+Both MCUs use 4 priority bits with the syscall ceiling at 5. Furi interrupt priorities map to NVIC 7..13 (Normal is 10). The `KamiSama` level maps to NVIC 4, above the syscall ceiling, and serves interrupts before the scheduler starts. EXTI lines run at 10 on the U5. Pin interrupts run at 5 on the Si917.
+
+# HAL modules
+
+The HAL is the `furi_hal_*` family in `targets/<target>/furi_hal/`.
+
+| Module | U5 | Si917 |
+| --- | --- | --- |
+| `furi_hal` | Early and main init sequences | Early and main init sequences |
+| `furi_hal_bus` | RCC clock gating per peripheral | M4 clock gates |
+| `furi_hal_clock` | PLL setup, kernel clock queries | PLL setup |
+| `furi_hal_cortex` | Caches, DWT, system reset, jumps to DFU, SRAM or flash | DWT |
+| `furi_hal_mpu` | Null guard, stack guard, backup SRAM attributes | |
+| `furi_hal_interrupt` | ISR registration by id, priorities, ISR time accounting | Timers and QEI |
+| `furi_hal_gpio`, `furi_hal_resources` | Pin tables, EXTI | HP, ULP and UULP pins |
+| `furi_hal_dma` | GPDMA and LPDMA channel allocation | uDMA channels |
+| `furi_hal_flash` | Page program and erase, option bytes, OTP | Base and free end only |
+| `furi_hal_nvm` | Backup SRAM block | Stub |
+| `furi_hal_rtc`, `furi_hal_random` | RTC, RNG | RNG |
+| `furi_hal_version`, `furi_hal_info` | OTP parsing, UID, MACs, device info | NWP firmware version, MACs, MBR security bits, enclave check |
+| `furi_hal_serial`, `furi_hal_serial_control` | USART driver with DMA and autobaud, handle arbitration | Same |
+| `furi_hal_spi`, `furi_hal_i2c` | Bus and handle model | |
+| `furi_hal_sdmmc` | eMMC and SD driver | |
+| `furi_hal_sai`, `furi_hal_dac` | Audio output paths | |
+| `furi_hal_light_sensor`, `furi_hal_display` | BH1730, front display power pin | |
+| `furi_hal_usb` | OTG HS bring-up | |
+| `furi_hal_power` | Reset, Si917 reset and DFU line control | Reset |
+| `furi_hal_crypto`, `furi_hal_crypto_storage` | | NWP crypto services, key slot storage |
+| `furi_hal_pwm`, `furi_hal_qei` | | RGB LED, rotary encoder |
+
+# Drivers
+
+| Driver (`lib/drivers/`) | Chip | Bus |
+| --- | --- | --- |
+| `bh1730` | ROHM BH1730 ambient light sensor | I2C1 |
+| `bq25798` | TI BQ25798 charger with ADC | I2C1 |
+| `ns4168` | NS4168 class-D amplifier | One GPIO, pulse count selects the high-pass filter |
+| `ssd1320` | SSD1320 OLED controller | SPI1 |
+
+# Debug tooling
+
+`scripts/debug/platforms/` holds OpenOCD and SVD descriptors: `stm32u595.json` (flash at `0x08000000`, `stm32u5x.cfg`, `STM32U595.svd`) and `siw917.json` (flash at `0x08202000`, `siw917.cfg`, `SiWx917.svd`). The GDB extensions in `scripts/debug/platforms/stm32u5/` read the running firmware version through the backup SRAM NVM block. The U5 SWD pins are only reachable with the debug board attached (see @ref quick-start).

--- a/documentation/JavaScript Applications.dox.md
+++ b/documentation/JavaScript Applications.dox.md
@@ -1,27 +1,20 @@
 # JavaScript Applications {#javascript-applications}
 
-This is a stub page about the JavaScript applications. Expand it with new aspects as they become established.
-
 # Introduction
 
-JavaScript applications are a locally-run form of [HTTP API](https://docs.busy.app/bar/dev/http-api) applications.
-To achieve this, the @ref firmware includes a JavaScript [interpreter](https://jerryscript.net/) to run user scripts
-and a set of standard and custom interfaces to be used by these scripts.
+JavaScript applications are a locally-run form of [HTTP API](https://docs.busy.app/bar/dev/http-api) applications. The @ref firmware includes a JavaScript interpreter ([JerryScript](https://jerryscript.net/)) and a small set of standard web interfaces. A script draws on the displays, plays sounds and blinks the lights by calling the HTTP API of the device over loopback with `fetch()`. Requests from `127.0.0.1` need no API token (see @ref http-api).
 
-Additionally, the firmware is able to enumerate and list currently installed applications and display them
-in the [APPS menu](https://docs.busy.app/bar/apps-and-integrations) for easy access.
+The firmware enumerates installed applications and lists them in the [APPS menu](https://docs.busy.app/bar/apps-and-integrations).
+
+What the runtime does **not** offer at this time: a native display, image, font or animation API, button events, a LED or sound API, file system access, a busy timer API, `require()`, and a way for the script to read its own settings values. The Back key always stops the application.
 
 # Application structure
 
 ## Applications directory
 
-The firmware is looking for JavaScript applications in the `/ext/user_assets` directory on the EMMC storage.
-
-Every subfolder in this directory will be searched for a valid application file structure.
+The firmware looks for JavaScript applications in `/ext/user_assets` on the eMMC. The registry checks every direct subdirectory for a valid application file structure. The directory name must equal the manifest `id`.
 
 ## Application file structure
-
-Every JavaScript application must implement the following basic file structure:
 
 ```
 /ext/user_assets
@@ -36,109 +29,239 @@ Every JavaScript application must implement the following basic file structure:
         └── main.js
 ```
 
-The firmware will look for these hardcoded file names when looking for applications.
-
 ### Root directory
 
-Required. The name must be at most 32 characters long and contain only ASCII alphanumeric characters.
-
-The only allowed special characters are: `_` (underscore), `-` (minus) and `.` (period).
-
-To improve the name uniqueness, a reverse domain name scheme is recommended, but is not required.
+Required. The name must be at most 32 characters long and contain only ASCII alphanumeric characters plus `_`, `-` and `.`. The runtime currently rejects ids that contain `-`, so use `[A-Za-z0-9._]` only. A reverse domain name scheme is the recommended form.
 
 ### appmeta directory
 
-Required. Contains the application metadata. See the table below for contents summary.
+Required. Contains the application metadata.
 
-| File                  | Purpose                              | Required? |
-| --------------------- | ------------------------------------ | :-------: |
-| `manifest.json`       | Application manifest (see below)     | YES       |
-| `settings.json`       | Application settings description     | NO [1]    |
-| `icon_front_8x8.png`  | Icon to be shown in front display UI | NO [2]    |
-| `icon_back_11x11.png` | Icon to be shown in back display UI  | NO [3]    |
-
-- [1] If not present, it is assumed that the application does not have any settings.
-- [2] Must be a 8x8px PNG colour image. If not present, a default icon will be used.
-- [3] Must be a 11x11px PNG greyscale image. If not present, a default icon will be used.
+| File | Purpose | Required |
+| --- | --- | --- |
+| `manifest.json` | Application manifest | Yes |
+| `settings.json` | Application settings schema | No. Without it the application has no Setup screen. |
+| `icon_front_8x8.png` | 8x8 color icon for the front display | No. A default icon is used. |
+| `icon_back_11x11.png` | 11x11 grayscale icon for the back display | No. A default icon is used. |
 
 ### scripts directory
 
-Required. Contains the JavaScript script files.
-
-The `main.js` file is the application entry point and is required. Any number of additional `.js` files may be present if required.
+Required. `main.js` is the entry point and is always evaluated as an ES module. Relative import specifiers resolve other `.js` files against the `scripts` directory.
 
 ### Additional directories
 
-The root directory may also contain any number of additional directories. The maximum length of the full path is limited to 256 characters and is subject to the same character restrictions as the root directory name, with the addition of the directory separator `/` (forward slash).
-
-It is recommended, but not required, to group the resource files necessary for the application to comprehensively named directories, e.g.
-
-- `resources`, `data` -- any kind of resource files used by the application
-- `images`, `graphics`, `gfx` -- graphic resources (such as icons or background images)
-- `animations` -- self explanatory
-- `sounds` -- self explanatory, etc.
+The root directory may contain any number of other directories, for example `images`, `animations` or `sounds`. The full path has a limit of 256 characters. Files under the application directory are addressable from the display API through `path` relative to the application root.
 
 ## Manifest file
 
-Application manifest file is a JSON file that matches the following schema:
+Parser: `lib/js_app/js_app_manifest.c`. The file must be 1 to 512 bytes.
 
 ```json
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "object",
-    "properties": {
-        "format_version": {
-            "type": "number",
-            "description": "Manifest file format version"
-        },
-        "id": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 32,
-            "pattern": "^[a-zA-Z0-9._-]+$",
-            "description": "Unique application ID (must match the root directory name)"
-        },
-        "name": {
-            "type": "string",
-            "description": "Display name to be shown in the UI"
-        },
-        "version": {
-            "type": "string",
-            "pattern": "^[0-9]+\.[0-9]+\.[0-9]+$",
-            "description": "Application version"
-        },
-        "description": {
-            "type": "string",
-            "default": "",
-            "description": "Free form application description"
-        },
-        "author": {
-            "type": "string",
-            "default": "",
-            "description": "Application author (individual, company, etc.)"
-        },
-        "heap_size_kib": {
-            "type": "number",
-            "minimum": 1,
-            "maximum": 512,
-            "default": 128,
-            "description": "The amount of memory reserved for application heap, in KiB"
-        },
-        "debug": {
-            "type": "boolean",
-            "default": false,
-            "description": "If true, display in UI only when developer mode is enabled"
-        }
-    },
-    "required": [
-        "format_version",
-        "id",
-        "name",
-        "version"
-    ]
+    "format_version": 1,
+    "id": "app.busy.js_example",
+    "name": "JS App Example",
+    "version": "0.1.0",
+    "description": "A simple JS application example",
+    "author": "BUSY Bar team",
+    "heap_size_kib": 128,
+    "debug": false
 }
 ```
 
+| Key | Type | Required | Rules | Default |
+| --- | --- | --- | --- | --- |
+| `format_version` | number | Yes | Must be 1. Other values log a warning. | |
+| `id` | string | Yes | Must equal the directory name | |
+| `name` | string | Yes | Shown in the APPS menu and the navigation bar | |
+| `version` | string | Yes | `major.minor.patch` | |
+| `description` | string | No | | `""` |
+| `author` | string | No | | `""` |
+| `heap_size_kib` | number | No | 1..512. The whole JavaScript heap. | 128 |
+| `debug` | boolean | No | `true` hides the application unless Dev mode is on | `false` |
+
 ## Settings file
 
-To be decided
+`appmeta/settings.json` declares settings that the user can edit on the device in the Setup screen. Parser: `lib/js_app/js_app_settings.c`.
+
+Root keys: `format_version` (must be 1), `version` (number greater than 0, the schema version stored with the values), `fields` (non-empty object of field nodes). Field ids start with `[a-z]` and continue with `[a-z0-9_]`. Every field has `label` (required), `description` (optional) and `type`:
+
+| Type | Extra keys | Rules |
+| --- | --- | --- |
+| `boolean` | `default` | |
+| `integer` | `default`, `min`, `max`, `step` | `min <= max`, `step` not 0, `(max - min)` divisible by `step`, default in range |
+| `string` | `default`, `sensitive`, `min_length`, `max_length` | `max_length` up to 255 (default 64). Sensitive values are shown as `***`. |
+| `enum` | `default`, `options` | 1..32 options of `{value, label}` with unique values. The default must be an option value. |
+| `color` | `default` | `#RRGGBB` or `#RRGGBBAA` |
+| `time` | `default` | `HH:MM` or `HH:MM:SS` |
+| `geolocation` | `default` | `{mode: "auto" or "fixed", name, lat, lon}`. `fixed` requires both coordinates. |
+| `group` | `fields` | Nested fields, four levels deep at most |
+
+Example:
+
+```json
+{
+    "format_version": 1,
+    "version": 1,
+    "fields": {
+        "enabled": { "label": "Enabled", "type": "boolean", "default": true },
+        "refresh": { "label": "Refresh (s)", "type": "integer", "default": 60, "min": 10, "max": 600, "step": 10 },
+        "mode": { "label": "Mode", "type": "enum", "default": "a",
+                  "options": [ { "value": "a", "label": "Mode A" }, { "value": "b", "label": "Mode B" } ] },
+        "api_key": { "label": "API key", "type": "string", "default": "", "sensitive": true, "max_length": 128 },
+        "accent": { "label": "Accent", "type": "color", "default": "#FF6D16" },
+        "alarm": { "label": "Alarm", "type": "time", "default": "07:30" }
+    }
+}
+```
+
+The launcher stores the values in `/ext/apps_data/jsrunner/<id>.settings.json` as `{"version": N, "values": {...}}`. Groups nest, enums store the option value, color and time store their formatted strings. On the device only boolean, integer and enum fields are editable. The other types are read-only. **No API currently passes these values to the script.**
+
+# Installation
+
+Upload every file with `POST /api/assets/upload?application_name=<id>&file=<relative path>` and the file content as the body. Parent directories are created. `DELETE /api/assets/upload?application_name=<id>` removes the application. See @ref http-api. The build bundles applications placed in `applications_js/` in the source tree into the resources.
+
+JavaScript applications appear in the APPS menu only when the flag file `/ext/apps_data/apps_menu/js_apps_enabled` exists. Create it with the storage CLI or the storage API.
+
+# Life cycle
+
+1. The APPS menu launches `js_app_launcher` with the application id.
+2. The launcher shows the Start screen (icon, name, Start and Setup). Setup edits the settings.
+3. Start allocates a runtime context with the manifest heap size, parses `main.js` as a module, links imports and evaluates it. Console output goes to the device log (`console.log` at debug level, `info` at info, `error` at error, tag `JsAppLauncher`).
+4. The application stays alive while it has pending timers or fetches. When none remain, the runtime reports termination and the launcher returns to the Start screen.
+5. Back aborts the script (the VM throws `aborted` inside busy loops, the runtime stops fetches and frees timers) and returns to Start. From Start, Back returns to the APPS menu.
+
+Errors: a parse or link failure shows "Syntax error, check script.". A missing file or an invalid id shows "App loading failed, reinstall it.". An uncaught exception in top-level code terminates the application silently and logs `JsRunner: Error running script`.
+
+Limits: one JavaScript context firmware-wide, an 8 KiB application thread stack, 250 KiB per script file, the import root is valid only during the initial evaluation (do all static imports at top level).
+
+# Runtime API
+
+Implemented in `applications/services/js_runner/`. Native functions throw `TypeError` on too few arguments or an invalid `this`.
+
+## Globals
+
+| Global | Notes |
+| --- | --- |
+| `console.log`, `console.info`, `console.error` | The runtime stringifies the arguments and joins them with spaces. Objects print as `[object Object]`, use `JSON.stringify`. |
+| `setTimeout(fn, ms)`, `setInterval(fn, ms)` | Exactly two arguments. The runtime raises delays below 10 ms to 10 ms. No extra callback arguments. The runtime prints an exception in a callback as `Uncaught: ...` and the application continues. |
+| `clearTimeout(id)`, `clearInterval(id)` | Same function. |
+| `fetch(input, init)` | See below. |
+| `Request`, `Response`, `Headers`, `URL` | See below. |
+| `localStorage` | Persistent string store. |
+| `AbortController`, `DOMException`, `FormData` | Empty stubs so that libraries can feature-detect them. They do nothing. |
+
+Language: ES modules, `Promise`, `Array`, `Date` (uses the device time and time zone), `JSON`, `Math`, `RegExp`, `String`, `BigInt`, `Map`, `Set`, `WeakMap`, `WeakSet`, `WeakRef`, `DataView`, typed arrays, `SharedArrayBuffer`, `Atomics`, `Proxy`, `globalThis`. Not available: `Reflect`, Annex B functions (`escape`, `substr`, `__proto__` accessors), Unicode case conversion, `TextEncoder`, `atob`, `structuredClone`, `queueMicrotask`, `crypto`, `WebSocket`, `XMLHttpRequest`, `Blob`.
+
+## fetch
+
+`fetch(input, init)` returns a Promise that resolves when the response headers arrive. Rejections are **strings**, not `Error` objects.
+
+- `input`: a URL string or a `Request`. `http://` and `https://` are supported. TLS uses the device CA bundle.
+- `init.method`: string, default GET.
+- `init.headers`: a plain object. At most 10 headers. The runtime drops extra ones. `fetch` does not accept a `Headers` instance here.
+- `init.body`: converted to a string. Binary bodies are not supported.
+- `init.dispatcher.connect.useDeviceKey`: when true, the request presents the device TLS client certificate (mutual TLS with BUSY cloud services).
+- Ignored: `signal`, `credentials`, `mode`, `redirect`, `cache`, `keepalive`. There is no timeout.
+
+Each fetch runs in its own thread and keeps the application alive until it completes.
+
+## Request
+
+`new Request(input, init)`. `input` is a URL string or another `Request`. The result is a plain object with `url`, `method`, `headers`, `body` and `dispatcher` properties. There is no `clone()`.
+
+## Response
+
+Produced by `fetch`. Properties: `status`, `statusText`, `ok`, `headers` (a `Headers`), `body` (a readable stream), `bodyUsed`, `type` (`"basic"`), `url`.
+
+Body methods, each returning a Promise, one consumer per response: `text()`, `json()` (rejects with the parse error), `arrayBuffer()`, `bytes()`. `blob()` and `formData()` reject with `"unimplemented"`.
+
+`response.body.getReader()` returns a reader with `read()` (resolves `{done, value}` with `Uint8Array` chunks as they arrive), `cancel()` and `closed`. The body is also an async iterable, so `for await (const chunk of response.body)` works. An example is installed at `/ext/apps_assets/js_runner/example/fetch.js`.
+
+## Headers
+
+`new Headers()` creates an empty set. Methods: `get(name)` (case-insensitive), `set(name, value)`, `has(name)`, `entries()`, `keys()`, `values()`, `forEach(callback)`. The `Headers` object itself is not iterable; iterate over `entries()`. There is no `append` or `delete`.
+
+## URL
+
+`new URL(string)`. No base argument. Read-only getters: `href`, `origin`, `protocol`, `host`, `hostname`, `port`, `pathname`, `search`, and `toString()`. No `hash`, `username`, `password` or `searchParams`.
+
+## localStorage
+
+Strings only, persisted per application id in `/ext/apps_data/jsrunner/<id>.localstorage.json`. Members: `length`, `key(index)`, `getItem(key)`, `setItem(key, value)`, `removeItem(key)`, `clear()`. Non-string arguments throw `TypeError`. Every write rewrites the whole file, so keep it small. Property style access (`localStorage.foo`) is not supported.
+
+# Example
+
+`scripts/main.js`:
+
+```js
+import { draw } from "./ui.js";
+
+const KEY = "last_temp";
+let temp = localStorage.getItem(KEY);
+
+async function refresh() {
+    try {
+        const r = await fetch("https://api.example.com/now", { headers: { "Accept": "application/json" } });
+        if (!r.ok) { console.error("HTTP", r.status, r.statusText); return; }
+        const j = await r.json();
+        temp = String(j.temp);
+        localStorage.setItem(KEY, temp);
+    } catch (e) {
+        console.error("fetch failed:", String(e));
+    }
+    await draw("com.example.weather", temp ?? "--");
+}
+
+refresh();
+setInterval(refresh, 60000);
+```
+
+`scripts/ui.js`:
+
+```js
+export async function draw(app, text) {
+    const body = JSON.stringify({ application_name: app, elements: [
+        { id: "t", type: "text", x: 36, y: 8, align: "center", font: "normal", text, display: "front" },
+        { id: "b", type: "text", x: 0, y: 0, align: "top_left", font: "small", text, display: "back" }
+    ]});
+    const r = await fetch("http://127.0.0.1/api/display/draw", { method: "POST", body,
+                          headers: { "Content-Type": "application/json" } });
+    if (!r.ok) console.error("draw:", await r.text());
+}
+```
+
+The draw request's `application_name` is not bound to the JavaScript application id. Use your own id so that clearing elements does not affect other clients.
+
+# CLI
+
+```
+js [-i app_id] [file]   run a script file, or open a REPL when no file is given
+js -k                   abort the running script
+```
+
+The REPL evaluates each line as a classic script and prints the result. `js -i <id> /ext/user_assets/<id>/scripts/main.js` runs an installed application with its own `localStorage` file and prints console output to the terminal instead of the device log. The CLI context uses a 96 KiB heap and the application id `app.busy.cli`. Because only one context may exist, the command fails with "Out of resources" while the launcher runs an application.
+
+# Debugging checklist
+
+1. The application is not in the APPS menu: check the `js_apps_enabled` flag file, that the directory name equals the manifest id, that the manifest is at most 512 bytes and parses (log tag `JsAppManifest`), that `scripts/main.js` exists, and that `debug` is false or Dev mode is on.
+2. "Syntax error, check script.": the device log shows `JsRunner: Error parsing script: <file>:<line>: <message>`. A missing module shows `JSGlue: Cannot open file ...`.
+3. "App loading failed, reinstall it.": file error, an id containing `-`, or another JavaScript context running (`js -k`).
+4. The application returns to Start immediately: top-level code finished without pending timers or fetches, or an uncaught exception occurred.
+5. Draw calls do nothing: watch the web server log for `... is required` style validation messages and check `application_name` and `display`.
+6. Out of memory: the log shows `JSGlue: jerryscript fatal error` followed by a crash. Raise `heap_size_kib` (up to 512) or reduce live data.
+
+# Host C API
+
+`applications/services/js_runner/js_runner.h`, for firmware code that embeds scripts:
+
+| Function | Purpose |
+| --- | --- |
+| `js_runner_context_alloc(runner, app_id, heap_size, console_callback, context)` | Start the application thread and the JerryScript context |
+| `js_runner_run(handle, path, termination_callback, context)` | Parse, link and start evaluating a module file. Returns after parse and link. |
+| `js_runner_run_snippet(handle, code, print_result, ...)` | Evaluate a classic script string |
+| `js_runner_join(exec_handle, timeout)` | Wait until no timers or fetches remain |
+| `js_runner_abort(exec_handle)`, `js_runner_abort_all(runner)` | Request termination |
+| `js_runner_context_free(handle)` | Stop the thread |
+
+The JerryScript port lives in `targets/f21/jerryscript/jerryscript_glue.c` (context allocation, time and time zone, module file reading, fatal errors). Build flags are in `lib/jerryscript.scons`. The engine is the `flipperdevices/jerryscript` fork, branch `bsb`.

--- a/documentation/Native Applications.dox.md
+++ b/documentation/Native Applications.dox.md
@@ -1,3 +1,114 @@
 # Native Applications {#native-applications}
 
-This is a stub page about native applications.
+Native applications are part of the firmware image. `application.fam` manifests declare them, the directories described in `applications/README.md` group them, and the loader starts them (see @ref user-interface). This page documents the manifest format, the application life cycle and every application in the tree.
+
+# Manifest format
+
+Every `application.fam` is a Python file with one `App(...)` call per unit. Fields in use:
+
+| Field | Meaning |
+| --- | --- |
+| `appid` | Unique id. Also the thread application id, which selects the per-application data directory. |
+| `apptype` | `FlipperAppType.SERVICE`, `STARTUP`, `CLICMD`, `APP`, `SETTINGS`, `SYSTEM`, `DEBUG` or `METAPACKAGE` |
+| `name` | Display name, or the command word for `CLICMD` |
+| `entry_point` | C function to run |
+| `targets` | Target list, for example `["f20", "f21", "f22"]` or `["f64", "f65"]`. Two manifests may declare the same `appid` with disjoint target lists. |
+| `stack_size` | Thread stack in bytes |
+| `order` | Start order for services and hooks, menu order for settings applications |
+| `requires` | Application ids that must be present in the build |
+| `provides` | Metapackage members, or extra units such as CLI commands |
+| `sources` | Explicit source list (default: glob) |
+| `cdefines` | Defines exported to the whole build, used for feature detection (`SRV_WIFI`, `SRV_TIME`, ...) |
+| `resources` | Directory merged into the resources tree |
+| `flags` | Application flags, for example `InsomniaSafe` |
+| `sdk_headers` | Headers exported to the external application SDK |
+
+Types and their meaning:
+
+| Type | Role |
+| --- | --- |
+| `SERVICE` | Background thread started at boot |
+| `STARTUP` | Hook function run once at boot in a temporary thread |
+| `CLICMD` | Command registered in the CLI registry |
+| `APP` | Application reachable from the mode switch or the APPS menu |
+| `SETTINGS` | Entry of the settings menu |
+| `SYSTEM` | Application launched programmatically, not listed in any menu |
+| `DEBUG` | Entry of the Debug apps menu, visible when Dev mode is on |
+| `METAPACKAGE` | Group selected by an application set |
+
+The external `.fap` application type is supported by the tooling (`scripts/fbt_tools/fbt_extapps.py`) but no manifest in the tree uses it.
+
+# Application life cycle
+
+An application is a thread entry point that receives an argument string. The common skeleton:
+
+1. Open the records it needs (`gui`, `storage`, `time`, ...).
+2. Under `with_gui()`, take the `Main` layer root widget of each display and build the screens. Most applications use a `SceneManager`, a front window widget, and a back display column with a `NavBar` and a scene window.
+3. Install a thread signal callback. `FuriSignalAboutToExit` (sent by the desktop before a switch transition) lets the application play an exit animation. `FuriSignalExit` (sent by the loader) must stop the event loop.
+4. Run the event loop. Input arrives through widgets or a layer input callback. Usually the application handles only `Back` itself.
+5. Free the widgets and close the records, then return.
+
+Applications that must not be interrupted by an automatic firmware update call `updater_pause_autoupdates()` and `updater_resume_autoupdates()`. Applications that need to control remote drawing change their loader priority.
+
+# Main applications (`applications/main/`)
+
+| Application | Launched by | Description |
+| --- | --- | --- |
+| `busy` (`APP`, order 10) | BUSY and CUSTOM switch positions, remote start | The busy timer front end. See @ref busy-timer. |
+| `clock` (`APP`, order 20) | APPS menu | Full screen clock. Setup toggles date, seconds and colon blink; settings in `/ext/apps_data/clock/settings.json`. The time format comes from the `time` service. Pauses automatic updates while open. |
+| `power_on` (`SYSTEM`) | Desktop at boot | Waits for the initial switch position, showing "Starting..." after 500 ms. On the first boot (no `/ext/apps_data/power_on/done.txt`) it plays the power-on animations on both displays and waits for any key, powering the device off after 15 minutes without interaction. |
+| `settings_menu` (`SYSTEM`) | SETTINGS switch position | Title card, then a menu built from every `SETTINGS` application descriptor, ordered by `order`. An argument names the sub-application to return to. |
+| `soft_off` (`SYSTEM`) | OFF switch position | Plays the turn-off animation, then releases the low power lock so the displays and light sensor sleep. Re-takes the lock when the switch moves. |
+
+# Settings applications (`applications/settings/`)
+
+Each settings application, when called with a descriptor argument, fills a `SettingsAppDescriptor` (titles, icons, `menu_extra`, `display_in_menu`) and returns. When launched, it shows its screens and returns to `settings_menu` on Back.
+
+| Order | Application | Screens |
+| --- | --- | --- |
+| 0 | `ble_settings` | Pairing mode (5 minute window, blinking status lights) when not paired, "Connected" when paired, Forget device dialog |
+| 10 | `wifi_settings` | Not configured: QR code to the connection guide. Configured: state and SSID, View IP address, Forget network. No on-device SSID entry. |
+| 20 | `matter_settings` | Pair device (QR and manual code on the back display), Forget all pairings, commissioning result screens, "Contact support" if the Matter stack is broken |
+| 30 | `account_settings` | Get pairing code (4 digit PIN for cloud.busy.app), linked account info with a shortened email, Unlink |
+| 40 | `sound_settings` | Volume slider 0..100 in steps of 5 with a preview sound |
+| 50 | `brightness_settings` | Mode Auto or Manual, Level 0..100 in steps of 5 |
+| 55 | `time_settings` | Time zone list, 12 h or 24 h format |
+| 60 | `firmware_settings` | Check for update, install dialog, low battery screen (40% rule), version info, auto-update switch, channel selector in Dev mode |
+| 70 | `system_settings` | Power (shut down, restart, battery info), Debug (Dev mode on or off), Factory reset |
+| 80 | `about` | General (name, serial, hardware version, MAC addresses, display sizes), Firmware (version, branch, commit, API, build date, uptime), Compliance (FCC and IC ids), Open-source libraries |
+| 90 | `debug_app_list` | Lists the `DEBUG` applications. Visible only in Dev mode. |
+
+# System applications (`applications/system/`)
+
+| Application | Type | Description |
+| --- | --- | --- |
+| `apps_menu` | `SYSTEM` | The APPS menu. Lists `clock` and, when the flag file `/ext/apps_data/apps_menu/js_apps_enabled` exists, every installed JavaScript application. Remembers `active_application` and relaunches it when the switch returns to APPS. |
+| `js_app_launcher` | `SYSTEM` | Start, Setup and Run screens for a JavaScript application. See @ref javascript-applications. |
+| `message` | `SYSTEM` | Shows its argument as a status message. Used by the desktop to display application start errors. |
+| `updater` family | `SERVICE`, `STARTUP`, `CLICMD` | The updater service, the update UI hook, the update executor (recovery side), the `update` and `factory_reset` commands. See @ref updater. |
+| `tar_cli` | `CLICMD` | `tar` command |
+| `fetch_cli` | `CLICMD` | `fetch` command, an HTTP client with TLS client authentication |
+| `crypto_backup` | `CLICMD` (U5), `STARTUP` (Si917) | Raw backup and restore of the Si917 key storage |
+| `crypto` | `CLICMD` (Si917) | Key storage management |
+| `crypto_test`, `nvm_test`, `wifi_cli_test` | `CLICMD` (Si917) | Test shells for the crypto accelerators, NVM3 and the radio |
+
+# Debug applications (`applications/debug/`)
+
+Visible under Settings, Debug apps when Dev mode is on. Built by the `debug_apps` metapackage.
+
+| Application | Purpose |
+| --- | --- |
+| `anim_test` | Plays two test animations through `AnimPlayer` |
+| `back_display_test`, `back_display_factory` | Drawing test and factory test patterns for the OLED (the factory variant is in the `factory_testing` set) |
+| `front_display_test` | LED matrix test patterns |
+| `gui_test` | Widget showcase |
+| `input_test` | Shows key and switch events. Hold Back to exit. |
+| `light_sensor_test` | Raw channel readings and derived values |
+| `dummy` | Shows a label with its argument |
+| `storage_bench` | `storage_benchmark` CLI command |
+| `unit_tests` | `unit_tests` CLI command with the minunit suites (`unit_tests` application set) |
+| `crash_test`, `led_indicator`, `time_test` | Present in the tree but not built |
+
+# Dev mode
+
+The NVM debug flag, toggled from Settings, System, Debug or with `sysctl debug 1`, gates: the Debug apps entry, the demo mode in the busy timer setup, the firmware channel selector, `update 917_probe`, the `gpio` and `otp` commands, the low battery bypass for updates while on USB, and the automatic reboot on intercom failure (suppressed in Dev mode). The `sysctl` service mirrors the flag into its settings file so it survives reboots.

--- a/documentation/Services.dox.md
+++ b/documentation/Services.dox.md
@@ -1,3 +1,120 @@
 # Services {#services}
 
-This is a stub page about the services.
+Services are background threads and start-up hooks declared in `applications/services/application.fam`. They start in `order` sequence at boot and publish their instance through a record. The @ref architecture page describes the mechanism. This page is the catalogue: what each service does and where it is documented in detail.
+
+# STM32U5 services
+
+The `basic_services` metapackage (storage, input, gui, front and back display, font registry, power, status bar, brightness control, device info, log storage) is present in every U5 application set, including recovery. `extended_services` adds everything else.
+
+| Order | Service | Record | Purpose | Details |
+| --- | --- | --- | --- | --- |
+| 1 | `cli_intercom` | `cli_intercom` | Relays a shell to the Si917 over the intercom (`sl_cli`) | @ref cli |
+| 3 | `log_storage` | `log_storage` | Two 16 KiB log rings (local U5 log and the Si917 console on USART2) and `log_dump` | @ref cli |
+| 10 | `storage` | `storage` | eMMC filesystems, path aliases, file API | @ref storage-and-settings |
+| 10 | `device_info` (hook) | `device_info` | Registry of device information key-value segments | @ref cli |
+| 15 | `sl_info` (hook) | `sl_info` | Caches the Si917 device information received over the intercom | @ref architecture |
+| 20 | `cli_u5` (hook) | `cli` | Creates the CLI registry and registers every command | @ref cli |
+| 20 | `usb_srv` | `usb_network` | TinyUSB CDC-NCM, the `EX` network interface, a DHCP server | @ref connectivity |
+| 30 | `intercom` | `intercom` | The link to the Si917 | @ref architecture |
+| 30 | `network` (hook) | `network` | lwIP initialization, Mongoose DNS, `netstat` | @ref architecture |
+| 35 | `sysctl` (hook) | | Dev mode, UI debug overlay, CLI over Wi-Fi, access log level | @ref cli |
+| 40 | `power_srv` | `power` | BQ25798 charger, USB-PD, state of charge, battery state machine, power off and reboot | below |
+| 40 | `cli_socket` (hook) | | The CLI on TCP port 23 | @ref cli |
+| 45 | `device_name` | `device_name` | The user-visible device name, validated and persisted, published to MQTT and BLE | @ref storage-and-settings |
+| 50 | `supervisor` | | User-facing fault handling: battery, storage, intercom errors | below |
+| 60 | `input` | `input`, `input_events` | Logical input events from the Si917 | @ref user-interface |
+| 60 | `font_registry` (hook) | `font_registry` | Font loading and cache | @ref user-interface |
+| 65 | `canvas` | `CANVAS` | Remote drawing overlay for the HTTP display API | @ref user-interface |
+| 70 | `back_display` | `back_display` | SSD1320 OLED driver service | @ref user-interface |
+| 80 | `front_display` | `front_display` | LED matrix driver service | @ref user-interface |
+| 90 | `light_sensor` | `light_sensor` | Ambient light level | @ref user-interface |
+| 95 | `brightness_control` | `brightness_control` | Auto and manual brightness for displays and lights | @ref user-interface |
+| 100 | `audio` | `audio` | PCM playback, volume | @ref user-interface |
+| 110 | `wifi` | `wifi` | Wi-Fi state machine, saved network, the `WL` interface | @ref connectivity |
+| 120 | `loader` | `loader` | Runs one application at a time | @ref user-interface |
+| 130 | `status_lights` | `status_lights` | RGB LED presets, forwarded to the Si917 | @ref user-interface |
+| 140 | `ble` | `ble` | BLE policy, HTTP tunnel and state streaming over GATT | @ref connectivity |
+| 150 | `time` | `time` | RTC, SNTP, time zones | @ref connectivity |
+| 160 | `mqtt` | `mqtt` | Cloud link, account linking, HTTP proxy and streaming modules | @ref connectivity |
+| 165 | `discovery` | `discovery` | mDNS hostname and service records | @ref connectivity |
+| 180 | `tls_crypto` | `tls_crypto` | Certificates and signing from the Si917 key storage | @ref connectivity |
+| 185 | `state_publisher` | `state_publisher` | Aggregates device state into protobuf frames for WebSocket, BLE and MQTT | below |
+| 190 | `busy_timer` | `busy_timer` | The timer model, cloud sync, Matter coupling | @ref busy-timer |
+| 200 | `gui` | `gui` | LVGL, layers, widgets, input dispatch | @ref user-interface |
+| 230 | `status_bar` | `status_bar` | Indicators on the back display | @ref user-interface |
+| 240 | `desktop` | `desktop` | Mode switch to application mapping, transitions | @ref user-interface |
+| 250 | `matter` | `matter` | Matter switch, commissioning, credentials | @ref connectivity |
+| 260, 270 | `mqtt_streaming`, `mqtt_http_proxy` | | MQTT modules | @ref connectivity |
+| 300 | `recovery` | | Recovery firmware only: runs a factory reset | @ref updater |
+| 300 | `update_executor` | | Updater stage only: flashes the images | @ref updater |
+| 310, 320 | `updater`, `update_ui` (hook) | `updater` | Update check, download, staging, automatic updates, update screens | @ref updater |
+| 330 | `low_power` | `low_power` | Reference counted lock. At zero it sleeps the displays and the light sensor. | below |
+| | `web_server` | | Mongoose HTTP server and the API | @ref http-api |
+| | `api_tokens` | `api_tokens` | Bearer tokens for the HTTP API | @ref http-api |
+| | `ca_storage` (hook) | `ca_storage` | Parses the CA bundle once at boot | @ref connectivity |
+| | `js_runner` | `js_runner` | JerryScript runtime and the `js` command | @ref javascript-applications |
+| | `startup_dfu_hook` | | Si917 only, listed here for completeness | @ref hardware |
+
+`cdc_echo` and `cdc_screen` are unused USB CDC test services. `intercom_test` and `wifi_test` are demo services that are not part of any application set.
+
+# SiWG917 services
+
+`basic_services`: cli, input, network, wifi, nvm, matter, startup_dfu_hook, device_info. `intercom_services`: status_lights, cli_intercom, ble, tls_crypto, sl_info, supervisor.
+
+| Order | Service | Purpose |
+| --- | --- | --- |
+| 1 | `cli_intercom` | Shell endpoint for `sl_cli` |
+| 5 | `startup_dfu_hook` | DFU button handling at boot |
+| 10 | `device_info` | Device information registry |
+| 20 | `cli_si917` | CLI registry |
+| 30 | `intercom`, `network` | Intercom transport, IPv6 lwIP |
+| 80 | `input` | Buttons, switch, encoder |
+| 90 | `tls_crypto` | Serves certificates and signatures from the key storage |
+| 100 | `supervisor` | Signs random data every second and crashes after 10 failures |
+| 110 | `wifi` | Radio association, frame bridging |
+| 120 | `nvm` | NVM3 key-value store |
+| 130 | `sl_info`, `status_lights` | Device information dump, RGB LED backend |
+| 140 | `ble` | GATT server |
+| 200 | `matter` | Matter node |
+| | `cli_uart` | UART shell in the `hwtest` set |
+| | `crash` | Crashes on start in the `917_crash` set |
+
+# Services without a dedicated page
+
+## power
+
+`applications/services/power/` (record `power`). A 1 s tick reads the BQ25798 status and ADC, low-pass filters voltage and state of charge (charge only moves in the charging direction while charging), and publishes `ChargingStateUpdate`, `ChargeAmountUpdate`, `BatteryPresent`, `BatteryNotPresent` and `UsbConnectionStateUpdate`. The service applies the charge limit setting with a 10% re-enable hysteresis.
+
+Battery state machine: `Normal`, `Low` (below 15%) and `Critical` (below 5%) with a 3% hysteresis; charging forces `Normal`. Each transition publishes a `Start` and `Stop` event pair.
+
+`power_off()` refuses while USB is connected. `power_reboot(mode)` supports `Hardware` (charger reset), `Normal` (reset the Si917 then the U5), `NormalU5`, `Normal917`, `DfuU5` (jump to the ST ROM bootloader) and `Dfu917` (Si917 into its ROM bootloader). Shipping mode: at boot, if the NVM flag is set, the service waits for USB to be unplugged and powers off. CLI: `power`.
+
+## supervisor
+
+`applications/services/supervisor/supervisor.c` shows fault screens on the GUI system layer of both displays, locks input while a blocking fault is shown, and holds the low power lock while any warning is active:
+
+| Warning | Trigger | Screen and action |
+| --- | --- | --- |
+| Battery not ready | Battery not present at boot | "Battery issue, contact support", input locked |
+| Battery critical | `PowerEventBatteryCriticalStart` | "Connect charger", 30 s countdown, then power off |
+| Rebooting | Matter `WillReboot` | Spinner |
+| Storage errors | `/bkp` or `/ext` failed to mount | "Storage error", OK formats or repartitions, resets NVM, reboots |
+| Intercom error | Any intercom error status | "System error, restart device". Dumps logs to `/ext/intercom_failure_log.txt`, reboots after 30 s of uptime unless Dev mode is on. |
+
+## state_publisher
+
+`applications/services/state_publisher/` (record `state_publisher`, 16 KiB stack plus a fetch thread). It collects device state from the brightness, time, Wi-Fi, updater, power, audio, device name, Matter, input, busy timer and BLE services, and front display frames from `screen_streamer.c` (RGB888, L8 or L4, optionally run length encoded). The service serializes updates as protobuf `BSB_State_StateUpdate` messages (nanopb, schema in the `assets/proto` submodule) and fans them out to up to 16 registered transports (`WebSocket`, `BLE`, `MQTT` classes), each with its own frame interval and rate limit. A heartbeat goes out every 991 ms. `send_complete_snapshot` sends a full `BSB_State_State`.
+
+## low_power
+
+A reference counted lock (`low_power_lock()`, `low_power_unlock()`) that starts at 1. When the count reaches 0 the service puts both displays and the light sensor to sleep; any lock wakes them. It does not touch MCU clocks. `soft_off` releases the initial lock, the supervisor and the canvas take locks while active.
+
+## log_storage
+
+Keeps a 16 KiB ring of the U5 log (through a log handler) and a 16 KiB ring of the Si917 console received on USART2 at 230400 baud. `log_storage_dump(path)` writes the device information and both rings to `/ext/log.txt` or the given path (only complete lines). `log_storage_suspend_remote()` releases the UART so the updater can use it. There is no on-device crash dump; the test bench detects crashes through the serial console.
+
+## device_info, sl_info, device_name
+
+`device_info` holds an ordered list of key-value segments that the CLI, the About screen and the log dump print. The U5 keys carry the prefix `u5_` (commit hash, branch, version, build date, target, API version). The Si917 keys carry the prefix `sl_` (the same set, plus Wi-Fi and BLE MACs, NWP firmware version, secure boot, signature, encryption and anti-rollback flags, enclave validity) and arrive through `sl_info` over the intercom at boot; until then `sl_intercom_status` reports `error`.
+
+`device_name` validates the name (20 characters, printable ASCII, not only spaces), persists it, publishes it as a `FuriState`, sends `{"name": ...}` on the MQTT `state` topic, and feeds the BLE Device Name characteristic, the DHCP hostname and the mDNS hostname.

--- a/documentation/Storage and Settings.dox.md
+++ b/documentation/Storage and Settings.dox.md
@@ -1,0 +1,104 @@
+# Storage and Settings {#storage-and-settings}
+
+# Storage layout
+
+All file storage is on the eMMC, managed by the `storage` service (`applications/services/storage/`, record `storage`, U5 only). There is no internal flash filesystem and no `/int` mount point. Two exFAT partitions exist:
+
+| Mount point | Partition | Size | Access | Content |
+| --- | --- | --- | --- | --- |
+| `/bkp` | 1 | 256 MiB | Read-only after boot | Factory recovery bundle (`/bkp/recovery/update.json`), battery calibration, crypto storage backup |
+| `/ext` | 2 | Rest of the device | Read-write | Everything else |
+
+At boot the service mounts `/bkp`, checks that it is not larger than 512 MiB (an older partition table is rejected), sets it read-only, then mounts `/ext`. The `supervisor` service shows mount failures as a "Storage error" prompt. OK formats or repartitions the device, resets the NVM block and reboots. The `sysctl storage_bkp_unlock 1` CLI command makes `/bkp` writable when the NVM debug flag is set.
+
+Other persistent state lives outside the filesystem: the 2 KiB backup SRAM block on the U5 (`furi_hal_nvm`: debug flag, boot mode, shipping mode flag, last switch position, fault data) and the NVM3 store on the Si917 (`nvm` service: BLE bonding data, crypto storage access mode, Matter fabrics).
+
+## Path prefixes
+
+`applications/services/storage/storage.h` defines the prefixes that every application uses:
+
+| Macro | Expands to | Notes |
+| --- | --- | --- |
+| `EXT_PATH(p)` | `/ext/p` | |
+| `BACKUP_PATH(p)` | `/bkp/p` | |
+| `APP_DATA_PATH(p)` | `/data/p` | Rewritten by the storage service to `/ext/apps_data/<appid>/p` |
+| `APP_ASSETS_PATH(p)` | `/assets/p` | Rewritten to `/ext/apps_assets/<appid>/p` |
+| `SHARED_ASSETS_PATH(p)` | `/ext/apps_assets/shared/p` | Also `SHARED_ANIM_PATH`, `SHARED_IMG_PATH`, `SHARED_SOUND_PATH` |
+
+The `<appid>` is the application id of the **calling thread**. The same `APP_DATA_PATH("settings.json")` therefore resolves to a different file when called from a service thread, from a CLI command thread or from the web server thread. Services that must be reachable from other threads use absolute paths (the `sysctl` service is one example). The service creates the data directory automatically on write.
+
+## Directory map
+
+| Path | Owner |
+| --- | --- |
+| `/ext/apps_data/<appid>/` | Per application data and settings files |
+| `/ext/apps_assets/<appid>/{animations,images,sounds,themes}` | Bundled assets, installed from the resources bundle |
+| `/ext/apps_assets/shared/{animations,images,sounds,fonts,ca}` | Shared assets, fonts and the CA bundle |
+| `/ext/apps_assets/web_server/www/` | The built web UI, OpenAPI document and Swagger UI |
+| `/ext/user_assets/<id>/` | User uploaded JavaScript applications and their resources |
+| `/ext/update/` | Update download and staging area |
+| `/ext/.sys_update.txt`, `/ext/.update_session.json` | Update pointer file and session configuration |
+| `/ext/Manifest` | Resource manifest, used to remove old resources on update |
+| `/ext/log.txt`, `/ext/intercom_failure_log.txt` | Log dumps |
+| `/bkp/recovery/` | Factory bundle used by factory reset and the recovery firmware |
+| `/bkp/crypto_backup.bin` | Optional raw backup of the Si917 crypto storage |
+
+## Storage service API
+
+The service runs one thread with an 8 deep message queue. The public API in `storage.h` is fully synchronous: file operations (`storage_file_open/read/write/seek/...`), directory operations, common operations (`stat`, `remove`, `rename`, `copy`, `mkdir`, `fs_info`, `migrate`), SD level operations (`format`, `mount`, `unmount`, `info`), and helpers such as `storage_simply_mkdir`, `storage_read_entire_file`, `storage_write_entire_file`. `storage_posix_api.c` routes newlib `fopen` and friends to the same service. LVGL reads images and fonts through the `C:` filesystem driver in `lib/lvgl_addons/fs/`, and Mongoose serves static files through the adapter in `targets/f21/mongoose/mongoose_glue.c`.
+
+Events on the storage pubsub: `CardMount`, `CardUnmount`, `CardMountError`, `FileClose`, `DirClose`. On `PowerEventShutdown` the service syncs every open file and refuses further requests until revived.
+
+The `storage` CLI command (see @ref cli) exposes list, read, write, copy, remove, rename, mkdir, stat, info, tree, md5, timestamp, tar extract and format.
+
+# Settings
+
+Every persistent setting is a JSON file managed by `lib/setting_provider`. A service describes its settings as a tree of typed descriptors, and the library loads, validates, migrates and saves the file.
+
+## Descriptor model
+
+`setting_provider_alloc(path, version, migrations, count)` returns a provider. `setting_provider_load(provider, root, struct)` fills a C structure from the file. `save`, `reset`, `validate` and `free` complete the API.
+
+Descriptor types: `Bool`, `Int`, `Float`, `String` (with `max_size`), `Enum` (string map, for example `"24h"`), `Custom` (string serialized through callbacks, for example a time zone), `Union` (tagged by an enum), `Struct`, `Raw` (direct cJSON callbacks). Each descriptor has a default value (or a callback that produces it) and an optional validation callback. Descriptors map JSON keys to structure fields with `offsetof`.
+
+## File format and semantics
+
+Each file is one JSON object with a top-level `version` number and the keys of the root structure. On load:
+
+- A file that does not parse, or a missing structure, is reset to defaults and rewritten.
+- Missing keys are filled with defaults and the file is rewritten. Invalid values fall back to defaults.
+- The library migrates a stored version lower than the current version step by step through the registered migration callbacks. A missing or failing migration, or a version newer than the firmware supports, resets the file to defaults.
+- Save validates and rewrites the whole file. There is no temporary-file rename in the library. `lib/storage_utils/temp_file.h` is available for callers that need it.
+
+All services in the tree are currently at version 1 or 2 with no registered migrations.
+
+## Settings files
+
+| File | Service | Keys and defaults |
+| --- | --- | --- |
+| `/ext/apps_data/power_srv/settings.json` | power | `charge_limit` 100 (30..100) |
+| `/ext/apps_data/time/settings.json` | time | `is_enabled` true, `server_address` `udp://time.busy.app:123`, `timezone` `New York`, `boot_delay` 300 s, `background_sync_interval` 10800 s, `retry_sync_interval` 600 s, `time_format` `24h` |
+| `/ext/apps_data/sysctl/settings.json` | sysctl | `cli_wifi_enabled` false, `websrv_accesslog_level` 0, `debug_enabled` (mirrors the NVM flag), `ui_debug_mode` 0 |
+| `/ext/apps_data/device_name/settings.json` | device_name | `name` `BUSY Bar` (20 characters max, ASCII only) |
+| `/ext/apps_data/brightness_control/config.json` | brightness_control | `mode` `auto`, `brightness` 50 |
+| `/ext/apps_data/audio/audio.json` | audio | `volume` 1.0 |
+| `/ext/apps_data/busy_timer/settings_busy.json`, `settings_custom.json`, `state.json` | busy_timer | Profiles and the last snapshot, see @ref busy-timer |
+| `/ext/apps_data/updater/settings.json` | updater | `check_url` `default`, `check_channel_id` `release`, `check_startup_interval` 10 min, `check_interval` 5 h, `autoupdate_enabled` true, `autoupdate_interval_start` 02:00, `autoupdate_interval_end` 05:00, `autoupdate_attempt_delay` 5 min |
+| `/ext/apps_data/wifi/settings.json` | wifi | `credentials{ssid, passphrase, security}`, `ip_config{management, type, ipv4{address, mask, gateway}}` |
+| `/ext/apps_data/ble/settings.json` | ble | `enabled` false |
+| `/ext/apps_data/mqtt/settings.json`, `state.json` | mqtt | `config{server_url, client_cert_type, ignore_server_cert}`; `client_id`, `session_id`, `user_id`, `email`, `token` |
+| `/ext/apps_data/usb_srv/settings.json` | usb_network | `ip_config{address 10.0.4.20, netmask 255.255.255.0, gateway 0.0.0.0}` |
+| `/ext/apps_data/web_server/access.json` | web_server | `access_mode` 0, `access_key` |
+| `/ext/apps_data/tokens/access.json` | api_tokens | `tokens[]` with hashes and metadata |
+| `/ext/apps_data/clock/settings.json` | clock | `show_date` true, `show_seconds` false, `blink_colons` true |
+| `/ext/apps_data/apps_menu/settings.json` | apps_menu | `active_application` |
+| `/ext/apps_data/jsrunner/<id>.settings.json`, `<id>.localstorage.json` | JavaScript applications | Per application values, see @ref javascript-applications |
+| `/ext/apps_data/matter/cd_selection.txt` | matter | `production`, `dev` or `certification` (plain text) |
+
+## Helper libraries
+
+- `lib/settings_helpers/`: `app_desc.h` defines the descriptor a settings application returns to the settings menu (titles, icons, `menu_extra`, `display_in_menu`). `gui_params.h` holds the settings assets path.
+- `lib/storage_utils/`: `dir_walk.h` (recursive directory iterator) and `temp_file.h`.
+- `lib/toolbox/tar/`: `TarArchive` with uncompressed, heatshrink and gzip read modes, used by the updater, the `tar` CLI command and `storage extract`.
+- `lib/toolbox/compress.c`: streaming decoder over heatshrink or zlib.
+- `lib/flipper_format/`: the Flipper key-value text format. No service uses it. It remains for its unit tests.

--- a/documentation/Tooling Tests and CI.dox.md
+++ b/documentation/Tooling Tests and CI.dox.md
@@ -1,0 +1,116 @@
+# Tooling, Tests and CI {#tooling-tests-ci}
+
+This page complements @ref build-system with the host-side scripts, the bundle and resource wiring, the test suite and the CI workflows.
+
+# Build wiring
+
+## Layers and targets
+
+`fbt-project.json` declares three build layers, all git submodules: `fbtng` (the build tool), `core_libs` (the furi runtime) and `freertos`. `project.scons` at the repository root adds the project specific variables (`U5_TARGET_HW` 22, `SIL_TARGET_HW` 65, `SIL917_INSECURE` true, `INTERCOM_FORCE_VERSION`) and decides what to build: with `TARGET_HW` unset it builds the Si917 target, then the U5 target, then the `bsbdist` components that produce bundles and `dist/`; with `TARGET_HW` set it builds one target only.
+
+`bsb_common_env_init.scons` registers every library under `lib/` as a component (`lib/register_bsb_common_libs.scons`), adds `applications/` to the lint sources, and injects the `INTERCOM_FORCE_VERSION` define.
+
+The custom SCons tools in `scripts/fbt_tools/` and the environment modules in `scripts/fbt_env_modules/` supply: asset converters (`bsb_assets.py`), the JavaScript application copier (`bsb_apps.py`), CA bundle refresh (`bsb_certs.py`), update bundles and flash over HTTP (`bsb_update_bundle.py`), external application support (`fbt_extapps.py`), Si917 image conversion, signing and flashing (`fwbin_silabs.py`, `fwsign_silabs.py`, `fwflash_silabs.py`).
+
+## Targets not covered by the build system page
+
+| Target | Effect |
+| --- | --- |
+| `dist_signed` | Signed Si917 images and `*_signed.tgz` bundles. Exists only when `SI917_SIGN_KEYSTORE` or all three `SI917_SIGN_SERVICE_*` variables are set. |
+| `update_bundle` | Build the update bundle without installing it into `dist/` |
+| `openapi_spec`, `openapi_dist` | Merge the OpenAPI segments, install into the web root or `dist/` |
+| `faps`, `fap_<appid>` | Build external applications (`.fap`). The tooling exists but no manifest in the tree uses it. |
+| `sdk_tree`, `api_check`, `api_table`, `get_apiversion` | SDK header tree and API symbol table for external applications |
+| `proto` | Compile `assets/proto` with nanopb |
+| `crypto_provision`, `matter_provision`, `mqtt_provision`, `crypto_wipe`, `mqtt_wipe` | Provisioning scripts against the connected device |
+| `update_cacert` | Refresh `assets/shared/ca/cacert.pem` from curl.se |
+
+Build variables not on the build system page: `SIL917_INSECURE`, `SI917_NWP_STACK` (path of the radio image), `SI917_SIGN_KEYSTORE`, `SI917_SIGN_SERVICE_URL`, `SI917_SIGN_SERVICE_TOKEN`, `SI917_SIGN_SERVICE_PROFILE`, `COMMANDER_CLI`, `SI917_PORT`. Application sets not listed there: `917_crash`, `hwtest`, `factory_testing`.
+
+`flash_usb` details: one invocation accepts one preset only, the bundle never contains backup partition resources, and `--signed` with a Si917 image included requires the signing configuration.
+
+## Artifacts
+
+Build products land in `fbt_layers/fbtng/build/f<target>-<firmware or updater>-<C, D or CD>/`. The `dist` target installs `dist/f<U5>-D/busybar-f<U5>-<name>-<DIST_SUFFIX>.<ext>` for `update.tgz`, `bkp.tgz`, `firmware.elf`, `firmware.dfu`, `firmware.bin`, `updater.elf`, `updater.bin`, `sil_firmware.rps`, `sil_firmware.elf`, `sil_nwp.rps`, `openapi.yaml`, plus the signed variants. CI adds a recovery DFU and a SHA-256 sum file.
+
+# Scripts
+
+All device-facing scripts default to `10.0.4.20`: the CLI socket on port 23 and HTTP on port 80.
+
+| Script | Purpose |
+| --- | --- |
+| `testops.py` | CI and QA device operations: `wait`, `get-version`, `power`, `input`, `device_info`, `sanity`, `uptime`, `debug`, `format`, `update-fw` (HTTP upload with retries and optional OpenOCD reset), `update-bundle`, `unit-tests` |
+| `update.py` | `u5 <dfu or hex> [--to-dfu]` flashes the U5 with `dfu-util` or `STM32_Programmer_CLI`; `917 <rps> [--nwp]` uploads and flashes a Si917 image through the CLI |
+| `update_bundle.py` | Builds a bundle directory, tar or tgz from stage, DFU, RPS and resource inputs (see @ref updater) |
+| `update_over_http.py` | Uploads a bundle to `POST /api/update` with an optional intercom version gate |
+| `storage.py` | Remote filesystem operations over the CLI socket: `send`, `receive`, `list`, `mkdir`, `remove`, `format_ext`, `stress` |
+| `run.py` (`./run`) | Legacy build and flash driver for `f20` and `f21`. Superseded by the `flash_usb` targets. |
+| `streaming.py` | Live display viewer. Targets a WebSocket route that no longer exists. |
+| `swagger.py`, `openapi_merge.py` | OpenAPI merge and Swagger UI generation |
+| `seq2anim.py`, `image.py`, `audio.py`, `ttf2font.py`, `sound_test.py` | Asset converters (see @ref user-interface) |
+| `bsbotp.py` | Build and verify OTP blocks (see @ref hardware) |
+| `bin2rps.py`, `sign_silabs_rps.py`, `flashrps.py` | Si917 image wrapping, signing and serial flashing |
+| `matter_provision.py`, `mqtt_provision.py`, `vault_provision.py`, `credentials.py`, `crypto_storage.py` | Key and certificate provisioning (see @ref connectivity) |
+| `map_analyse_upload.py` | Uploads ELF section sizes and map files to the size analyzer in CI |
+| `check-submodules.py` | Verifies that every submodule is on the branch listed in `.github/expected-submodule-branches.txt` |
+| `get_silabs_lib.sh` | Fetches a WiseConnect or Simplicity SDK package through Conan |
+| `battery_calibration/` | Off-device rig (Arduino plus INA219) and plotting scripts that produce `factory.bat_cal` |
+| `debug/platforms/` | OpenOCD and SVD descriptors and GDB helpers |
+
+Shared Python helpers live in `scripts/flipper/`: `app.py` (argparse base), `cli.py` (TCP stream to the CLI), `storage_socket.py` (file transfer over the CLI).
+
+# Tests
+
+The `tests/` directory is a pytest suite that runs against a real device. `tests/README.md` and `tests/AGENTS.md` describe it.
+
+## Set-up
+
+Python 3.12 with Poetry (`pyproject.toml`), or `requirements.txt` for CI. `bootstrap_local.sh` creates the virtual environment, copies `config/.env.example` to `config/.env`, probes the device and runs two smoke tests. Configuration keys (`config/config.py`): `BUSYBAR_IP` (10.0.4.20), `DEVICE_CHECK_PORT` (80), `DAPLINK_U5_ID`, `DAPLINK_917_ID`, `BSB_FIRMWARE_PATH` (a checkout with the toolchain and debug descriptors, for crash traces), `SESSION_LOG_DIR`, plus cloud, Wi-Fi, BLE, Home Assistant and Allure settings.
+
+## Harness
+
+`tests/conftest.py` defines session fixtures (`web_base_url`, `device_flasher`, an autouse fixture that dismisses the first-boot screen) and function fixtures: a logged `requests.Session`, one typed client per API area (`system_api`, `wifi_api`, `storage_api`, `assets_api`, `account_api`, `ble_api`, `settings_api`, `input_api`, `streaming_api`, `update_api`, `busy_api`, `smart_home_api`), CLI connections, and a device information cache.
+
+An autouse health monitor probes `GET /api/version` before and after every test. On failure it classifies the problem (port unreachable, API unhealthy, tolerated 503, crash detected through the bench serial logger), requests a GDB trace, resets the device through the DAPLink probe and fails the test with the reason.
+
+## Markers and coverage
+
+`pyproject.toml` declares the markers: `cli`, `frontend`, `api`, `mqtt`, `uses_cloud`, `external_service`, `state_publisher`, `uses_ble`, `matter`, `mdns`, `rate_limiter`, `long_running`, `regression`, `uses_si917`, `mtls`, `schemathesis` and others. `regression` tests run only on `-rc` tags or when a commit message contains `[run regression]`.
+
+| Directory | Coverage |
+| --- | --- |
+| `integration/cli/` | Configuration, diagnostics, `fetch` (including mutual TLS against a local server), JavaScript `fetch` and `localStorage`, peripherals, power, shell, storage, submenus, system |
+| `integration/frontend/` | Every HTTP API area: account, assets and display screenshots against reference frames, BLE, busy timer, token authentication over USB and Wi-Fi, CORS for every documented method, display drawing and priorities, input, Matter, schema conformance with schemathesis against the served OpenAPI document, settings and tokens, state publisher, storage, streaming, system, update, web UI, Wi-Fi |
+| `integration/discovery/` | mDNS name, port, TXT records, re-announce on rename |
+| `integration/matter/` | Commissioning into a real Home Assistant (skipped without `HA_URL`) |
+| `integration/mqtt/` | Broker connectivity, cloud initiated unlink |
+| `integration/state_publisher/` | Protobuf contract, events and rate limiting over WebSocket, MQTT and BLE |
+
+Unit tests on the device are a separate thing: the `unit_tests` application set adds the `unit_tests` CLI command with minunit suites (argparse, crypto, datetime, device name, HTTP, JavaScript application settings, JavaScript, JSON helper, pipe, rate limiter, record, RLE, RTC, setting provider, state, storage, tar, timer, URL, XPM).
+
+# CI
+
+Workflows live in `.github/workflows/`. Builds run on a self-hosted `BsbShell` runner, device tests on `BusyBarTest` and `BusyBarBrickTest` benches. An indexer receives the artifacts and serves them from `https://update.busy.app/builds/busybar-firmware/<branch>/`. Pull requests from forks never upload.
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| `build.yml` | Push to `dev`, tags, pull requests | Builds the `22_65` pair (and `21_64` on demand) with `dist` and `dist_signed`, checks that generated files are unchanged, uploads bundles, ELFs and size reports, comments on the pull request, then runs the updater, integration, unit and brick test jobs and the `tests-passed` gate |
+| `compact-build.yml` | Push to `dev`, pull requests | Release profile build (`DEBUG=0 COMPACT=1`) to prove the size optimized image links |
+| `updater-test.yml` | Called by build | Flashes the bundle on a bench (`power reboot`, `debug 1`, `format`, `update-fw`), runs `sanity`, updates again with the same package |
+| `unit-test.yml` | Called by build | Flashes the `unit_tests` build and runs the `unit_tests` CLI command |
+| `integration-tests.yml` | Called by build, manual | Flashes, runs `pytest` with the marker filter, uploads results to Allure TestOps and the serial run log to S3, comments a summary |
+| `brick-test.yml` | Called by build | Flashes the `917_crash` build, verifies that `sanity` fails, recovers with the normal bundle through the storage and CLI fallback path |
+| `lint.yml` | Pull requests | Submodule branch check, `reuse lint`, `./fbt lint` for `f21` and `f64` |
+| `docs.yml` | Push to `dev`, tags, pull requests | `./fbt doxygen` with warnings treated as errors |
+| `frontend-build.yml` | Pull requests touching `assets/frontend/` | Rebuilds the web UI and fails if the committed build differs |
+| `openapi-diff.yml` | Changes to the OpenAPI sources | `oasdiff` breaking-change report, semantic version bump enforcement, `API_VERSION` consistency check |
+| `copilot-code-review.yml` | Pull request ready for review | Requests an automated review |
+| `reindex.yml` | Release published | Asks the indexer to rebuild the release directory |
+
+Release profile: a git tag builds with `DEBUG=0 COMPACT=1`, signs the Si917 images when the secrets exist, and uploads. Tags containing `-rc` run the full regression suite. Publishing the GitHub release triggers the reindex.
+
+# Licensing and style tooling
+
+- `REUSE.toml` and `LICENSES/` declare the licenses: GPL-2.0-or-later for the firmware sources, MIT for `applications_js/`, CC-BY-SA-4.0 for assets and documentation, OFL-1.1 for fonts, Apache-2.0 for the Matter glue and Swagger UI, and a Silicon Labs license for the radio firmware. `reuse lint` runs in CI. `LICENSE.md` still says CC-BY 4.0 for assets, which disagrees with `REUSE.toml`.
+- `.clang-format` is enforced by `./fbt lint` and applied by `./fbt format` (see @ref code-style). `.clangd` adjusts flags for the language server.
+- `./fbt doxygen` builds this documentation from `documentation/doxygen/Doxyfile.cfg`; `./fbt doxy` opens it (see @ref docs-howto).

--- a/documentation/Updater.dox.md
+++ b/documentation/Updater.dox.md
@@ -1,0 +1,82 @@
+# Updater {#updater}
+
+Firmware updates install a bundle that can contain the U5 firmware, the Si917 application and radio images, and the resources. The normal firmware downloads, verifies and stages the bundle, then reboots into a RAM resident updater stage that writes the images. This page covers the bundle format, both halves of the flow, automatic updates, recovery and factory reset. The @ref build-system and @ref tooling-tests-ci pages cover the build side (how bundles are produced).
+
+# Bundle format
+
+A bundle is a tar archive, optionally gzip compressed, produced by `scripts/update_bundle.py`. All entries have uid and gid 0 and mtime 0 so builds are reproducible.
+
+| Entry | Manifest key | Content |
+| --- | --- | --- |
+| `update.json` | | The manifest |
+| `updater.bin` | `updater_stage`, `updater_stage_crc32` | The RAM resident updater stage |
+| `firmware.dfu` | `updater_dfu` | U5 firmware as a DfuSe file (vendor 0x0483, product 0xDF11) |
+| `firmware.rps` | `updater_sil_fw` | Si917 M4 application |
+| `SiWG917-*.rps` | `updater_sil_radio_fw` | Si917 NWP radio firmware |
+| `resources.tar` | `updater_resources` | The `/ext/apps_assets` tree |
+| `resources/` | | Backup partition content, only in `bkp` bundles |
+
+Manifest fields: `version` (format version 1), `target` (hardware target number, for example 22), `update_name`, `firmware_info`, `security_flags` and the paths above. Security flags: `NwpSigned` 1, `M4Signed` 2, `NwpEncrypted` 4, `M4Encrypted` 8, `U5Encrypted` 16. Signed bundles carry `NwpSigned | M4Signed`. `lib/toolbox/update_lib/update_manifest.c` parses the manifest and `update_config.c` validates it (format version, hardware target match, stage file presence and CRC).
+
+The build produces these bundles in the combined `./fbt` build: `update` (resources, M4, NWP), `bkp` (the same plus backup partition resources), and signed variants when Si917 signing is configured. The `flash_usb` presets build a bundle with a chosen subset and push it to `POST /api/update`.
+
+# Normal firmware side
+
+Service: `applications/system/updater/` (`updater`, order 310, record `updater`). Paths: root `/ext/update`, download `/ext/update/bundle.tar`, staging `/ext/update/staging`, directory cache `/ext/update/directory.json`, pointer file `/ext/.sys_update.txt`, session configuration `/ext/.update_session.json`.
+
+## Update check
+
+`update_checker.c` downloads the channel directory from `check_url` (default `https://update.busy.app/busybar-firmware/directory.json`) and walks `channels[]` for the configured channel (`release` by default; `dev` and `rc` are selectable when the debug flag is set), then `versions[]` and `files[]` for the entry whose `target` is `f<hw target>` and whose `type` is `update_tgz`, or `update_signed_tgz` on devices that report signed Si917 firmware. It records the URL, SHA-256, version, changelog and id. The check runs 10 minutes after boot, then every 5 hours, and on demand (`updater_check_for_update()`, `POST /api/update/check`, the Firmware settings screen). The result is `Available` when the found version differs from the active version.
+
+## Installation
+
+An installation requires an updater session, which takes a single-slot lock and checks the battery: at least 40% charge, unless the debug flag is set and USB is connected. The stages, each reported on `UpdaterUpdateState` with progress:
+
+1. **Download** (`FetchLoader` to `bundle.tar`, abortable).
+2. **SHA verification** of the file against the expected hash, when one is known.
+3. **Unpack** into the staging directory.
+4. **Prepare**: validate the manifest, compare the security flags with the live device (from `sl_info`), decide which components to install (the radio image is skipped when its version equals the running NWP version), write the session configuration and the pointer file.
+5. **Apply**: set the NVM boot mode to `Update` and reboot the U5.
+
+Entry points: `updater_install_from_url(url, sha)` runs steps 1 to 5 in an install thread. `POST /api/update` streams a bundle to `bundle.tar` and runs steps 3 to 5. The CLI commands `update install`, `install_tar` and `install_web` start at different stages. The `update_ui` start-up hook draws the download and prepare screens on the GUI system layer above the running application; Back aborts a download.
+
+## Automatic updates
+
+A timer runs every `autoupdate_attempt_delay` (5 min). The timer applies an update only when all of these hold: auto update is enabled, the local time is inside the window (02:00 to 05:00 by default), a checked update is available, no check is in flight, the debug flag is off, and no application holds an update pause. The BUSY timer scene and the clock application pause updates while they run (`updater_pause_autoupdates()`, reference counted).
+
+Settings are in `/ext/apps_data/updater/settings.json` (see @ref storage-and-settings) and exposed on `/api/update/autoupdate`.
+
+# Updater stage
+
+At the next boot the U5 sees boot mode `Update`, clears it, mounts the eMMC without the RTOS, reads the pointer file and the manifest, CRC-checks `updater.bin`, copies it to SRAM and jumps to it (see @ref hardware). The stage is the same firmware linked for RAM execution with the `update_executor` service (`applications/system/updater/update_executor/`).
+
+Stages of the worker (`update_task.c`), with weighted progress:
+
+1. **ReadManifest**: check the hardware target, read the pointer file, load the session configuration and the manifest, check that every referenced file exists.
+2. **ValidateDFUImage**, **FlashWrite**, **FlashValidate**: validate the DfuSe headers and CRC, program flash pages, then read back and compare every page.
+3. **917RadioWrite**, **917RadioInstall**, **917Write**, **917Install**: reset the Si917 into its ROM bootloader, negotiate the baud rate (921600 down to 9600), select the image slot and stream the RPS file with Kermit (`sl_updater/`, 3 retries, 30 s install timeout for the radio and 15 s for the application).
+4. **ResourcesFileCleanup**, **ResourcesDirCleanup**, **ResourcesFileUnpack**: delete every file and directory listed in the old `/ext/Manifest`, then unpack the new `resources.tar` into `/ext`.
+5. **Completed**: show "Update completed" and "Restarting device", delete the session configuration, reset.
+
+On failure the stage becomes `Error` with a message and a stage-percent code, the screen shows "Update failed", and the session configuration is left in place. There is no automatic rollback. If U5 flashing never started, the previous image remains. Otherwise a reboot retries the update.
+
+# Recovery firmware and factory reset
+
+The `recovery` application set builds a firmware whose only job is a factory reset: its `recovery` service shows "Recovering...", starts an updater session and calls `factory_reset_perform()`. CI builds and publishes it as `busybar-f<hw>-recovery-<suffix>.dfu`.
+
+`factory_reset_perform(updater, shipping_mode)` (`lib/toolbox/update_lib/factory_reset.c`):
+
+1. Forget the BLE bond and reset the Matter fabrics (skipped in the recovery firmware, which lacks those services).
+2. Format `/ext`, which also removes the Wi-Fi credentials and all settings.
+3. Reset the U5 NVM block. Optionally set the shipping mode flag.
+4. Prepare and apply the factory bundle `/bkp/recovery/update.json` from the read-only backup partition, so the updater stage reinstalls the factory firmware and resources.
+
+It is reachable from Settings, System, Factory reset (requires 40% battery), from the CLI command `factory_reset [-s]`, and from the recovery firmware.
+
+# Si917 images outside the bundle
+
+`update 917 <rps>` and `update 917_ta <rps>` on the CLI flash an application or radio image directly from a file on `/ext`. `scripts/update.py 917 <rps> [--nwp]` uploads the file and runs the command. `scripts/flashrps.py` flashes from a host over the Si917 UART with the SWO line grounded. See @ref hardware for the bootloader details.
+
+# Version check between the two MCUs
+
+The intercom handshake compares the git hash of both images. A `flash_usb` bundle that omits the Si917 application would therefore fail after the U5 update unless the hashes match. The build variable `INTERCOM_FORCE_VERSION` pins the handshake string, and the `flash_usb` targets pass the same string to `scripts/update_over_http.py`, which reads `intercom_version` from `GET /api/status/firmware` and refuses the upload on a mismatch. See @ref build-system.

--- a/documentation/User Interface.dox.md
+++ b/documentation/User Interface.dox.md
@@ -1,0 +1,176 @@
+# User Interface {#user-interface}
+
+This page covers the display pipeline, the GUI framework, input, the application life cycle (desktop and loader), animations, status indicators, brightness and audio. All of it runs on the U5 except the input backend and the status lights backend, which run on the Si917.
+
+# Displays
+
+| | Front | Back |
+| --- | --- | --- |
+| Panel | 72x16 RGB LED matrix | SSD1320 160x80 grayscale OLED |
+| Color depth | 24 bit (`LV_COLOR_FORMAT_RGB888`) | 8 bit in LVGL, packed to 4 bit for the panel |
+| Draw buffer | 3456 bytes, direct render mode | 12800 bytes, direct render mode |
+| Service | `front_display` (order 80) | `back_display` (order 70) |
+| Usable area for applications | Whole panel | 148x80. The rightmost 12 px column holds the status bar. |
+
+## Front display service
+
+`front_display_draw()` copies an RGB888 frame and sends it through the LED driver pipeline: an index lookup table maps frame buffer pixels to the transmit order of the three chained driver ICs, a 256 entry gamma table (gamma 2.8, flattened toward 2.5 at low brightness) converts each channel to 16 bit, and the encoded stream goes out over OCTOSPI1 by DMA. The TIM5 scan interrupt starts the transfer right after VSYNC so data loads between scan frames. The driver enables output after 10 blank frames.
+
+Other API: `front_display_set_brightness()` (0..100, regenerates the gamma table), `front_display_set_blanked()` (fades to black over 200 ms and drops draws while blanked), `front_display_sleep_mode()` (cuts the panel rail once the current DMA transfer ends). The service waits until the power service reports the battery present before it powers the panel, because the matrix draws from the battery rail.
+
+## Back display service
+
+`back_display_draw()` converts the L8 buffer to packed L4 and marks it dirty. The actual SPI transfer happens on the next tearing-effect interrupt from the panel, so updates are frame synchronized. The API also offers `back_display_set_contrast()` (default 25), `back_display_set_gamma_table()` (15 entries) and a reference counted `back_display_sleep_mode()`.
+
+## GUI service
+
+The `gui` service (order 200, record `gui`, high priority thread) owns a single LVGL 9 instance with one `lv_display_t` per panel. It ticks LVGL every 8 ms, refreshes every 16 ms, registers the `C:` filesystem driver over the storage service, attaches one theme per display, and funnels input events from the `input_events` pubsub into LVGL.
+
+LVGL is compiled with the software renderer only, a 1 MiB image cache, the baked `busy_regular_5` font as default, the `bar`, `canvas`, `image` and `label` widgets, flex and grid layouts, the PNG decoder and the QR code library. The build patches the binary image extension from `bin` to `image`, which is why external images ship as `*.image`. Configuration is in `targets/f21/config/lv_conf.h`.
+
+### Layers
+
+Each display has four layers, top to bottom: `System` (status bar, desktop transition overlay, supervisor warnings), `Top` (dialogs, the HTTP canvas overlay), `Main` (the running application) and `Bottom`. Every layer has one root widget per display. The GUI offers input layer by layer from `System` down. The first layer that consumes an event stops propagation.
+
+### Widget model
+
+`Widget` (`applications/services/gui/widget.h`) is an `lv_obj_t` subclass. Every module follows the same pattern: an opaque structure whose first member is the base widget, an LVGL class derived from `widget_lvgl_class`, `x_alloc(parent)`, `x_free()` and `x_get_base()`. Class data carries an optional input callback and a per-display style callback, so one widget renders correctly on both panels.
+
+An application gets a screen by opening `RECORD_GUI`, taking the `Main` layer root for each display and allocating widgets under it. All widget calls must happen under `gui_lock()` (the `with_gui()` macro). There is no view dispatcher: the application owns its LVGL objects and frees them before it exits.
+
+Modules in `applications/services/gui/modules/`:
+
+| Module | Purpose |
+| --- | --- |
+| `label` | Text with theme font sizes, alignment, wrap, dots, scroll and circular scroll modes, inline color commands |
+| `image` | Image from a path (cached), uncached, or from raw pixels |
+| `anim_player`, `anim_menu` | Animation playback and a two-option animated menu driven by named sections |
+| `menu`, `submenu` | Vertical lists with icons and sublabels |
+| `dialog` | Two-option dialog with an optional icon |
+| `var_item_list` | Settings list: switch, selector, spinbox, timebox |
+| `flex_layout`, `flex_box` | Row and column containers |
+| `nav_bar` | Back display header with a breadcrumb stack |
+| `title_card`, `anim_title_card` | Icon plus title, optionally animated |
+| `status_view` | Icon plus primary and secondary text |
+| `progress_bar`, `qr_code`, `countdown`, `canvas` | Self describing |
+| `snap_image` | Blurred or dimmed capture of the current frame, used behind modals |
+| `transition_overlay`, `overlap_fader` | Color or mask overlays and edge fades |
+| `mirror_card`, `front_display_mirror` | Live copy of the front display on the back display |
+
+`scene_manager.h` is a plain scene stack (`enter`, `exit`, `event` callbacks, custom, back and tick events) that most applications use. It is not tied to LVGL.
+
+### Themes and fonts
+
+Two themes (`lib/lvgl_addons/themes/`) style every widget class per display. Front: black background, gray text, white when focused, fonts `busy_regular_5` and `busy_regular_7`. Back: gray text, white when focused, fonts `busy_regular_5`, `busy_regular_9` and `busy_bold_10`.
+
+The `font_registry` start-up hook loads fonts by path from `/ext/apps_assets/shared/fonts/`, caches up to 7 with reference counting, and returns baked in-flash fonts for `busy_regular_5` and `busy_regular_9`. Available fonts: `busy_bold_7`, `busy_bold_10`, `busy_condensed_7`, `busy_regular_5/7/9/14`, `busy_superscript_7`, `busy_tiny`, `lana_pixel_regular_11`. The `fontstat` CLI command prints the cache.
+
+# Input
+
+## Hardware side (Si917)
+
+`applications/services/input/input_f64.c` reads three buttons (OK, Back, Start/Pause), the five mode switch contacts (Busy, Status, Off, Apps, Settings) and the rotary encoder through the QEI peripheral. Pin interrupts start a 2 ms debounce timer that waits for 10 stable samples before it emits an event. The backend publishes events locally and sends them over the `Input` intercom channel. At start-up it sends every already-pressed pin as a press so the U5 learns the initial switch position.
+
+## Logical side (U5)
+
+`applications/services/input/input.c` (record `input`, pubsub `input_events`) turns intercom events into `InputEvent{key, type, sequence}`:
+
+- Keys: `Up`, `Down`, `Right`, `Left`, `Ok`, `Back`, `Start`, `Busy`, `Custom`, `Off`, `Apps`, `Settings`. Encoder rotation maps to `Up` and `Down`, one step per event.
+- Types: `Press`, `Release`, `Short` (released before the long threshold), `Long` (held 300 ms), `Repeat` (every 150 ms after long while held).
+- The mode switch position is a `FuriState` (`input_get_switch_pos()`). It defaults to Busy if nothing arrives within 1.5 s of boot.
+
+Widgets react to `Short` presses. `Up` and `Down` navigate, `Ok` and `Start` both confirm, `Back` is left to the application. `input_key_press/release/toggle()` inject software events; the `input` CLI command and `POST /api/input` use them.
+
+# Desktop and loader
+
+## Loader
+
+The `loader` service (record `loader`) runs one application at a time. `loader_start(name, args)` finds the application in the generated tables, allocates a thread with the manifest stack size and application id, sets the loader priority to 10 and starts it. `loader_stop()` sends `FuriSignalExit` to the application thread; an application must install a signal handler, release its widgets and records, and return. `loader_lock()` blocks application starts without running anything.
+
+Loader priority (`loader.h`): stub 0, passthrough 9, default 10, max application 90, max 100, blocking 101. Only the running application may change it. The canvas service uses it to decide whether an HTTP draw request may cover the current application. CLI: `loader open <name>`, `loader kill`.
+
+## Desktop
+
+The `desktop` service (record `desktop`) maps the mode switch to applications and animates the transition:
+
+| Switch position | Application | Argument |
+| --- | --- | --- |
+| BUSY | `busy` | |
+| CUSTOM | `busy` | `custom` |
+| OFF | `soft_off` | |
+| APPS | `apps_menu` | |
+| SETTINGS | `settings_menu` | |
+
+Flow on a switch change: the desktop shows a 100 ms fade to black on the front display, sends `FuriSignalAboutToExit` to the running application so it can play an exit animation, debounces the switch for 100 ms, stops the application through the loader, starts the new one, then plays the mask animation `horizontal_mask_transition_72x16.anim` (section `right_to_left` or `left_to_right` depending on the direction, no animation when going to OFF). If the start fails, the `message` application shows the loader error.
+
+`desktop_replace_current_app(name, args)` lets applications replace each other, for example a settings sub-application returning to the settings menu. A pending programmatic request is not overridden by a switch request. The start-up application is `power_on`.
+
+# Animations
+
+## The `.anim` file format
+
+Custom format with the signature `bicycle1`. It supports true color, true color with alpha and 4 bit grayscale, per-frame change masks (none, all, run length, bitmap), per-frame pixel encodings (raw, run length, a QOI-like encoding), inter-frame compression, and **named sections** (ranges of frames). The encoder forces a key frame at every section start so the decoder can enter any section without decoding earlier frames. Section 0 is always `default`. The @ref file_formats page describes the full rationale and the buffer pipeline. The structures are in `lib/anim_file/anim_file_format.h`.
+
+Source animations are zip files `name_WxH.zip` with `frame_N.png` files and a `meta.json` (`fps`, `color_mode`, `sections[]`), converted by `scripts/seq2anim.py` during the resources build. `assets/animations/README.md` documents the archive rules.
+
+## Library and widgets
+
+`lib/anim_file/anim_file.h`: `anim_file_alloc(storage, path, options)`, `anim_file_set_out_buf()`, `anim_file_frame()` (decodes the next frame and returns flags such as `Last`, `Finished`, `Looping`, `NoChange`), `anim_file_set_section(flags, name)` with `FinishCurrent` and `Loop` flags, and `anim_file_set_offset(x, y)` for sub-pixel translation (requires the intermediate buffer option, and renders fractional offsets through a 3x3 bilinear kernel).
+
+`AnimPlayer` wraps the decoder in an `lv_canvas` with a timer at `1000/fps` ms and adds `set_source`, `set_section`, `start`, `pause`, `set_offset` and a frame callback. `AnimMenu` drives a menu of N options from sections named `item-X` and `transition-X-to-Y`.
+
+# Status bar and status lights
+
+## Status bar
+
+The `status_bar` service places a 12 px wide column on the back display `System` layer with, top to bottom, BLE, Wi-Fi, audio and USB indicators and a battery indicator with a numeric label. It listens to the power pubsub, the audio pubsub, the Wi-Fi state and the BLE pubsub. Images come from `/ext/apps_assets/status_bar/images/`.
+
+## Status lights
+
+The RGB LED lives on the Si917. The U5 `status_lights` service forwards `StatusLightsCommand` frames over the intercom; the Si917 backend runs the preset and drives the PWM. API: `status_lights_run_preset(preset, color)`, `status_lights_set_brightness(0..100)`.
+
+Presets: `Off`, `StaticColor`, `Fade` (triangle), `RainbowGradient`, `Blink` (500 ms), `Notification` (three blinks at full brightness, used by the HTTP draw API). The backend scales each channel with a gamma of 1.85. CLI on the Si917: `status_lights <r> <g> <b>`.
+
+# Brightness
+
+The `light_sensor` service samples the BH1730 once per second, keeps a 5 sample mean of the lux value clamped to 1..10000, and quantizes it on a logarithmic scale to a level 0..15 with hysteresis. The `light_sensor` CLI command prints the raw channels.
+
+The `brightness_control` service (record `brightness_control`) owns one logical brightness for three sinks. Mode `auto` uses `level/15`, mode `manual` uses `brightness/100`. Each sink maps the value through its own curve:
+
+| Sink | Range | Curve |
+| --- | --- | --- |
+| Front display | 1..100 | Ease-in (power 0.5) |
+| Back display contrast | 1..71 | Linear |
+| Status lights | 5..90 | Linear |
+
+Temporary per-sink overrides exist for the settings screens (`brightness_control_set_brightness_override()`). The state is a `FuriState` with mode, effective brightness and the setting. CLI: `display brightness <0-100 or auto>`, `display show <front or back> <file>`, `display gamma back <max> <gamma>`.
+
+# Audio
+
+Sound files are headerless raw PCM, mono, 44100 Hz, signed 16 bit little endian (`.snd`). `scripts/audio.py` converts any source with ffmpeg: mono downmix, loudness normalization to -6 LUFS, and a speaker compensation EQ from `scripts/audio_eq.txt`.
+
+The `audio` service (record `audio`) plays one file at a time through SAI1 with an 8192 sample ping-pong DMA buffer. A 100 ms fade-in applies at start and a 100 ms fade-out at stop. Playing a file while another plays fades the current one out first. There is no mixing.
+
+API: `audio_enable()` and `audio_disable()` are reference counted and control the amplifier with a 100 ms settle time. `audio_play_file(path)` requires at least one enable holder. `audio_stop()` stops playback. `audio_set_volume(0.0..1.0)` persists to `/ext/apps_data/audio/audio.json`. Events: `AudioEventVolumeUpdate`, `AudioEventPlayEnd`. CLI: `audio start <path>`, `audio stop`.
+
+# Canvas (remote drawing)
+
+The `canvas` service (record `CANVAS`, order 65) backs `POST /api/display/draw` (see @ref http-api). It keeps up to 100 elements (image, animation, text, countdown, rectangle, raw image) with an id, position, alignment, display, z-index and a timeout or an absolute expiry. Elements render on the `Top` layer of both displays, sized like the `Main` root so the status bar stays visible. While a canvas is shown, a mirror card on the back display shows the front display when the back has no elements of its own. The canvas consumes every input. `Back` or any switch change closes the canvas.
+
+A draw request carries a priority. The service rejects it (`LowPriority`) when the loader priority of the running application is higher. It retries a rejected asynchronous draw for 1.5 s on every priority change. If the running application raises its priority above the canvas, the service clears the canvas. This is how the BUSY timer blocks remote drawing during a session.
+
+# Assets
+
+`./fbt resources` builds the resource tree that lands at `/ext/apps_assets` on the device. The first directory level under each asset type becomes the application namespace. Names carry the pixel size as a suffix (`front_power_on_72x16`, `battery_8x18`).
+
+| Type | Source | Converter | Output |
+| --- | --- | --- | --- |
+| Animation | `assets/animations/<app>/name_WxH.zip` | `seq2anim.py` | `<app>/animations/name_WxH.anim` |
+| External image | `assets/images/external/<app>/name_WxH.png` | `image.py -f BIN` (LVGL binary) | `<app>/images/name_WxH.image` |
+| Internal image | `assets/images/internal/*.png` | `image.py -f C` | Linked `I_<name>` descriptors, used for fallback icons |
+| Sound | `assets/sounds/<app>/*.wav` | `audio.py` | `<app>/sounds/*.snd` |
+| Font | `assets/shared/fonts/*.font` | Copy (TTF conversion is not yet in the toolchain) | `shared/fonts/*.font` |
+| Web UI, OpenAPI, Swagger UI | `assets/frontend-build/public`, `applications/services/web_server/openapi` | gzip, merge | `web_server/www/` |
+| JavaScript applications | `applications_js/<id>/` | Copy | `/ext/user_assets/<id>/` |
+
+Application manifests can add a `resources` directory that the build merges into the tree, for example the BUSY themes in `applications/main/busy/resources/`.


### PR DESCRIPTION
# What's new

This PR fills the developer documentation stubs and adds one page per firmware subsystem. It does not change firmware behavior. The second commit adds an optional workflow that publishes the Doxygen output to GitHub Pages.

## Decisions for the reviewer

1. **Keep or drop the Pages workflow** (`.github/workflows/docs-pages.yml`, second commit). It runs Doxygen directly with the config variables that `./fbt doxygen` sets. It therefore needs only the `doxygen-awesome-css` submodule and no toolchain download. It deploys on pushes to `dev` and on manual dispatch. It needs Pages enabled with the "GitHub Actions" source on this repository. If the team does not want Pages, drop that commit and the PR is docs only. A rendered copy of this branch is at https://allixsenos.github.io/busybar-firmware/ for review.
2. **Page granularity.** The new pages are subpages of `Firmware`, and `Tooling, Tests and CI` is a subpage of `Contributing`. The sidebar therefore keeps six top-level entries. If a flatter or a deeper structure is preferred, the `@subpage` lists in `Firmware.dox.md` and `Contributing.dox.md` are the only places to change.
3. **File Formats** is now a subpage of `Firmware` instead of a top-level sidebar entry.

## Pages

Rewritten stubs: `Hardware`, `Firmware` (now a hub with a feature map), `Services` (catalogue with order, record and purpose), `Native Applications` (manifest reference, life cycle, every application), `JavaScript Applications` (manifest, settings schema, runtime API, example, debugging checklist), `Contributing`.

New pages: `Architecture` (two MCUs, runtime, service model, intercom, network stack split), `Storage and Settings`, `User Interface`, `Busy Timer`, `Connectivity`, `HTTP API` (all endpoints, access control, WebSocket, OpenAPI pipeline), `Command Line Interface` (transports and every command), `Updater`, `Tooling, Tests and CI`.

Every statement comes from the source on `dev` at 736af4c7. The analysis ran without the submodules checked out. Statements about FBT internals, furi, lwIP, Mongoose and the Silicon Labs SDKs therefore describe how this repository configures and calls them, not their internals.

The analysis also found defects, filed separately as #1026, #1027, #1028, #1029, #1030, #1031, #1032, #1033.

## Acceptance criteria

| Criterion | Status |
| --- | --- |
| Doxygen builds with `WARN_AS_ERROR` and no warnings | :white_check_mark: on the fork CI, Doxygen 1.12.0 |
| Every `@ref` and `@subpage` resolves, every page label is unique | :white_check_mark: |
| The `docs.yml` workflow passes on this PR | Pending |
| Reviewed by a maintainer for factual errors | Unmet |

## Still to do

1. Decide on the Pages workflow (decision 1).
2. If Pages is kept, point the "ready to read version" link in `documentation/README.md` at the published site.

# Verification

- On the fork, the new workflow ran Doxygen 1.12.0 over this branch with no warnings and published the result: https://github.com/allixsenos/busybar-firmware/actions/runs/34684841116
- I cross-checked all 62 HTTP endpoints against the handler tables, every CLI command against the `CLICMD` manifests, and every settings file against the `setting_provider` interfaces.
- An ASD-STE100 style checker linted the prose. The new pages score between 1.2 and 2.4 violations per 100 words.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix (documentation only, no device test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
